### PR TITLE
Linux portu — platform abstraction + UI + paketleme + CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,3 +54,66 @@ jobs:
           name: HekaDrop-app-macos-arm64
           path: target/release/HekaDrop.app
           retention-days: 7
+
+  test-linux:
+    name: Test + Build (Linux)
+    runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+      DEBIAN_FRONTEND: noninteractive
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Cargo cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install system deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            protobuf-compiler \
+            libwebkit2gtk-4.1-dev \
+            libxdo-dev \
+            libsoup-3.0-dev \
+            libgtk-3-dev \
+            libayatana-appindicator3-dev \
+            zenity
+
+      - name: Format check
+        run: cargo fmt --all -- --check
+
+      - name: Clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings
+
+      - name: Test
+        run: cargo test --all
+
+      - name: Build (release)
+        run: cargo build --release
+
+      - name: Build .deb package
+        continue-on-error: true
+        run: |
+          if [ -f scripts/make-deb.sh ]; then
+            chmod +x scripts/make-deb.sh
+            ./scripts/make-deb.sh
+          else
+            echo "scripts/make-deb.sh henüz yok — skip"
+          fi
+
+      - name: Upload .deb artifact
+        if: success() || failure()
+        uses: actions/upload-artifact@v5
+        with:
+          name: HekaDrop-deb-ubuntu
+          path: |
+            target/debian/*.deb
+            HekaDrop-*.deb
+          if-no-files-found: ignore
+          retention-days: 7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Codecov raporu + badge entegrasyonu
 - Criterion benchmark iskeleti (`bench.yml`)
 - Rustdoc yayın adımı GitHub Pages'e
+- Linux portu: GTK3 + WebKit2GTK + AppIndicator tray; zenity/kdialog dialog; systemd user service autostart
+- Sabit TCP port 47893 (HEKADROP_PORT env ile override'lanabilir) — firewall kurallarını kolaylaştırır
+- Platform abstraction modülü (`src/platform.rs`) — cross-platform path/device-name/open/clipboard
+- Alınan dosya bildiriminde aksiyon butonları (Aç / Klasörde göster) — Linux'ta D-Bus, macOS'ta düz bildirim
+- mDNS yayın filtresi: Docker/virbr/tailscale sanal arayüzleri hariç bırakılır (yanlış IP çözümlenmesini önler)
+- Makefile'a Linux hedefleri: `install-linux`, `install-linux-system`, `uninstall-linux`, `deb`
+- Cargo.toml `[package.metadata.deb]` — cargo-deb ile paket üretimi
 
 ### Changed
 - `Settings` yapısı JSON migration ile geri uyumlu (eski alanlar opsiyonel)
 - Rate limiter trusted cihazlar için bypass yolunu erken adımda kestirir (daha az kilit tutma)
 - Progress yayınları debounce (UI'ya yansıyan event sayısı azaltıldı)
+- Config/log yolları XDG uyumlu (`~/.config/HekaDrop`, `~/.local/state/HekaDrop/logs`); macOS'ta `~/Library/...` aynı kalır
+- Cihaz adı platform-aware: macOS'ta `scutil`, Linux'ta `/etc/hostname`
 
 ### Fixed
 - Reject sonrası pending destination temizliği (orphan dosyalar geride kalmıyordu)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,6 +35,137 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling 3.11.0",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "atk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -56,6 +187,12 @@ dependencies = [
  "libc",
  "system-deps",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
@@ -137,6 +274,25 @@ checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2 0.6.4",
 ]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "byteorder"
@@ -609,6 +765,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -622,6 +805,27 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -775,6 +979,19 @@ name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -1168,6 +1385,7 @@ dependencies = [
  "hmac",
  "if-addrs",
  "mdns-sd",
+ "notify-rust",
  "p256",
  "parking_lot",
  "pretty_assertions",
@@ -1188,6 +1406,12 @@ dependencies = [
  "tray-icon",
  "wry",
 ]
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -1486,6 +1710,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "js-sys"
+version = "0.3.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "keyboard-types"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1623,6 +1857,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
+name = "mac-notification-sys"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29a16783dd1a47849b8c8133c9cd3eb2112cfbc6901670af3dba47c8bbfb07d3"
+dependencies = [
+ "cc",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+ "time",
+]
+
+[[package]]
 name = "malloc_buf"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1669,7 +1915,7 @@ dependencies = [
  "flume",
  "if-addrs",
  "log",
- "polling",
+ "polling 2.8.0",
  "socket2 0.5.10",
 ]
 
@@ -1776,6 +2022,20 @@ name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+
+[[package]]
+name = "notify-rust"
+version = "4.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c8146c105ae33d744e2d645f684d063b01176a99daf5986556266777b428816"
+dependencies = [
+ "futures-lite",
+ "log",
+ "mac-notification-sys",
+ "serde",
+ "tauri-winrt-notification",
+ "zbus",
+]
 
 [[package]]
 name = "nu-ansi-term"
@@ -1957,6 +2217,7 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.1",
  "block2 0.6.2",
+ "libc",
  "objc2 0.6.4",
  "objc2-core-foundation",
 ]
@@ -2025,6 +2286,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "p256"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2060,6 +2331,12 @@ dependencies = [
  "libc",
  "system-deps",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -2227,6 +2504,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2269,6 +2557,20 @@ dependencies = [
  "log",
  "pin-project-lite",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2448,6 +2750,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
 dependencies = [
  "prost",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.37.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -2735,6 +3046,17 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3035,6 +3357,18 @@ name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+
+[[package]]
+name = "tauri-winrt-notification"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b1e66e07de489fe43a46678dd0b8df65e0c973909df1b60ba33874e297ba9b9"
+dependencies = [
+ "quick-xml",
+ "thiserror 2.0.18",
+ "windows 0.61.3",
+ "windows-version",
+]
 
 [[package]]
 name = "tempfile"
@@ -3381,6 +3715,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3421,6 +3766,17 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "uuid"
+version = "1.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+dependencies = [
+ "js-sys",
+ "serde_core",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "valuable"
@@ -3478,6 +3834,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+dependencies = [
+ "unicode-ident",
 ]
 
 [[package]]
@@ -3641,11 +4042,24 @@ version = "0.60.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddf874e74c7a99773e62b1c671427abf01a425e77c3d3fb9fb1e4883ea934529"
 dependencies = [
- "windows-collections",
+ "windows-collections 0.1.1",
  "windows-core 0.60.1",
- "windows-future",
+ "windows-future 0.1.1",
  "windows-link 0.1.3",
- "windows-numerics",
+ "windows-numerics 0.1.1",
+]
+
+[[package]]
+name = "windows"
+version = "0.61.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+dependencies = [
+ "windows-collections 0.2.0",
+ "windows-core 0.61.2",
+ "windows-future 0.2.1",
+ "windows-link 0.1.3",
+ "windows-numerics 0.2.0",
 ]
 
 [[package]]
@@ -3655,6 +4069,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5467f79cc1ba3f52ebb2ed41dbb459b8e7db636cc3429458d9a852e15bc24dec"
 dependencies = [
  "windows-core 0.60.1",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -3684,6 +4107,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
+]
+
+[[package]]
 name = "windows-future"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3691,6 +4127,17 @@ checksum = "a787db4595e7eb80239b74ce8babfb1363d8e343ab072f2ffe901400c03349f0"
 dependencies = [
  "windows-core 0.60.1",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+ "windows-threading",
 ]
 
 [[package]]
@@ -3709,6 +4156,17 @@ name = "windows-implement"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83577b051e2f49a058c308f17f273b570a6a758386fc291b5f6a934dd84e48c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3760,6 +4218,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3792,6 +4260,15 @@ name = "windows-strings"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
+dependencies = [
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link 0.1.3",
 ]
@@ -3885,6 +4362,15 @@ dependencies = [
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -4033,6 +4519,15 @@ name = "winnow"
 version = "0.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]
@@ -4235,6 +4730,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "zbus"
+version = "5.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca82f95dbd3943a40a53cfded6c2d0a2ca26192011846a1810c4256ef92c60bc"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow 0.7.15",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897e79616e84aac4b2c46e9132a4f63b93105d54fe8c0e8f6bffc21fa8d49222"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffd8af6d5b78619bab301ff3c560a5bd22426150253db278f164d6cf3b72c50f"
+dependencies = [
+ "serde",
+ "winnow 0.7.15",
+ "zvariant",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4319,3 +4875,43 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zvariant"
+version = "5.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5708299b21903bbe348e94729f22c49c55d04720a004aa350f1f9c122fd2540b"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow 0.7.15",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b59b012ebe9c46656f9cc08d8da8b4c726510aef12559da3e5f1bf72780752c"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f75c23a64ef8f40f13a6989991e643554d9bef1d682a281160cf0c1bc389c5e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.117",
+ "winnow 0.7.15",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,10 @@ cipher = { version = "0.4", features = ["block-padding"] }
 subtle = "2"
 elliptic-curve = { version = "0.13", features = ["sec1"] }
 
+[target.'cfg(target_os = "linux")'.dependencies]
+# Aksiyon butonlu (Aç / Klasörde göster) D-Bus bildirimleri için.
+notify-rust = "4"
+
 [build-dependencies]
 prost-build = "0.13"
 
@@ -61,3 +65,21 @@ tokio-test = "0.4"
 lto = "thin"
 codegen-units = 1
 strip = true
+
+# cargo-deb (Linux .deb paketleme) için metadata.
+# Kullanım: `./scripts/make-deb.sh`  veya  `cargo deb`
+[package.metadata.deb]
+maintainer = "destek@sourvice.com"
+copyright = "2026 sourvice.com"
+license-file = ["LICENSE", "0"]
+extended-description = "HekaDrop — Google Quick Share protokolünü Rust ile konuşan açık kaynak, ücretsiz dosya paylaşım aracı. Android cihazlarla doğrudan dosya paylaşımı (bulut yok, hesap yok)."
+depends = "$auto, zenity"
+recommends = "wl-clipboard | xclip, notify-osd | libnotify-bin"
+section = "net"
+priority = "optional"
+assets = [
+    ["target/release/hekadrop", "usr/bin/", "755"],
+    ["resources/hekadrop.desktop", "usr/share/applications/", "644"],
+    ["resources/icon.png", "usr/share/icons/hicolor/512x512/apps/hekadrop.png", "644"],
+    ["README.md", "usr/share/doc/hekadrop/", "644"],
+]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help build release universal test check clean icon bundle dmg install uninstall install-service uninstall-service run dev all
+.PHONY: help build release universal test check clean icon bundle dmg install uninstall install-service uninstall-service run dev all install-linux install-linux-system uninstall-linux uninstall-linux-system deb
 
 PROFILE ?= release
 APP = target/$(PROFILE)/HekaDrop.app
@@ -22,6 +22,13 @@ help:
 	@echo "  make dev                — RUST_LOG=hekadrop=debug cargo run"
 	@echo "  make clean              — cargo clean + .icns temizle"
 	@echo "  make all                — test + bundle"
+	@echo ""
+	@echo "Linux:"
+	@echo "  make install-linux         — release + ~/.local altına kur (user)"
+	@echo "  make install-linux-system  — release + /usr/local altına kur (sudo)"
+	@echo "  make uninstall-linux       — user kurulumu kaldır"
+	@echo "  make uninstall-linux-system — system kurulumu kaldır (sudo)"
+	@echo "  make deb                   — cargo-deb ile HekaDrop-<version>.deb üret"
 
 build:
 	cargo build
@@ -99,3 +106,21 @@ clean:
 	rm -rf resources/AppIcon.iconset
 
 all: test bundle
+
+# Linux
+install-linux:
+	cargo build --release
+	./scripts/install-linux.sh --user
+
+install-linux-system:
+	cargo build --release
+	sudo ./scripts/install-linux.sh --system
+
+uninstall-linux:
+	./scripts/uninstall-linux.sh --user
+
+uninstall-linux-system:
+	sudo ./scripts/uninstall-linux.sh --system
+
+deb:
+	./scripts/make-deb.sh

--- a/README.md
+++ b/README.md
@@ -91,6 +91,61 @@ make install-service       # oturum açılışında otomatik başlat (launchd)
 
 Gereksinimler: Rust 1.90+, `protoc`, Xcode CLT (macOS için `iconutil`).
 
+### Linux (AppImage / deb / kaynak)
+
+#### Kaynaktan
+
+```bash
+# Sistem bağımlılıkları (Debian/Ubuntu)
+sudo apt install protobuf-compiler libwebkit2gtk-4.1-dev libxdo-dev \
+                 libsoup-3.0-dev libgtk-3-dev \
+                 zenity wl-clipboard  # kdialog ve xclip da kabul edilir
+
+# Derle ve kur
+git clone https://github.com/YatogamiRaito/HekaDrop.git
+cd HekaDrop
+make test
+make install-linux          # ~/.local/bin + ~/.local/share/applications (user)
+# veya
+sudo make install-linux-system  # /usr/local/bin + /usr/share/applications (system)
+```
+
+Runtime paketleri: `zenity` (dialog'lar için şart — yoksa `kdialog` fallback), `wl-clipboard`
+veya `xclip`/`xsel` (gelen URL/metni panoya kopyalamak için), `notify-osd` veya herhangi
+bir libnotify implementasyonu (bildirimler + aksiyon butonları).
+
+#### .deb paketi
+
+```bash
+make deb                    # cargo-deb ile target/debian/hekadrop_<ver>_amd64.deb üretir
+sudo apt install ./target/debian/hekadrop_*.deb
+```
+
+`.deb` paketleri ileride [GitHub Releases](https://github.com/YatogamiRaito/HekaDrop/releases)
+sayfasında da yayınlanacak.
+
+#### UFW / firewall notu
+
+```bash
+sudo ufw allow 47893/tcp    # HekaDrop TCP sabit portu
+sudo ufw allow 5353/udp     # mDNS / Bonjour
+```
+
+TCP port varsayılan olarak **47893**'tür; farklı bir port kullanmak için `HEKADROP_PORT`
+ortam değişkenini ayarlayın.
+
+#### Otomatik başlatma
+
+Tepsi (tray) menüsünden **"Başlangıçta aç"**'ı işaretleyin — `~/.config/systemd/user/`
+altına bir user unit yükler ve `systemctl --user enable` ile oturum açılışında başlatır.
+
+#### Pencere kapatma davranışı
+
+Pencerenin `X` düğmesine basınca uygulama arkaplanda çalışmaya devam eder; tamamen
+kapatmak için tepsi menüsünden **"Çıkış"**'ı kullanın. GNOME'da tepsi ikonu varsayılan
+olarak görünmeyebilir — [AppIndicator Support](https://extensions.gnome.org/extension/615/appindicator-support/)
+GNOME uzantısını yükleyin.
+
 ## Kullanım
 
 1. **HekaDrop**'u başlatın → menü çubuğunda `⇄` simgesi belirir.
@@ -118,6 +173,7 @@ yazılacaktır.
 src/
 ├── main.rs         ─ platform UI orkestrasyonu (tao event loop + wry WebView + tray-icon)
 ├── ui.rs           ─ platform UI helper (dialog, notify, clipboard)
+├── platform.rs    ─ platform abstraction (paths, open, clipboard, device name)
 │
 ├── server.rs       ─ TCP accept + rate limiter
 ├── connection.rs   ─ receiver state machine
@@ -164,7 +220,7 @@ src/
 | Platform | Alıcı | Gönderici | UI  | Notlar |
 |----------|:-----:|:---------:|:---:|--------|
 | macOS    | ✅    | ✅        | ✅  | Universal2 (Intel + Apple Silicon), DMG + Homebrew cask |
-| Linux    | 🚧    | 🚧        | ⏳  | Çekirdek protokol hazır; tepsi/UI katmanı planlanıyor (zbus + webkit2gtk) |
+| Linux    | ✅    | ✅        | ✅  | GTK3 + WebKit2GTK + AppIndicator tray; zenity/kdialog dialog; systemd user service; Ubuntu/Debian .deb |
 | Windows  | ⏳    | ⏳        | ⏳  | Yol haritasında (tray-icon + webview2, MSIX paketleme) |
 | Android / iOS | —  | —      | —   | Karşı taraf cihaz olarak kullanılır; native istemci geliştirilmeyecek |
 
@@ -173,7 +229,7 @@ Lejant: ✅ tamam · 🚧 geliştirme aşamasında · ⏳ planlı
 ## Yol haritası
 
 - **0.2.0** — clipboard senkronizasyonu, İngilizce arayüz (i18n altyapısı), klasör drag-drop, SHA-256 integrity UI göstergesi
-- **0.3.0** — Linux UI (zbus tray + webkit2gtk penceresi, systemd user service)
+- **0.3.0** — Linux UI (GTK3 + WebKit2GTK + AppIndicator tray, systemd user service) — ✅ **tamamlandı (2026 Nisan)**
 - **0.4.0** — Windows UI (tray-icon + webview2, MSIX paket, winget manifest)
 - **0.5.0+** — partial transfer resume, keychain entegrasyonu, otomatik klasör indirme kuralları
 
@@ -216,7 +272,8 @@ Protokolün tersine mühendislik çalışmasına ve referans implementasyonlara 
 protocol. It speaks UKEY2 + AES-256-CBC + HMAC-SHA256, performs mDNS discovery on
 `_FC9F5ED42C8A._tcp.local.`, and acts as both receiver and sender — a drop-in
 local-network alternative to Google's closed-source QuickDrop. The macOS build ships
-as a Universal2 `.app` with a menu bar UI; Linux and Windows ports are on the roadmap.
+as a Universal2 `.app` with a menu bar UI; the Linux build ships as `.deb` and a
+system-wide install with a GTK3 + WebKit2GTK + AppIndicator tray UI; the Windows port is on the roadmap.
 Security features include ephemeral P-256 ECDH, 4-digit PIN MITM protection, SHA-256
 file integrity, replay-safe sequence counters, a rate limiter (trusted devices bypass
 it), and disciplined log rotation (daily + max 3 files + 10 MB cap).

--- a/resources/hekadrop.desktop
+++ b/resources/hekadrop.desktop
@@ -1,0 +1,12 @@
+[Desktop Entry]
+Name=HekaDrop
+GenericName=Quick Share File Transfer
+Comment=Google Quick Share protokolü (Rust) — dosya paylaşım aracı
+Exec=hekadrop
+Icon=hekadrop
+Terminal=false
+Type=Application
+Categories=Network;FileTransfer;Utility;
+Keywords=quickshare;nearby;share;file;transfer;airdrop;
+StartupNotify=true
+StartupWMClass=hekadrop

--- a/scripts/install-linux.sh
+++ b/scripts/install-linux.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# Ne yapar: HekaDrop binary'sini, .desktop dosyasını ve ikon'ları Linux sistemine
+# kurar. Kullanıcı-başına (~/.local) veya sistem-geneli (/usr/local) modları vardır.
+#
+# Kullanım:
+#   ./scripts/install-linux.sh            # varsayılan: --user
+#   ./scripts/install-linux.sh --user
+#   sudo ./scripts/install-linux.sh --system
+
+set -euo pipefail
+
+# Proje köküne geç
+cd "$(dirname "$0")/.."
+
+# Varsayılan mod
+MODE="user"
+
+# Argüman ayrıştırma
+if [[ $# -gt 0 ]]; then
+  case "$1" in
+    --user)
+      MODE="user"
+      ;;
+    --system)
+      MODE="system"
+      ;;
+    -h|--help)
+      echo "Kullanım: $0 [--user|--system]"
+      echo "  --user    Kullanıcı-başına kur (~/.local, varsayılan)"
+      echo "  --system  Sistem-geneli kur (/usr/local, sudo gerektirir)"
+      exit 0
+      ;;
+    *)
+      echo "HATA: Bilinmeyen argüman: $1" >&2
+      echo "Kullanım: $0 [--user|--system]" >&2
+      exit 2
+      ;;
+  esac
+fi
+
+# Kaynak binary yolu — CARGO_TARGET_DIR override'ına izin ver
+CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-target}"
+SRC_BIN="${CARGO_TARGET_DIR}/release/hekadrop"
+SRC_DESKTOP="resources/hekadrop.desktop"
+SRC_ICON="resources/icon.png"
+
+# Ön-kontroller: gerekli dosyalar mevcut mu?
+if [[ ! -f "$SRC_BIN" ]]; then
+  echo "HATA: Release binary bulunamadı: $SRC_BIN" >&2
+  echo "       Önce şunu çalıştır: cargo build --release" >&2
+  exit 1
+fi
+
+if [[ ! -f "$SRC_DESKTOP" ]]; then
+  echo "HATA: .desktop dosyası bulunamadı: $SRC_DESKTOP" >&2
+  exit 1
+fi
+
+if [[ ! -f "$SRC_ICON" ]]; then
+  echo "HATA: Icon dosyası bulunamadı: $SRC_ICON" >&2
+  exit 1
+fi
+
+# Hedef yolları moda göre ayarla
+if [[ "$MODE" == "user" ]]; then
+  BIN_DIR="${HOME}/.local/bin"
+  APP_DIR="${HOME}/.local/share/applications"
+  ICON_BASE="${HOME}/.local/share/icons/hicolor"
+  SUDO=""
+else
+  BIN_DIR="/usr/local/bin"
+  APP_DIR="/usr/local/share/applications"
+  ICON_BASE="/usr/local/share/icons/hicolor"
+  # System modda root olmalıyız; sudo yoksa erişim zaten başarısız olur
+  if [[ $EUID -ne 0 ]]; then
+    echo "HATA: --system kurulumu root yetkisi gerektirir." >&2
+    echo "       Şunu dene: sudo $0 --system" >&2
+    exit 1
+  fi
+  SUDO=""
+fi
+
+echo "==> HekaDrop Linux kurulumu başlıyor (mod: ${MODE})"
+
+# Dizinleri oluştur
+$SUDO mkdir -p "$BIN_DIR" "$APP_DIR" "$ICON_BASE"
+
+# Binary'i kur
+echo "==> Binary kopyalanıyor → ${BIN_DIR}/hekadrop"
+$SUDO install -m 0755 "$SRC_BIN" "${BIN_DIR}/hekadrop"
+
+# .desktop'u kur
+echo "==> .desktop kopyalanıyor → ${APP_DIR}/hekadrop.desktop"
+$SUDO install -m 0644 "$SRC_DESKTOP" "${APP_DIR}/hekadrop.desktop"
+
+# İkon'u kur — ImageMagick varsa tüm boyutlara üret
+if command -v convert >/dev/null 2>&1; then
+  echo "==> ImageMagick algılandı — hicolor boyutları üretiliyor"
+  for SIZE in 16 24 32 48 64 128 256 512; do
+    ICON_DIR="${ICON_BASE}/${SIZE}x${SIZE}/apps"
+    $SUDO mkdir -p "$ICON_DIR"
+    $SUDO convert "$SRC_ICON" -resize "${SIZE}x${SIZE}" \
+      "${ICON_DIR}/hekadrop.png"
+    echo "   - ${SIZE}x${SIZE}"
+  done
+else
+  echo "UYARI: ImageMagick ('convert' komutu) bulunamadı."
+  echo "       Tek boyut (512x512) kopyalanıyor — GTK/KDE runtime'da downscale yapacak."
+  echo "       Tüm boyutları üretmek için: sudo apt install imagemagick  (veya dnf / pacman)"
+  ICON_DIR="${ICON_BASE}/512x512/apps"
+  $SUDO mkdir -p "$ICON_DIR"
+  $SUDO install -m 0644 "$SRC_ICON" "${ICON_DIR}/hekadrop.png"
+fi
+
+# Cache'leri tazele (hata verirse sessizce geç — kritik değil)
+if command -v update-desktop-database >/dev/null 2>&1; then
+  echo "==> update-desktop-database çağrılıyor"
+  $SUDO update-desktop-database "$APP_DIR" >/dev/null 2>&1 || true
+fi
+
+if command -v gtk-update-icon-cache >/dev/null 2>&1; then
+  echo "==> gtk-update-icon-cache çağrılıyor"
+  $SUDO gtk-update-icon-cache -f -t "$ICON_BASE" >/dev/null 2>&1 || true
+fi
+
+# Özet
+echo ""
+echo "✓ HekaDrop başarıyla kuruldu (mod: ${MODE})"
+echo ""
+echo "Kurulum yerleri:"
+echo "  Binary   : ${BIN_DIR}/hekadrop"
+echo "  Desktop  : ${APP_DIR}/hekadrop.desktop"
+echo "  Icons    : ${ICON_BASE}/<size>/apps/hekadrop.png"
+echo ""
+
+# PATH kontrolü (user modda)
+if [[ "$MODE" == "user" ]]; then
+  case ":${PATH}:" in
+    *":${BIN_DIR}:"*)
+      ;;
+    *)
+      echo "UYARI: ${BIN_DIR} PATH'inde değil."
+      echo "       ~/.bashrc veya ~/.zshrc dosyana şunu ekle:"
+      echo "         export PATH=\"\$HOME/.local/bin:\$PATH\""
+      echo ""
+      ;;
+  esac
+fi
+
+# Güvenlik duvarı hatırlatması
+echo "Güvenlik duvarı (UFW) kullanıyorsan, Quick Share için şu portları aç:"
+echo "  sudo ufw allow 47893/tcp"
+echo "  sudo ufw allow 5353/udp"
+echo ""
+echo "Otomatik başlatma için HekaDrop arayüzünden \"Başlangıçta aç\" seçeneğini işaretle."

--- a/scripts/make-deb.sh
+++ b/scripts/make-deb.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Ne yapar: cargo-deb ile HekaDrop için .deb paketi üretir ve proje köküne
+# HekaDrop-<version>.deb adıyla kopyalar.
+#
+# Kullanım:
+#   ./scripts/make-deb.sh
+
+set -euo pipefail
+
+# Proje köküne geç
+cd "$(dirname "$0")/.."
+
+# cargo-deb yüklü mü?
+if ! cargo deb --version >/dev/null 2>&1; then
+  echo "==> cargo-deb bulunamadı — kuruluyor"
+  cargo install cargo-deb
+fi
+
+# Versiyonu Cargo.toml'dan çek (ilk 'version =' satırı — [package] başlığı altındaki)
+VERSION="$(awk -F '"' '/^version[[:space:]]*=/ { print $2; exit }' Cargo.toml)"
+if [[ -z "$VERSION" ]]; then
+  echo "HATA: Cargo.toml'dan versiyon alınamadı." >&2
+  exit 1
+fi
+
+echo "==> cargo deb (HekaDrop v${VERSION})"
+cargo deb
+
+# cargo-deb çıktı dosyası: target/debian/hekadrop_<version>_amd64.deb
+# Mimari host'a göre değişebilir (aarch64, arm64, vb.) — o yüzden glob ile bul.
+DEB_SRC="$(ls -t target/debian/hekadrop_"${VERSION}"_*.deb 2>/dev/null | head -n1 || true)"
+if [[ -z "$DEB_SRC" || ! -f "$DEB_SRC" ]]; then
+  echo "HATA: cargo-deb çıktısı bulunamadı (target/debian/hekadrop_${VERSION}_*.deb)." >&2
+  exit 1
+fi
+
+DEB_DST="HekaDrop-${VERSION}.deb"
+cp -f "$DEB_SRC" "$DEB_DST"
+
+echo ""
+echo "✓ .deb paketi hazır:"
+echo "   Kaynak : $DEB_SRC"
+echo "   Kopya  : $DEB_DST"
+echo ""
+echo "Kurmak için:"
+echo "   sudo apt install ./${DEB_DST}"
+echo "   # veya:"
+echo "   sudo dpkg -i ${DEB_DST} && sudo apt -f install"

--- a/scripts/uninstall-linux.sh
+++ b/scripts/uninstall-linux.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Ne yapar: HekaDrop'u Linux sisteminden kaldırır (binary, .desktop, icon'lar,
+# systemd user service). Config/log dizinleri kasıtlı olarak dokunulmaz —
+# kullanıcı isterse manuel silebilir.
+#
+# Kullanım:
+#   ./scripts/uninstall-linux.sh            # varsayılan: --user
+#   ./scripts/uninstall-linux.sh --user
+#   sudo ./scripts/uninstall-linux.sh --system
+
+set -euo pipefail
+
+# Varsayılan mod
+MODE="user"
+
+# Argüman ayrıştırma
+if [[ $# -gt 0 ]]; then
+  case "$1" in
+    --user)
+      MODE="user"
+      ;;
+    --system)
+      MODE="system"
+      ;;
+    -h|--help)
+      echo "Kullanım: $0 [--user|--system]"
+      exit 0
+      ;;
+    *)
+      echo "HATA: Bilinmeyen argüman: $1" >&2
+      echo "Kullanım: $0 [--user|--system]" >&2
+      exit 2
+      ;;
+  esac
+fi
+
+# Hedef yolları moda göre ayarla
+if [[ "$MODE" == "user" ]]; then
+  BIN_PATH="${HOME}/.local/bin/hekadrop"
+  DESKTOP_PATH="${HOME}/.local/share/applications/hekadrop.desktop"
+  ICON_BASE="${HOME}/.local/share/icons/hicolor"
+  APP_DIR="${HOME}/.local/share/applications"
+else
+  BIN_PATH="/usr/local/bin/hekadrop"
+  DESKTOP_PATH="/usr/local/share/applications/hekadrop.desktop"
+  ICON_BASE="/usr/local/share/icons/hicolor"
+  APP_DIR="/usr/local/share/applications"
+  if [[ $EUID -ne 0 ]]; then
+    echo "HATA: --system kaldırma işlemi root yetkisi gerektirir." >&2
+    echo "       Şunu dene: sudo $0 --system" >&2
+    exit 1
+  fi
+fi
+
+echo "==> HekaDrop Linux kaldırılıyor (mod: ${MODE})"
+
+# 1) systemd user service varsa durdur & sil (yalnız user modda anlamlı)
+if [[ "$MODE" == "user" ]]; then
+  SERVICE_PATH="${HOME}/.config/systemd/user/hekadrop.service"
+  if [[ -f "$SERVICE_PATH" ]]; then
+    echo "==> systemd user service kaldırılıyor"
+    systemctl --user disable --now hekadrop.service >/dev/null 2>&1 || true
+    rm -f "$SERVICE_PATH"
+    systemctl --user daemon-reload >/dev/null 2>&1 || true
+    echo "   ✓ ${SERVICE_PATH}"
+  fi
+fi
+
+# 2) Binary
+if [[ -f "$BIN_PATH" ]]; then
+  echo "==> Binary siliniyor: $BIN_PATH"
+  rm -f "$BIN_PATH"
+else
+  echo "   (binary zaten yok: $BIN_PATH)"
+fi
+
+# 3) .desktop
+if [[ -f "$DESKTOP_PATH" ]]; then
+  echo "==> .desktop siliniyor: $DESKTOP_PATH"
+  rm -f "$DESKTOP_PATH"
+else
+  echo "   (.desktop zaten yok: $DESKTOP_PATH)"
+fi
+
+# 4) Icon'lar — tüm hicolor boyutlarını tara
+if [[ -d "$ICON_BASE" ]]; then
+  echo "==> Icon'lar siliniyor: ${ICON_BASE}/<size>/apps/hekadrop.png"
+  # -f ile: dosya yoksa sessiz geç
+  find "$ICON_BASE" -type f -name "hekadrop.png" -print -delete 2>/dev/null || true
+fi
+
+# Cache'leri tazele
+if command -v update-desktop-database >/dev/null 2>&1; then
+  update-desktop-database "$APP_DIR" >/dev/null 2>&1 || true
+fi
+
+if command -v gtk-update-icon-cache >/dev/null 2>&1; then
+  gtk-update-icon-cache -f -t "$ICON_BASE" >/dev/null 2>&1 || true
+fi
+
+# Özet
+echo ""
+echo "✓ HekaDrop kaldırıldı (mod: ${MODE})"
+echo ""
+echo "Not: Config ve log dizinlerine dokunulmadı. İstersen manuel sil:"
+echo "  rm -rf \"\$HOME/.config/HekaDrop\"      # ayarlar"
+echo "  rm -rf \"\$HOME/.local/state/HekaDrop\" # log'lar"

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,18 +12,7 @@ pub fn service_type() -> String {
 }
 
 pub fn device_name() -> String {
-    std::env::var("HEKADROP_NAME")
-        .ok()
-        .or_else(|| {
-            std::process::Command::new("scutil")
-                .args(["--get", "ComputerName"])
-                .output()
-                .ok()
-                .and_then(|o| String::from_utf8(o.stdout).ok())
-                .map(|s| s.trim().to_string())
-                .filter(|s| !s.is_empty())
-        })
-        .unwrap_or_else(|| "HekaDrop Mac".to_string())
+    crate::platform::device_name()
 }
 
 pub fn random_endpoint_id() -> [u8; 4] {

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -296,13 +296,14 @@ pub async fn handle(mut socket: TcpStream, peer: SocketAddr) -> Result<()> {
                                 path.display(),
                                 total_size
                             );
-                            ui::notify(
+                            ui::notify_file_received(
                                 "HekaDrop",
                                 &format!(
                                     "İndirildi: {} ({})",
                                     path.file_name().and_then(|n| n.to_str()).unwrap_or("dosya"),
                                     human_size(total_size)
                                 ),
+                                path.clone(),
                             );
                         }
                     }
@@ -541,12 +542,12 @@ fn handle_text_payload(peer: &SocketAddr, kind: TextType, data: &[u8]) {
     };
     match kind {
         TextType::Url => {
-            let _ = std::process::Command::new("open").arg(&text).spawn();
+            crate::platform::open_url(&text);
             info!("[{}] URL açıldı: {}", peer, text);
             ui::notify("HekaDrop", &format!("URL açıldı: {}", preview(&text, 80)));
         }
         _ => {
-            copy_to_clipboard(&text);
+            crate::platform::copy_to_clipboard(&text);
             info!(
                 "[{}] metin panoya kopyalandı ({} karakter)",
                 peer,
@@ -557,19 +558,6 @@ fn handle_text_payload(peer: &SocketAddr, kind: TextType, data: &[u8]) {
                 &format!("Metin panoya kopyalandı: {}", preview(&text, 80)),
             );
         }
-    }
-}
-
-fn copy_to_clipboard(text: &str) {
-    use std::io::Write;
-    let child = std::process::Command::new("pbcopy")
-        .stdin(std::process::Stdio::piped())
-        .spawn();
-    if let Ok(mut c) = child {
-        if let Some(stdin) = c.stdin.as_mut() {
-            let _ = stdin.write_all(text.as_bytes());
-        }
-        let _ = c.wait();
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ use std::sync::OnceLock;
 use std::time::Duration;
 use tao::event::{Event, WindowEvent};
 use tao::event_loop::{ControlFlow, EventLoopBuilder};
+#[cfg(target_os = "macos")]
 use tao::platform::macos::{ActivationPolicy, EventLoopExtMacOS};
 use tao::window::WindowBuilder;
 use tokio::runtime::Handle;
@@ -19,6 +20,7 @@ mod error;
 mod frame;
 mod mdns;
 mod payload;
+mod platform;
 mod secure;
 mod sender;
 mod server;
@@ -114,7 +116,8 @@ fn main() {
     run_app();
 }
 
-/// Hem stdout'a hem de `~/Library/Logs/HekaDrop/hekadrop.log` dosyasına yazar.
+/// Hem stdout'a hem de platforma uygun log dizinindeki `hekadrop.log` dosyasına yazar
+/// (macOS: `~/Library/Logs/HekaDrop`, Linux: `~/.local/state/HekaDrop/logs`).
 ///
 /// Log şişmesi koruması:
 ///   - Günlük rotation (her gün yeni dosya)
@@ -128,8 +131,7 @@ fn setup_logging() {
     let filter =
         EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("hekadrop=info"));
 
-    let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".into());
-    let log_dir = std::path::PathBuf::from(home).join("Library/Logs/HekaDrop");
+    let log_dir = platform::logs_dir();
     let _ = std::fs::create_dir_all(&log_dir);
 
     // Başlangıç temizliği — appender açılmadan önce diski kontrol altına al.
@@ -189,8 +191,14 @@ fn truncate_oversized_logs(dir: &std::path::Path, max_bytes: u64) {
 }
 
 fn run_app() -> ! {
+    #[cfg(target_os = "macos")]
     let mut event_loop = EventLoopBuilder::new().build();
-    // Dock'ta görünme — her zaman sadece menü çubuğunda
+    #[cfg(not(target_os = "macos"))]
+    let event_loop = EventLoopBuilder::new().build();
+
+    // Dock'ta görünme — her zaman sadece menü çubuğunda (macOS'a özgü davranış;
+    // Linux'ta pencere yöneticileri bunu uygulama tarafından yönetmez).
+    #[cfg(target_os = "macos")]
     event_loop.set_activation_policy(ActivationPolicy::Accessory);
 
     let device_name = state::get().settings.read().resolved_device_name();
@@ -245,7 +253,7 @@ fn run_app() -> ! {
         .build(&event_loop)
         .expect("window oluşturulamadı");
 
-    let webview = WebViewBuilder::new()
+    let builder = WebViewBuilder::new()
         .with_html(WINDOW_HTML)
         .with_ipc_handler(|req| {
             let cmd = req.into_body();
@@ -261,9 +269,21 @@ fn run_app() -> ! {
                 }
             }
             true
-        })
-        .build(&window)
-        .expect("webview oluşturulamadı");
+        });
+
+    // Linux (GTK): wry WebView bir gtk::Container içine monte edilmelidir;
+    // raw-window-handle yolu desteklenmez. macOS/Windows'ta `.build(&window)`.
+    #[cfg(target_os = "linux")]
+    let webview = {
+        use tao::platform::unix::WindowExtUnix;
+        use wry::WebViewBuilderExtUnix;
+        let vbox = window
+            .default_vbox()
+            .expect("tao pencere gtk_vbox döndürmedi");
+        builder.build_gtk(vbox).expect("webview oluşturulamadı")
+    };
+    #[cfg(not(target_os = "linux"))]
+    let webview = builder.build(&window).expect("webview oluşturulamadı");
 
     let menu_channel = MenuEvent::receiver();
     let open_downloads_id = open_downloads.id().clone();
@@ -427,9 +447,7 @@ fn handle_ipc(cmd: &str) {
             ui::notify("HekaDrop", "İstatistikler sıfırlandı");
         }
         "open_logs" => {
-            let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".into());
-            let log_dir = std::path::PathBuf::from(home).join("Library/Logs/HekaDrop");
-            let _ = std::process::Command::new("open").arg(&log_dir).spawn();
+            platform::open_path(&platform::logs_dir());
         }
         "check_update" => {
             if let Some(rt) = RUNTIME.get() {
@@ -542,14 +560,12 @@ fn push_stats_to_ui() {
         .map(|(n, b)| format!("{} ({})", n, human_size(b as i64)))
         .unwrap_or_else(|| "—".to_string());
 
-    let home = std::env::var("HOME").unwrap_or_default();
-
     let payload = serde_json::json!({
         "app_version": env!("CARGO_PKG_VERSION"),
         "device_name": st_settings_resolved_name(),
         "service_type": crate::config::service_type(),
         "port": state::listen_port(),
-        "log_dir": format!("{}/Library/Logs/HekaDrop", home),
+        "log_dir": platform::logs_dir().to_string_lossy(),
         "config_path": settings::config_path().to_string_lossy(),
         "bytes_received": human_size(s.bytes_received as i64),
         "bytes_sent": human_size(s.bytes_sent as i64),
@@ -610,15 +626,12 @@ fn push_history_to_ui() {
 }
 
 fn reveal_in_finder(path: &str) {
-    let _ = std::process::Command::new("open")
-        .arg("-R")
-        .arg(path)
-        .spawn();
+    platform::reveal_path(std::path::Path::new(path));
 }
 
 fn open_downloads_folder() {
     let dl = state::get().settings.read().resolved_download_dir();
-    let _ = std::process::Command::new("open").arg(&dl).spawn();
+    platform::open_path(&dl);
 }
 
 fn open_config_file() {
@@ -626,10 +639,7 @@ fn open_config_file() {
     if !path.exists() {
         let _ = state::get().settings.read().save();
     }
-    let _ = std::process::Command::new("open")
-        .arg("-R")
-        .arg(&path)
-        .spawn();
+    platform::reveal_path(&path);
 }
 
 fn progress_signature(p: &state::ProgressState) -> String {
@@ -875,6 +885,7 @@ fn human_size(bytes: i64) -> String {
     }
 }
 
+#[cfg(target_os = "macos")]
 fn toggle_login_item() {
     let home = match std::env::var("HOME") {
         Ok(h) => h,
@@ -954,4 +965,106 @@ fn toggle_login_item() {
         "HekaDrop",
         "Otomatik başlatma açıldı (launchd agent yüklendi)",
     );
+}
+
+/// Linux: systemd --user tabanlı otomatik başlatma.
+///
+/// `~/.config/systemd/user/hekadrop.service` dosyasını yazar ya da kaldırır.
+/// Gerçek binary yolu `std::env::current_exe()` ile alınır — `cargo run` ya da
+/// kurulu binary olsun aynı kalır.
+#[cfg(not(target_os = "macos"))]
+fn toggle_login_item() {
+    let home = match std::env::var("HOME") {
+        Ok(h) => h,
+        Err(_) => {
+            ui::notify("HekaDrop", "HOME bulunamadı");
+            return;
+        }
+    };
+
+    let unit_dir = std::path::PathBuf::from(&home).join(".config/systemd/user");
+    let unit_path = unit_dir.join("hekadrop.service");
+    let unit_name = "hekadrop.service";
+
+    if unit_path.exists() {
+        let _ = std::process::Command::new("systemctl")
+            .args(["--user", "disable", "--now", unit_name])
+            .output();
+        let _ = std::fs::remove_file(&unit_path);
+        let _ = std::process::Command::new("systemctl")
+            .args(["--user", "daemon-reload"])
+            .output();
+        ui::notify(
+            "HekaDrop",
+            "Otomatik başlatma kapatıldı (systemd user unit kaldırıldı)",
+        );
+        return;
+    }
+
+    let exe = match std::env::current_exe() {
+        Ok(p) => p,
+        Err(e) => {
+            ui::show_info(
+                "HekaDrop — otomatik başlatma",
+                &format!("current_exe alınamadı: {}", e),
+            );
+            return;
+        }
+    };
+
+    let unit = format!(
+        "[Unit]\n\
+         Description=HekaDrop — Quick Share alıcı/gönderici\n\
+         After=graphical-session.target\n\
+         \n\
+         [Service]\n\
+         Type=simple\n\
+         ExecStart={}\n\
+         Restart=on-failure\n\
+         RestartSec=10\n\
+         \n\
+         [Install]\n\
+         WantedBy=default.target\n",
+        exe.display()
+    );
+
+    if let Err(e) = std::fs::create_dir_all(&unit_dir) {
+        ui::show_info(
+            "HekaDrop",
+            &format!(
+                "systemd user dizini oluşturulamadı: {}\n{}",
+                e,
+                unit_dir.display()
+            ),
+        );
+        return;
+    }
+    if let Err(e) = std::fs::write(&unit_path, unit) {
+        ui::show_info(
+            "HekaDrop",
+            &format!("service dosyası yazılamadı: {}\n{}", e, unit_path.display()),
+        );
+        return;
+    }
+
+    let _ = std::process::Command::new("systemctl")
+        .args(["--user", "daemon-reload"])
+        .output();
+    let enable = std::process::Command::new("systemctl")
+        .args(["--user", "enable", "--now", unit_name])
+        .output();
+    match enable {
+        Ok(o) if o.status.success() => ui::notify(
+            "HekaDrop",
+            "Otomatik başlatma açıldı (systemd user unit yüklendi)",
+        ),
+        Ok(o) => ui::show_info(
+            "HekaDrop",
+            &format!(
+                "systemctl --user enable hata:\n{}",
+                String::from_utf8_lossy(&o.stderr).trim()
+            ),
+        ),
+        Err(e) => ui::show_info("HekaDrop", &format!("systemctl çalıştırılamadı: {}", e)),
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -967,12 +967,22 @@ fn toggle_login_item() {
     );
 }
 
+/// macOS/Linux dışındaki platformlarda (ör. Windows) otomatik başlatma henüz
+/// uygulanmadı; UI'yi kırmayacak şekilde stub bildirim gösterilir.
+#[cfg(all(not(target_os = "macos"), not(target_os = "linux")))]
+fn toggle_login_item() {
+    ui::show_info(
+        "HekaDrop — otomatik başlatma",
+        "Bu platformda otomatik başlatma henüz desteklenmiyor.",
+    );
+}
+
 /// Linux: systemd --user tabanlı otomatik başlatma.
 ///
 /// `~/.config/systemd/user/hekadrop.service` dosyasını yazar ya da kaldırır.
 /// Gerçek binary yolu `std::env::current_exe()` ile alınır — `cargo run` ya da
 /// kurulu binary olsun aynı kalır.
-#[cfg(not(target_os = "macos"))]
+#[cfg(target_os = "linux")]
 fn toggle_login_item() {
     let home = match std::env::var("HOME") {
         Ok(h) => h,

--- a/src/mdns.rs
+++ b/src/mdns.rs
@@ -2,7 +2,7 @@ use crate::config;
 use anyhow::Result;
 use mdns_sd::{ServiceDaemon, ServiceInfo};
 use std::net::IpAddr;
-use tracing::info;
+use tracing::{info, warn};
 
 pub struct MdnsHandle {
     daemon: ServiceDaemon,
@@ -15,7 +15,13 @@ impl Drop for MdnsHandle {
     }
 }
 
-pub fn advertise(device_name: &str, port: u16) -> Result<MdnsHandle> {
+/// mDNS yayınını başlatır.
+///
+/// `None` döner: ağ arayüzü yoksa — bu durumda uygulama UI olarak çalışmaya
+/// devam eder (Ayarlar/Geçmiş görüntülenebilir), sadece yeni cihazlar
+/// keşfedilemez. Bu davranış kasıtlı: ağ kablosu çıkıkken uygulamayı açıp
+/// kapatmak gerekmesin.
+pub fn advertise(device_name: &str, port: u16) -> Result<Option<MdnsHandle>> {
     let service_type = config::service_type();
     let endpoint_id = config::random_endpoint_id();
     let instance = config::instance_name(&endpoint_id);
@@ -45,10 +51,11 @@ pub fn advertise(device_name: &str, port: u16) -> Result<MdnsHandle> {
         .collect();
 
     if addrs.is_empty() {
-        anyhow::bail!(
-            "mDNS yayını için uygun IPv4 adresi bulunamadı — \
-             kablolu/kablosuz bağlantı aktif mi?"
+        warn!(
+            "mDNS yayını için uygun IPv4 adresi yok (kablo çıkık / sanal arayüzler filtrelendi) — \
+             mDNS devre dışı; ağ bağlantısı geldiğinde uygulamayı yeniden başlatın"
         );
+        return Ok(None);
     }
 
     let info = ServiceInfo::new(
@@ -74,5 +81,5 @@ pub fn advertise(device_name: &str, port: u16) -> Result<MdnsHandle> {
         addrs,
     );
 
-    Ok(MdnsHandle { daemon, fullname })
+    Ok(Some(MdnsHandle { daemon, fullname }))
 }

--- a/src/mdns.rs
+++ b/src/mdns.rs
@@ -21,12 +21,35 @@ pub fn advertise(device_name: &str, port: u16) -> Result<MdnsHandle> {
     let instance = config::instance_name(&endpoint_id);
     let endpoint_info_b64 = config::endpoint_info_b64(device_name);
 
+    // Sadece fiziksel/kablosuz arayüzleri yayınla. Docker, libvirt, Tailscale ve
+    // benzerleri LAN üzerinden erişilebilir değil; Android phone yanlış IP'yi
+    // deneyip başarısız olursa transfer düşer.
+    let skip_prefix = [
+        "docker",
+        "br-",
+        "veth",
+        "virbr",
+        "vnet",
+        "tailscale",
+        "zt",
+        "tun",
+        "tap",
+        "wg",
+    ];
     let addrs: Vec<IpAddr> = if_addrs::get_if_addrs()?
         .into_iter()
         .filter(|i| !i.is_loopback())
+        .filter(|i| !skip_prefix.iter().any(|p| i.name.starts_with(p)))
         .map(|i| i.ip())
         .filter(|ip| ip.is_ipv4())
         .collect();
+
+    if addrs.is_empty() {
+        anyhow::bail!(
+            "mDNS yayını için uygun IPv4 adresi bulunamadı — \
+             kablolu/kablosuz bağlantı aktif mi?"
+        );
+    }
 
     let info = ServiceInfo::new(
         &service_type,
@@ -43,11 +66,12 @@ pub fn advertise(device_name: &str, port: u16) -> Result<MdnsHandle> {
     daemon.register(info)?;
 
     info!(
-        "mDNS yayında: type={} instance={} name=\"{}\" endpoint_id={}",
+        "mDNS yayında: type={} instance={} name=\"{}\" endpoint_id={} addrs={:?}",
         service_type,
         instance,
         device_name,
-        String::from_utf8_lossy(&endpoint_id)
+        String::from_utf8_lossy(&endpoint_id),
+        addrs,
     );
 
     Ok(MdnsHandle { daemon, fullname })

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -1,0 +1,202 @@
+//! Platformdan bağımsız yardımcılar — config/logs yolları, device adı,
+//! dosya/URL açma, panoya kopyalama, otomatik başlatma.
+//!
+//! Bu modül tek giriş noktasıdır; çağıranlar (`settings`, `stats`, `main`,
+//! `connection`, `ui`) platforma göre ayrım yapmaz. Linux portu yeni target'lar
+//! eklerken sadece burası genişletilir.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Uygulamanın kalıcı ayar dizini.
+///
+/// - macOS: `~/Library/Application Support/HekaDrop`
+/// - Linux: `$XDG_CONFIG_HOME/HekaDrop` → `~/.config/HekaDrop`
+pub fn config_dir() -> PathBuf {
+    #[cfg(target_os = "macos")]
+    {
+        let home = std::env::var_os("HOME").expect("HOME tanımsız");
+        return PathBuf::from(home).join("Library/Application Support/HekaDrop");
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        if let Some(xdg) = std::env::var_os("XDG_CONFIG_HOME").filter(|v| !v.is_empty()) {
+            return PathBuf::from(xdg).join("HekaDrop");
+        }
+        let home = std::env::var_os("HOME").expect("HOME tanımsız");
+        PathBuf::from(home).join(".config/HekaDrop")
+    }
+}
+
+/// Log dosyalarının gideceği dizin.
+///
+/// - macOS: `~/Library/Logs/HekaDrop`
+/// - Linux: `$XDG_STATE_HOME/HekaDrop/logs` → `~/.local/state/HekaDrop/logs`
+pub fn logs_dir() -> PathBuf {
+    #[cfg(target_os = "macos")]
+    {
+        let home = std::env::var_os("HOME").expect("HOME tanımsız");
+        return PathBuf::from(home).join("Library/Logs/HekaDrop");
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        if let Some(xdg) = std::env::var_os("XDG_STATE_HOME").filter(|v| !v.is_empty()) {
+            return PathBuf::from(xdg).join("HekaDrop/logs");
+        }
+        let home = std::env::var_os("HOME").expect("HOME tanımsız");
+        PathBuf::from(home).join(".local/state/HekaDrop/logs")
+    }
+}
+
+/// Varsayılan indirme klasörü.
+///
+/// Linux'ta önce `xdg-user-dir DOWNLOAD` denenir; başarısızsa `~/Downloads`.
+pub fn default_download_dir() -> PathBuf {
+    #[cfg(not(target_os = "macos"))]
+    {
+        if let Ok(out) = Command::new("xdg-user-dir").arg("DOWNLOAD").output() {
+            if out.status.success() {
+                if let Ok(s) = String::from_utf8(out.stdout) {
+                    let trimmed = s.trim();
+                    if !trimmed.is_empty() {
+                        return PathBuf::from(trimmed);
+                    }
+                }
+            }
+        }
+    }
+    let home = std::env::var_os("HOME").expect("HOME tanımsız");
+    PathBuf::from(home).join("Downloads")
+}
+
+/// mDNS / UI için gösterilecek cihaz adı.
+///
+/// - macOS: `scutil --get ComputerName`
+/// - Linux: `hostname` / `/etc/hostname` → fallback "HekaDrop Linux"
+pub fn device_name() -> String {
+    if let Ok(v) = std::env::var("HEKADROP_NAME") {
+        if !v.is_empty() {
+            return v;
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        if let Ok(out) = Command::new("scutil")
+            .args(["--get", "ComputerName"])
+            .output()
+        {
+            if let Ok(s) = String::from_utf8(out.stdout) {
+                let t = s.trim();
+                if !t.is_empty() {
+                    return t.to_string();
+                }
+            }
+        }
+        return "HekaDrop Mac".to_string();
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        if let Ok(h) = std::fs::read_to_string("/etc/hostname") {
+            let t = h.trim();
+            if !t.is_empty() {
+                return format!("HekaDrop {}", t);
+            }
+        }
+        if let Ok(out) = Command::new("hostname").output() {
+            if let Ok(s) = String::from_utf8(out.stdout) {
+                let t = s.trim();
+                if !t.is_empty() {
+                    return format!("HekaDrop {}", t);
+                }
+            }
+        }
+        "HekaDrop Linux".to_string()
+    }
+}
+
+/// Verilen dosyayı/dizini işletim sisteminin varsayılan programıyla açar.
+pub fn open_path(path: &Path) {
+    #[cfg(target_os = "macos")]
+    let tool = "open";
+    #[cfg(not(target_os = "macos"))]
+    let tool = "xdg-open";
+    let _ = Command::new(tool).arg(path).spawn();
+}
+
+/// Dosyayı dosya yöneticisinde (Finder / Nautilus) seçili olarak gösterir.
+pub fn reveal_path(path: &Path) {
+    #[cfg(target_os = "macos")]
+    {
+        let _ = Command::new("open").arg("-R").arg(path).spawn();
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        // D-Bus FileManager1 çoğu Linux DE'de mevcut; başarısızsa parent dizini açarız.
+        let uri = format!("file://{}", path.display());
+        let dbus = Command::new("dbus-send")
+            .args([
+                "--session",
+                "--dest=org.freedesktop.FileManager1",
+                "--type=method_call",
+                "/org/freedesktop/FileManager1",
+                "org.freedesktop.FileManager1.ShowItems",
+                &format!("array:string:{}", uri),
+                "string:",
+            ])
+            .status();
+        if matches!(dbus, Ok(s) if s.success()) {
+            return;
+        }
+        let parent = path.parent().unwrap_or(path);
+        let _ = Command::new("xdg-open").arg(parent).spawn();
+    }
+}
+
+/// URL'i tarayıcıda açar.
+pub fn open_url(url: &str) {
+    #[cfg(target_os = "macos")]
+    let tool = "open";
+    #[cfg(not(target_os = "macos"))]
+    let tool = "xdg-open";
+    let _ = Command::new(tool).arg(url).spawn();
+}
+
+/// Metni sistem panosuna kopyalar.
+///
+/// Linux'ta Wayland (wl-copy) ve X11 (xclip/xsel) sırayla denenir.
+pub fn copy_to_clipboard(text: &str) {
+    use std::io::Write;
+    use std::process::Stdio;
+
+    #[cfg(target_os = "macos")]
+    let candidates: &[&[&str]] = &[&["pbcopy"]];
+    #[cfg(not(target_os = "macos"))]
+    let candidates: &[&[&str]] = &[
+        &["wl-copy"],
+        &["xclip", "-selection", "clipboard"],
+        &["xsel", "--clipboard", "--input"],
+    ];
+
+    for args in candidates {
+        let mut cmd = Command::new(args[0]);
+        if args.len() > 1 {
+            cmd.args(&args[1..]);
+        }
+        let child = cmd.stdin(Stdio::piped()).stderr(Stdio::null()).spawn();
+        if let Ok(mut c) = child {
+            if let Some(stdin) = c.stdin.as_mut() {
+                let _ = stdin.write_all(text.as_bytes());
+            }
+            if let Ok(status) = c.wait() {
+                if status.success() {
+                    return;
+                }
+            }
+        }
+    }
+    tracing::warn!(
+        "panoya kopyalama başarısız — yardımcı araç (wl-copy/xclip/xsel/pbcopy) bulunamadı"
+    );
+}

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -8,6 +8,15 @@
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+/// `$HOME` değerini al; tanımlı değilse `/tmp` fallback (macOS/Linux'ta
+/// pratikte gerçekleşmez ama daemon/systemd ortamlarında tekil bir senaryo
+/// olabilir — panic yerine degraded mode'a düşmek daha sağlıklı).
+fn home_dir() -> PathBuf {
+    std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("/tmp"))
+}
+
 /// Uygulamanın kalıcı ayar dizini.
 ///
 /// - macOS: `~/Library/Application Support/HekaDrop`
@@ -15,16 +24,14 @@ use std::process::Command;
 pub fn config_dir() -> PathBuf {
     #[cfg(target_os = "macos")]
     {
-        let home = std::env::var_os("HOME").expect("HOME tanımsız");
-        return PathBuf::from(home).join("Library/Application Support/HekaDrop");
+        home_dir().join("Library/Application Support/HekaDrop")
     }
     #[cfg(not(target_os = "macos"))]
     {
         if let Some(xdg) = std::env::var_os("XDG_CONFIG_HOME").filter(|v| !v.is_empty()) {
             return PathBuf::from(xdg).join("HekaDrop");
         }
-        let home = std::env::var_os("HOME").expect("HOME tanımsız");
-        PathBuf::from(home).join(".config/HekaDrop")
+        home_dir().join(".config/HekaDrop")
     }
 }
 
@@ -35,16 +42,14 @@ pub fn config_dir() -> PathBuf {
 pub fn logs_dir() -> PathBuf {
     #[cfg(target_os = "macos")]
     {
-        let home = std::env::var_os("HOME").expect("HOME tanımsız");
-        return PathBuf::from(home).join("Library/Logs/HekaDrop");
+        home_dir().join("Library/Logs/HekaDrop")
     }
     #[cfg(not(target_os = "macos"))]
     {
         if let Some(xdg) = std::env::var_os("XDG_STATE_HOME").filter(|v| !v.is_empty()) {
             return PathBuf::from(xdg).join("HekaDrop/logs");
         }
-        let home = std::env::var_os("HOME").expect("HOME tanımsız");
-        PathBuf::from(home).join(".local/state/HekaDrop/logs")
+        home_dir().join(".local/state/HekaDrop/logs")
     }
 }
 
@@ -65,8 +70,7 @@ pub fn default_download_dir() -> PathBuf {
             }
         }
     }
-    let home = std::env::var_os("HOME").expect("HOME tanımsız");
-    PathBuf::from(home).join("Downloads")
+    home_dir().join("Downloads")
 }
 
 /// mDNS / UI için gösterilecek cihaz adı.
@@ -93,7 +97,7 @@ pub fn device_name() -> String {
                 }
             }
         }
-        return "HekaDrop Mac".to_string();
+        "HekaDrop Mac".to_string()
     }
 
     #[cfg(not(target_os = "macos"))]
@@ -134,7 +138,10 @@ pub fn reveal_path(path: &Path) {
     #[cfg(not(target_os = "macos"))]
     {
         // D-Bus FileManager1 çoğu Linux DE'de mevcut; başarısızsa parent dizini açarız.
-        let uri = format!("file://{}", path.display());
+        // RFC 3986: file:// URI'sinde boşluk / `#` / `?` / `%` / non-ASCII vb.
+        // karakterler percent-encode edilmeli — aksi halde URI parse'ı bozulur
+        // ve Nautilus dosyayı bulamaz.
+        let uri = path_to_file_uri(path);
         let dbus = Command::new("dbus-send")
             .args([
                 "--session",
@@ -151,6 +158,74 @@ pub fn reveal_path(path: &Path) {
         }
         let parent = path.parent().unwrap_or(path);
         let _ = Command::new("xdg-open").arg(parent).spawn();
+    }
+}
+
+/// Bir dosya yolunu `file://` URI'sine çevirir (RFC 3986 percent-encoding).
+///
+/// Kaçmadan bırakılanlar: unreserved karakterler (`A-Z a-z 0-9 - . _ ~`)
+/// ve path ayırıcı `/`. Diğer her şey — boşluk, `#`, `?`, `%`, Türkçe karakter
+/// vb. — `%XX` olarak kodlanır. Bayt seviyesinde çalışır; UTF-8 sequence'ları
+/// doğru biçimde kodlanır.
+#[cfg(not(target_os = "macos"))]
+fn path_to_file_uri(path: &Path) -> String {
+    let bytes = path.as_os_str().as_encoded_bytes();
+    let mut out = String::from("file://");
+    for &b in bytes {
+        let unreserved = matches!(b,
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' | b'/'
+        );
+        if unreserved {
+            out.push(b as char);
+        } else {
+            out.push_str(&format!("%{:02X}", b));
+        }
+    }
+    out
+}
+
+#[cfg(all(test, not(target_os = "macos")))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn uri_basit_path_kodlamadan_gecer() {
+        assert_eq!(
+            path_to_file_uri(Path::new("/home/user/file.pdf")),
+            "file:///home/user/file.pdf"
+        );
+    }
+
+    #[test]
+    fn uri_bosluklu_dosya_adi_percent_encode() {
+        assert_eq!(
+            path_to_file_uri(Path::new("/home/user/my file.pdf")),
+            "file:///home/user/my%20file.pdf"
+        );
+    }
+
+    #[test]
+    fn uri_hash_ve_soru_isareti_encode() {
+        // `#` fragment, `?` query ayırıcısı olarak yorumlanacağından kodlanmalı.
+        assert_eq!(
+            path_to_file_uri(Path::new("/tmp/a#b?c.txt")),
+            "file:///tmp/a%23b%3Fc.txt"
+        );
+    }
+
+    #[test]
+    fn uri_yuzde_isareti_kendisi_de_encode() {
+        assert_eq!(
+            path_to_file_uri(Path::new("/tmp/%20raw.txt")),
+            "file:///tmp/%2520raw.txt"
+        );
+    }
+
+    #[test]
+    fn uri_turkce_karakterler_utf8_bayt_encode() {
+        // "şarkı" → UTF-8: 0xC5 0x9F 0x61 0x72 0x6B 0xC4 0xB1
+        let uri = path_to_file_uri(Path::new("/müzik/şarkı.mp3"));
+        assert_eq!(uri, "file:///m%C3%BCzik/%C5%9Fark%C4%B1.mp3");
     }
 }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -9,9 +9,12 @@ use tracing::{info, warn};
 const DEFAULT_PORT: u16 = 47893;
 
 pub async fn start_listener() -> Result<TcpListener> {
+    // `HEKADROP_PORT=0` özellikle filtrelenir: 0 "OS seçsin" anlamına gelir ama
+    // "sabit port" semantiğini kırar, log'u yanıltır. 0 geçilirse default'a düşer.
     let wanted = std::env::var("HEKADROP_PORT")
         .ok()
         .and_then(|s| s.parse::<u16>().ok())
+        .filter(|p| *p != 0)
         .unwrap_or(DEFAULT_PORT);
 
     // Sabit portu dene; kullanımdaysa OS'un seçeceği random port'a düş. Böylece

--- a/src/server.rs
+++ b/src/server.rs
@@ -3,9 +3,32 @@ use anyhow::Result;
 use tokio::net::TcpListener;
 use tracing::{info, warn};
 
+/// Varsayılan TCP portu. Random port yerine sabit değer seçildi çünkü
+/// Linux kullanıcıları UFW/firewalld ile tek sefer kural açıp unutmak ister.
+/// `HEKADROP_PORT` ortam değişkeniyle override edilebilir.
+const DEFAULT_PORT: u16 = 47893;
+
 pub async fn start_listener() -> Result<TcpListener> {
-    let listener = TcpListener::bind("0.0.0.0:0").await?;
-    Ok(listener)
+    let wanted = std::env::var("HEKADROP_PORT")
+        .ok()
+        .and_then(|s| s.parse::<u16>().ok())
+        .unwrap_or(DEFAULT_PORT);
+
+    // Sabit portu dene; kullanımdaysa OS'un seçeceği random port'a düş. Böylece
+    // çift-instance çalıştırma durumu kilitlenme yerine düşüş davranışı verir.
+    match TcpListener::bind(("0.0.0.0", wanted)).await {
+        Ok(l) => {
+            info!("TCP sabit portta dinleniyor: {}", wanted);
+            Ok(l)
+        }
+        Err(e) => {
+            warn!(
+                "sabit port {} alınamadı ({}) — random port'a düşülüyor",
+                wanted, e
+            );
+            Ok(TcpListener::bind("0.0.0.0:0").await?)
+        }
+    }
 }
 
 pub async fn accept_loop(listener: TcpListener) -> Result<()> {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,4 +1,6 @@
-//! Kalıcı ayarlar — `~/Library/Application Support/HekaDrop/config.json`.
+//! Kalıcı ayarlar — platforma göre:
+//!   - macOS: `~/Library/Application Support/HekaDrop/config.json`
+//!   - Linux: `~/.config/HekaDrop/config.json`
 //!
 //! JSON formatı insan tarafından okunabilir, ileri uyumlu. Bilinmeyen alanlar yok
 //! sayılır (`#[serde(default)]`).
@@ -183,16 +185,14 @@ impl Settings {
     }
 
     pub fn resolved_download_dir(&self) -> PathBuf {
-        self.download_dir.clone().unwrap_or_else(|| {
-            let home = std::env::var_os("HOME").expect("HOME tanımsız");
-            PathBuf::from(home).join("Downloads")
-        })
+        self.download_dir
+            .clone()
+            .unwrap_or_else(crate::platform::default_download_dir)
     }
 }
 
 pub fn config_path() -> PathBuf {
-    let home = std::env::var_os("HOME").expect("HOME tanımsız");
-    PathBuf::from(home).join("Library/Application Support/HekaDrop/config.json")
+    crate::platform::config_dir().join("config.json")
 }
 
 /// `trusted_devices` alanı için özel deserializer — hem yeni (nesne dizisi)

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -1,4 +1,6 @@
-//! Kalıcı kullanım istatistikleri — `~/Library/Application Support/HekaDrop/stats.json`.
+//! Kalıcı kullanım istatistikleri — platforma göre:
+//!   - macOS: `~/Library/Application Support/HekaDrop/stats.json`
+//!   - Linux: `~/.config/HekaDrop/stats.json`
 //!
 //! Her başarılı aktarım sonrası güncellenir. UI'da "Tanı" sekmesinde gösterilir.
 //! SystemTime yerine UNIX epoch saniye olarak saklanır (serde'de kolay, taşınabilir).
@@ -110,6 +112,5 @@ impl Stats {
 }
 
 fn stats_path() -> PathBuf {
-    let home = std::env::var_os("HOME").expect("HOME tanımsız");
-    PathBuf::from(home).join("Library/Application Support/HekaDrop/stats.json")
+    crate::platform::config_dir().join("stats.json")
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -184,7 +184,6 @@ pub fn notify_file_received(title: &str, body: &str, path: std::path::PathBuf) {
     {
         let _ = path; // macOS/Windows: şimdilik plain notify.
         notify(title, body);
-        return;
     }
 
     #[cfg(target_os = "linux")]
@@ -192,9 +191,13 @@ pub fn notify_file_received(title: &str, body: &str, path: std::path::PathBuf) {
         // notify-rust blocking API'si var; ayrı thread'de başlatıp dialog
         // kapanana kadar bekletiyoruz. Fire-and-forget — tokio runtime'ı
         // bloklamaz.
+        //
+        // `default` aksiyonu freedesktop spec'inde bildirim gövdesine
+        // tıklayınca tetiklenir (buton göstermez); "Klasörde göster" tek
+        // ek buton olarak kalır — aksi halde iki "Aç" butonu duplike görünür.
         let title = title.to_string();
         let body = body.to_string();
-        std::thread::Builder::new()
+        let spawned = std::thread::Builder::new()
             .name("hekadrop-notify".into())
             .spawn(move || {
                 use notify_rust::Notification;
@@ -203,7 +206,6 @@ pub fn notify_file_received(title: &str, body: &str, path: std::path::PathBuf) {
                     .summary(&title)
                     .body(&body)
                     .action("default", "Aç")
-                    .action("open", "Aç")
                     .action("reveal", "Klasörde göster")
                     .timeout(10_000)
                     .show();
@@ -219,17 +221,20 @@ pub fn notify_file_received(title: &str, body: &str, path: std::path::PathBuf) {
                     }
                 };
                 handle.wait_for_action(|action| match action {
-                    "open" | "default" => {
+                    "default" => {
                         crate::platform::open_path(&path);
                     }
                     "reveal" => {
                         crate::platform::reveal_path(&path);
                     }
-                    "__closed" => {}
                     _ => {}
                 });
-            })
-            .expect("notify thread spawn");
+            });
+        if let Err(e) = spawned {
+            // title/body closure'a taşındı; fallback için kullanamayız. Thread
+            // spawn'ı sistemsel bir hata — sadece warn ve geç.
+            tracing::warn!("bildirim thread'i başlatılamadı: {}", e);
+        }
     }
 }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,10 +1,18 @@
-//! macOS kullanıcı arayüzü — osascript ile native dialog ve bildirimler.
+//! Kullanıcı arayüzü yardımcıları — cross-platform dialog ve bildirimler.
 //!
-//! tray-icon / objc2 yerine `osascript` tercih edildi çünkü tokio runtime ile
-//! sürtünmesi az, tek komutla native AppKit dialog'u açar.
+//! macOS'ta `osascript` (AppKit dialog'u), Linux'ta `zenity` tercih edilir.
+//! Zenity yoksa `kdialog`'a düşer; ikisi de yoksa stderr'e log bırakıp kalıcı
+//! başarısızlık yerine "Reject/None" döner — böylece uygulama headless
+//! ortamda bile çökmez.
+//!
+//! tray-icon / objc2 yerine external process tercih edildi çünkü tokio
+//! runtime ile sürtünmesi az, tek komutla native dialog açar.
 
 use anyhow::Result;
+#[cfg(target_os = "macos")]
 use std::process::Command;
+#[cfg(not(target_os = "macos"))]
+use std::process::{Command, Stdio};
 use tokio::task;
 
 #[allow(unused_imports)]
@@ -36,69 +44,251 @@ pub async fn prompt_accept(
     let pin = pin_code.to_string();
     let files: Vec<(String, i64)> = files.iter().map(|f| (f.name.clone(), f.size)).collect();
 
-    task::spawn_blocking(move || {
-        let files_str = if files.is_empty() {
-            if text_count > 0 {
-                format!("{} metin", text_count)
-            } else {
-                "içerik yok".to_string()
-            }
-        } else {
-            files
-                .iter()
-                .map(|(n, s)| format!("• {} ({})", n, human_size(*s)))
-                .collect::<Vec<_>>()
-                .join("\n")
-        };
-
-        let message = format!(
-            "{} cihazından dosya gönderiliyor.\n\nPIN: {}\n\n{}",
-            device, pin, files_str
-        );
-
-        // osascript 3 buton destekler. En sağdaki default.
-        let script = format!(
-            r#"display dialog "{}" buttons {{"Reddet", "Kabul et", "Kabul + güven"}} default button "Kabul et" cancel button "Reddet" with title "HekaDrop" with icon note"#,
-            escape_applescript(&message)
-        );
-
-        let out = Command::new("osascript").arg("-e").arg(&script).output();
-        match out {
-            Ok(o) => {
-                let s = String::from_utf8_lossy(&o.stdout);
-                if s.contains("Kabul + güven") {
-                    AcceptResult::AcceptAndTrust
-                } else if s.contains("Kabul et") {
-                    AcceptResult::Accept
-                } else {
-                    AcceptResult::Reject
-                }
-            }
-            Err(_) => AcceptResult::Reject,
-        }
-    })
-    .await
-    .map_err(|e| anyhow::anyhow!("UI task join: {}", e))
+    task::spawn_blocking(move || prompt_accept_blocking(&device, &pin, &files, text_count))
+        .await
+        .map_err(|e| anyhow::anyhow!("UI task join: {}", e))
 }
 
-/// Kısa bildirim (macOS Notification Center). Başarı/hata mesajları için.
-pub fn notify(title: &str, body: &str) {
-    let script = format!(
-        r#"display notification "{}" with title "{}""#,
-        escape_applescript(body),
-        escape_applescript(title)
+fn format_payload_lines(files: &[(String, i64)], text_count: usize) -> String {
+    if files.is_empty() {
+        if text_count > 0 {
+            format!("{} metin", text_count)
+        } else {
+            "içerik yok".to_string()
+        }
+    } else {
+        files
+            .iter()
+            .map(|(n, s)| format!("• {} ({})", n, human_size(*s)))
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn prompt_accept_blocking(
+    device: &str,
+    pin: &str,
+    files: &[(String, i64)],
+    text_count: usize,
+) -> AcceptResult {
+    let files_str = format_payload_lines(files, text_count);
+    let message = format!(
+        "{} cihazından dosya gönderiliyor.\n\nPIN: {}\n\n{}",
+        device, pin, files_str
     );
-    let _ = Command::new("osascript").arg("-e").arg(&script).spawn();
+    let script = format!(
+        r#"display dialog "{}" buttons {{"Reddet", "Kabul et", "Kabul + güven"}} default button "Kabul et" cancel button "Reddet" with title "HekaDrop" with icon note"#,
+        escape_applescript(&message)
+    );
+    let out = Command::new("osascript").arg("-e").arg(&script).output();
+    match out {
+        Ok(o) => {
+            let s = String::from_utf8_lossy(&o.stdout);
+            if s.contains("Kabul + güven") {
+                AcceptResult::AcceptAndTrust
+            } else if s.contains("Kabul et") {
+                AcceptResult::Accept
+            } else {
+                AcceptResult::Reject
+            }
+        }
+        Err(_) => AcceptResult::Reject,
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn prompt_accept_blocking(
+    device: &str,
+    pin: &str,
+    files: &[(String, i64)],
+    text_count: usize,
+) -> AcceptResult {
+    let files_str = format_payload_lines(files, text_count);
+    let message = format!(
+        "{} cihazından dosya gönderiliyor.\n\nPIN: {}\n\n{}",
+        device, pin, files_str
+    );
+
+    // zenity yalnız "Tamam/İptal" 2 butonu destekler. "Kabul + güven"
+    // seçeneğini ikinci adımda soruyoruz: önce kabul/ret, sonra güven.
+    if have("zenity") {
+        let accept = Command::new("zenity")
+            .args([
+                "--question",
+                "--title=HekaDrop",
+                &format!("--text={}", message),
+                "--ok-label=Kabul et",
+                "--cancel-label=Reddet",
+                "--width=420",
+            ])
+            .stderr(Stdio::null())
+            .status();
+        let accepted = matches!(accept, Ok(s) if s.success());
+        if !accepted {
+            return AcceptResult::Reject;
+        }
+        let trust = Command::new("zenity")
+            .args([
+                "--question",
+                "--title=HekaDrop",
+                &format!("--text={} cihazını bu ve sonraki aktarımlar için güven listesine ekleyeyim mi?", device),
+                "--ok-label=Evet, güven",
+                "--cancel-label=Sadece bu sefer",
+            ])
+            .stderr(Stdio::null())
+            .status();
+        if matches!(trust, Ok(s) if s.success()) {
+            AcceptResult::AcceptAndTrust
+        } else {
+            AcceptResult::Accept
+        }
+    } else if have("kdialog") {
+        // kdialog 3-button: --yesnocancel → Evet (Accept+Trust) / Hayır (Accept) / İptal (Reject)
+        let out = Command::new("kdialog")
+            .args([
+                "--title",
+                "HekaDrop",
+                "--yesnocancel",
+                &format!(
+                    "{}\n\n(Evet = Kabul + güven, Hayır = Kabul, İptal = Reddet)",
+                    message
+                ),
+            ])
+            .status();
+        match out {
+            Ok(s) => match s.code() {
+                Some(0) => AcceptResult::AcceptAndTrust,
+                Some(1) => AcceptResult::Accept,
+                _ => AcceptResult::Reject,
+            },
+            Err(_) => AcceptResult::Reject,
+        }
+    } else {
+        tracing::warn!(
+            "prompt_accept: zenity/kdialog yok; aktarım otomatik reddedildi. \
+             `sudo apt install zenity` ile kurulum yapın."
+        );
+        AcceptResult::Reject
+    }
+}
+
+/// Dosya başarıyla alındıktan sonra gösterilen bildirim.
+///
+/// Linux'ta "Aç" ve "Klasörde göster" aksiyon butonları eklenir; kullanıcı
+/// butona bastığında dosya `xdg-open` ile, klasör ise file-manager ile açılır.
+/// macOS'ta aksiyon butonu desteklenmez — düz bildirim + tıklanınca Finder'da
+/// açma için fallback uygulanır (bkz. `NotificationCenter` gelecek iş).
+pub fn notify_file_received(title: &str, body: &str, path: std::path::PathBuf) {
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = path; // macOS/Windows: şimdilik plain notify.
+        notify(title, body);
+        return;
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        // notify-rust blocking API'si var; ayrı thread'de başlatıp dialog
+        // kapanana kadar bekletiyoruz. Fire-and-forget — tokio runtime'ı
+        // bloklamaz.
+        let title = title.to_string();
+        let body = body.to_string();
+        std::thread::Builder::new()
+            .name("hekadrop-notify".into())
+            .spawn(move || {
+                use notify_rust::Notification;
+                let handle = Notification::new()
+                    .appname("HekaDrop")
+                    .summary(&title)
+                    .body(&body)
+                    .action("default", "Aç")
+                    .action("open", "Aç")
+                    .action("reveal", "Klasörde göster")
+                    .timeout(10_000)
+                    .show();
+                let handle = match handle {
+                    Ok(h) => h,
+                    Err(e) => {
+                        tracing::warn!("notify-rust gösterim hatası: {}", e);
+                        // notify-send fallback'i — aksiyonsuz ama en azından görünsün.
+                        let _ = std::process::Command::new("notify-send")
+                            .args(["--app-name=HekaDrop", &title, &body])
+                            .status();
+                        return;
+                    }
+                };
+                handle.wait_for_action(|action| match action {
+                    "open" | "default" => {
+                        crate::platform::open_path(&path);
+                    }
+                    "reveal" => {
+                        crate::platform::reveal_path(&path);
+                    }
+                    "__closed" => {}
+                    _ => {}
+                });
+            })
+            .expect("notify thread spawn");
+    }
+}
+
+/// Kısa bildirim. Başarı/hata mesajları için.
+pub fn notify(title: &str, body: &str) {
+    #[cfg(target_os = "macos")]
+    {
+        let script = format!(
+            r#"display notification "{}" with title "{}""#,
+            escape_applescript(body),
+            escape_applescript(title)
+        );
+        let _ = Command::new("osascript").arg("-e").arg(&script).spawn();
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        // notify-send en yaygın; yoksa sessizce log'a yaz.
+        let spawned = Command::new("notify-send")
+            .args(["--app-name=HekaDrop", title, body])
+            .stderr(Stdio::null())
+            .spawn();
+        if spawned.is_err() {
+            tracing::info!("[notify] {}: {}", title, body);
+        }
+    }
 }
 
 /// Bilgi diyaloğu (blocking değil, fire-and-forget).
 pub fn show_info(title: &str, body: &str) {
-    let script = format!(
-        r#"display dialog "{}" buttons {{"Tamam"}} default button "Tamam" with title "{}" with icon note"#,
-        escape_applescript(body),
-        escape_applescript(title)
-    );
-    let _ = Command::new("osascript").arg("-e").arg(&script).spawn();
+    #[cfg(target_os = "macos")]
+    {
+        let script = format!(
+            r#"display dialog "{}" buttons {{"Tamam"}} default button "Tamam" with title "{}" with icon note"#,
+            escape_applescript(body),
+            escape_applescript(title)
+        );
+        let _ = Command::new("osascript").arg("-e").arg(&script).spawn();
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        if have("zenity") {
+            let _ = Command::new("zenity")
+                .args([
+                    "--info",
+                    &format!("--title={}", title),
+                    &format!("--text={}", body),
+                    "--width=420",
+                ])
+                .stderr(Stdio::null())
+                .spawn();
+        } else if have("kdialog") {
+            let _ = Command::new("kdialog")
+                .args(["--title", title, "--msgbox", body])
+                .spawn();
+        } else {
+            // Dialog yoksa en azından bir masaüstü bildirimi gönder.
+            notify(title, body);
+        }
+    }
 }
 
 /// `choose file` dialog → seçilen dosyanın tam yolu veya None (tek dosya).
@@ -107,10 +297,17 @@ pub async fn choose_file() -> Option<std::path::PathBuf> {
     choose_files().await.and_then(|mut v| v.pop())
 }
 
-/// Çoklu dosya seçim dialog'u → seçilen tüm POSIX path'lerin listesi.
+/// Çoklu dosya seçim dialog'u → seçilen tüm path'lerin listesi.
 pub async fn choose_files() -> Option<Vec<std::path::PathBuf>> {
-    task::spawn_blocking(|| {
-        let script = r#"
+    task::spawn_blocking(choose_files_blocking)
+        .await
+        .ok()
+        .flatten()
+}
+
+#[cfg(target_os = "macos")]
+fn choose_files_blocking() -> Option<Vec<std::path::PathBuf>> {
+    let script = r#"
 set theFiles to choose file with prompt "Gönderilecek dosyaları seçin" with multiple selections allowed
 set pathList to ""
 repeat with f in theFiles
@@ -118,7 +315,40 @@ repeat with f in theFiles
 end repeat
 pathList
 "#;
-        let out = Command::new("osascript").args(["-e", script]).output().ok()?;
+    let out = Command::new("osascript")
+        .args(["-e", script])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let text = String::from_utf8_lossy(&out.stdout);
+    let paths: Vec<_> = text
+        .lines()
+        .map(|l| l.trim())
+        .filter(|l| !l.is_empty())
+        .map(std::path::PathBuf::from)
+        .collect();
+    if paths.is_empty() {
+        None
+    } else {
+        Some(paths)
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn choose_files_blocking() -> Option<Vec<std::path::PathBuf>> {
+    if have("zenity") {
+        let out = Command::new("zenity")
+            .args([
+                "--file-selection",
+                "--multiple",
+                "--separator=\n",
+                "--title=Gönderilecek dosyaları seçin",
+            ])
+            .stderr(Stdio::null())
+            .output()
+            .ok()?;
         if !out.status.success() {
             return None;
         }
@@ -134,19 +364,95 @@ pathList
         } else {
             Some(paths)
         }
-    })
-    .await
-    .ok()
-    .flatten()
+    } else if have("kdialog") {
+        let out = Command::new("kdialog")
+            .args([
+                "--title",
+                "Gönderilecek dosyaları seçin",
+                "--getopenfilename",
+                "--multiple",
+                "--separate-output",
+                ".",
+            ])
+            .output()
+            .ok()?;
+        if !out.status.success() {
+            return None;
+        }
+        let text = String::from_utf8_lossy(&out.stdout);
+        let paths: Vec<_> = text
+            .lines()
+            .map(|l| l.trim())
+            .filter(|l| !l.is_empty())
+            .map(std::path::PathBuf::from)
+            .collect();
+        if paths.is_empty() {
+            None
+        } else {
+            Some(paths)
+        }
+    } else {
+        tracing::warn!("choose_files: zenity/kdialog yok");
+        None
+    }
 }
 
-/// `choose folder` dialog → seçilen klasörün POSIX path'i.
+/// `choose folder` dialog → seçilen klasörün path'i.
 pub async fn choose_folder() -> Option<std::path::PathBuf> {
-    task::spawn_blocking(|| {
-        let out = Command::new("osascript")
+    task::spawn_blocking(choose_folder_blocking)
+        .await
+        .ok()
+        .flatten()
+}
+
+#[cfg(target_os = "macos")]
+fn choose_folder_blocking() -> Option<std::path::PathBuf> {
+    let out = Command::new("osascript")
+        .args([
+            "-e",
+            r#"POSIX path of (choose folder with prompt "İndirme klasörünü seçin")"#,
+        ])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let path = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    if path.is_empty() {
+        None
+    } else {
+        Some(std::path::PathBuf::from(path))
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn choose_folder_blocking() -> Option<std::path::PathBuf> {
+    if have("zenity") {
+        let out = Command::new("zenity")
             .args([
-                "-e",
-                r#"POSIX path of (choose folder with prompt "İndirme klasörünü seçin")"#,
+                "--file-selection",
+                "--directory",
+                "--title=İndirme klasörünü seçin",
+            ])
+            .stderr(Stdio::null())
+            .output()
+            .ok()?;
+        if !out.status.success() {
+            return None;
+        }
+        let path = String::from_utf8_lossy(&out.stdout).trim().to_string();
+        if path.is_empty() {
+            None
+        } else {
+            Some(std::path::PathBuf::from(path))
+        }
+    } else if have("kdialog") {
+        let out = Command::new("kdialog")
+            .args([
+                "--title",
+                "İndirme klasörünü seçin",
+                "--getexistingdirectory",
+                ".",
             ])
             .output()
             .ok()?;
@@ -159,10 +465,9 @@ pub async fn choose_folder() -> Option<std::path::PathBuf> {
         } else {
             Some(std::path::PathBuf::from(path))
         }
-    })
-    .await
-    .ok()
-    .flatten()
+    } else {
+        None
+    }
 }
 
 /// Listeden cihaz seçim dialog'u. `labels` içindeki etiket indeks'i döner.
@@ -171,40 +476,116 @@ pub async fn choose_device(labels: Vec<String>) -> Option<usize> {
         return None;
     }
     let labels_clone = labels.clone();
-    let selected = task::spawn_blocking(move || {
-        let items = labels_clone
-            .iter()
-            .map(|s| format!("\"{}\"", escape_applescript(s)))
-            .collect::<Vec<_>>()
-            .join(", ");
-        let script = format!(
-            r#"choose from list {{{}}} with prompt "Hedef cihaz" with title "HekaDrop" default items {{"{}"}}"#,
-            items,
-            escape_applescript(&labels_clone[0])
-        );
-        let out = Command::new("osascript").args(["-e", &script]).output().ok()?;
-        let result = String::from_utf8_lossy(&out.stdout).trim().to_string();
-        if result == "false" || result.is_empty() {
-            return None;
-        }
-        Some(result)
-    })
-    .await
-    .ok()
-    .flatten()?;
-
+    let selected = task::spawn_blocking(move || choose_device_blocking(&labels_clone))
+        .await
+        .ok()
+        .flatten()?;
     labels.iter().position(|l| *l == selected)
 }
 
+#[cfg(target_os = "macos")]
+fn choose_device_blocking(labels: &[String]) -> Option<String> {
+    let items = labels
+        .iter()
+        .map(|s| format!("\"{}\"", escape_applescript(s)))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let script = format!(
+        r#"choose from list {{{}}} with prompt "Hedef cihaz" with title "HekaDrop" default items {{"{}"}}"#,
+        items,
+        escape_applescript(&labels[0])
+    );
+    let out = Command::new("osascript")
+        .args(["-e", &script])
+        .output()
+        .ok()?;
+    let result = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    if result == "false" || result.is_empty() {
+        return None;
+    }
+    Some(result)
+}
+
+#[cfg(not(target_os = "macos"))]
+fn choose_device_blocking(labels: &[String]) -> Option<String> {
+    if have("zenity") {
+        // zenity --list --radiolist: her satır [TRUE/FALSE, label]
+        let mut args: Vec<String> = vec![
+            "--list".into(),
+            "--radiolist".into(),
+            "--title=HekaDrop".into(),
+            "--text=Hedef cihaz".into(),
+            "--column=".into(),
+            "--column=Cihaz".into(),
+            "--width=480".into(),
+            "--height=360".into(),
+        ];
+        for (i, l) in labels.iter().enumerate() {
+            args.push(if i == 0 {
+                "TRUE".into()
+            } else {
+                "FALSE".into()
+            });
+            args.push(l.clone());
+        }
+        let out = Command::new("zenity")
+            .args(&args)
+            .stderr(Stdio::null())
+            .output()
+            .ok()?;
+        if !out.status.success() {
+            return None;
+        }
+        let result = String::from_utf8_lossy(&out.stdout).trim().to_string();
+        if result.is_empty() {
+            None
+        } else {
+            Some(result)
+        }
+    } else if have("kdialog") {
+        let mut args: Vec<String> = vec![
+            "--title".into(),
+            "HekaDrop".into(),
+            "--radiolist".into(),
+            "Hedef cihaz".into(),
+        ];
+        for (i, l) in labels.iter().enumerate() {
+            args.push(format!("{}", i));
+            args.push(l.clone());
+            args.push(if i == 0 { "on".into() } else { "off".into() });
+        }
+        let out = Command::new("kdialog").args(&args).output().ok()?;
+        if !out.status.success() {
+            return None;
+        }
+        let idx_str = String::from_utf8_lossy(&out.stdout).trim().to_string();
+        let idx: usize = idx_str.parse().ok()?;
+        labels.get(idx).cloned()
+    } else {
+        None
+    }
+}
+
 /// Dosya keşif sırasında basit bir ilerleme/bildirim dialog'u olmadığı için
-/// notify kullanıyoruz. Dönüş: kullanıcı iptal ederse false, gönderim başladıysa true.
+/// notify kullanıyoruz.
 #[allow(dead_code)]
 pub fn send_progress_notify(device: &str, file: &str) {
     notify("HekaDrop", &format!("Gönderiliyor: {} → {}", file, device));
 }
 
+#[cfg(target_os = "macos")]
 fn escape_applescript(s: &str) -> String {
     s.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+#[cfg(not(target_os = "macos"))]
+fn have(bin: &str) -> bool {
+    Command::new("sh")
+        .arg("-c")
+        .arg(format!("command -v {} >/dev/null 2>&1", bin))
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
 }
 
 fn human_size(bytes: i64) -> String {


### PR DESCRIPTION
## Özet
HekaDrop'u macOS'tan Linux'a port eder. Çekirdek protokol (UKEY2, AES-256-CBC, mDNS, P-256 ECDH) değişmedi; UI / path / autostart katmanları `cfg`-gated hale getirildi.

## Öne çıkanlar
- `src/platform.rs` — cross-platform abstraction (XDG yolları, device name, open/reveal/clipboard)
- Linux UI: GTK3 + WebKit2GTK (wry `build_gtk`) + AppIndicator tray
- Dialog: zenity (fallback kdialog)
- Bildirim: `notify-rust` aksiyon butonlarıyla ("Aç" / "Klasörde göster")
- Otomatik başlatma: systemd `--user` unit (launchd karşılığı)
- Sabit TCP port **47893** (`HEKADROP_PORT` env override) — firewall kurallarını kolaylaştırır
- mDNS filtresi: Docker / virbr / tailscale / veth / vnet / tun / tap / wg arayüzleri yayın dışı
- Paketleme: `.desktop`, `install-linux.sh` (user/system), `make-deb.sh` (cargo-deb), Makefile hedefleri
- CI: paralel `test-linux` job (ubuntu-latest), `.deb` artifact

## Commit'ler
1. `feat: Linux portu — platform abstraction + UI + systemd + fixed port`
2. `build: Linux paketleme (desktop/icon/deb) + CI ubuntu-latest job`
3. `docs: Linux portu README + CHANGELOG girişleri`

## Test planı
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — 0 uyarı
- [x] `cargo test --all` — 132/132 geçti
- [x] `cargo build --release` — OK
- [x] Lokal smoke test: Android'den dosya alım başarılı (192.168.1.x LAN, sabit port 47893)
- [ ] CI ubuntu-latest ilk run (PR açıldıktan sonra doğrulanır)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
