### PR TITLE
feat: Windows portu — native Win32 API + WinRT Toast

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,3 +117,44 @@ jobs:
             HekaDrop-*.deb
           if-no-files-found: ignore
           retention-days: 7
+
+  test-windows:
+    name: Test + Build (Windows)
+    runs-on: windows-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Cargo cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install protoc
+        # windows-latest'te chocolatey önceden kurulu; protoc yaygın paket.
+        run: choco install protoc -y --no-progress
+
+      - name: Format check
+        run: cargo fmt --all -- --check
+
+      - name: Clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings
+
+      - name: Test
+        run: cargo test --all
+
+      - name: Build (release)
+        run: cargo build --release
+
+      - name: Upload .exe artifact
+        uses: actions/upload-artifact@v5
+        with:
+          name: HekaDrop-exe-windows
+          path: target/release/hekadrop.exe
+          if-no-files-found: error
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@
 
 # Çalışma zamanı logları
 *.log
+
+# Üretilen paket artefaktları (kaynakta yok; make-deb.sh çıktıları)
+/HekaDrop-*.deb
+/HekaDrop-*.dmg

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1404,6 +1404,7 @@ dependencies = [
  "tracing-appender",
  "tracing-subscriber",
  "tray-icon",
+ "windows 0.58.0",
  "wry",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1404,7 +1404,7 @@ dependencies = [
  "tracing-appender",
  "tracing-subscriber",
  "tray-icon",
- "windows 0.58.0",
+ "windows 0.60.0",
  "wry",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,9 @@ notify-rust = "4"
 # Türkçe karakterleri bozuyor), Registry autostart, ShellExecute, MessageBox,
 # SHGetKnownFolderPath, GetComputerNameExW gibi native operasyonlar için
 # external process spawn etmekten daha hızlı ve doğru.
-windows = { version = "0.58", features = [
+# Versiyon wry/webview2-com ile uyumlu olsun (iki farklı windows-core sürümü
+# trait implementasyonlarında çakışıyor); wry 0.50 şu anda 0.60 kullanıyor.
+windows = { version = "0.60", features = [
     "Win32_Foundation",
     "Win32_System_Com",
     "Win32_System_DataExchange",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,27 @@ elliptic-curve = { version = "0.13", features = ["sec1"] }
 # Aksiyon butonlu (Aç / Klasörde göster) D-Bus bildirimleri için.
 notify-rust = "4"
 
+[target.'cfg(target_os = "windows")'.dependencies]
+# Windows Toast bildirimleri (aksiyon destekli — WinRT backend).
+notify-rust = "4"
+
+# Microsoft'un resmi Win32/WinRT binding'i. Feature-gated compile — sadece
+# kullandığımız API'ler binary'e girer. Clipboard (UTF-16 doğruluğu, `clip.exe`
+# Türkçe karakterleri bozuyor), Registry autostart, ShellExecute, MessageBox,
+# SHGetKnownFolderPath, GetComputerNameExW gibi native operasyonlar için
+# external process spawn etmekten daha hızlı ve doğru.
+windows = { version = "0.58", features = [
+    "Win32_Foundation",
+    "Win32_System_Com",
+    "Win32_System_DataExchange",
+    "Win32_System_Memory",
+    "Win32_System_Registry",
+    "Win32_System_SystemInformation",
+    "Win32_UI_Shell",
+    "Win32_UI_Shell_Common",
+    "Win32_UI_WindowsAndMessaging",
+] }
+
 [build-dependencies]
 prost-build = "0.13"
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -967,14 +967,149 @@ fn toggle_login_item() {
     );
 }
 
-/// macOS/Linux dışındaki platformlarda (ör. Windows) otomatik başlatma henüz
-/// uygulanmadı; UI'yi kırmayacak şekilde stub bildirim gösterilir.
-#[cfg(all(not(target_os = "macos"), not(target_os = "linux")))]
+/// macOS / Linux / Windows dışındaki platformlar için stub.
+#[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
 fn toggle_login_item() {
     ui::show_info(
         "HekaDrop — otomatik başlatma",
         "Bu platformda otomatik başlatma henüz desteklenmiyor.",
     );
+}
+
+/// Windows: `HKCU\Software\Microsoft\Windows\CurrentVersion\Run` Registry
+/// anahtarına "HekaDrop" değerini yazar ya da kaldırır. Binary yolu
+/// `current_exe()` ile alınır (tırnak içine alınarak; Program Files gibi
+/// boşluklu yollara dayanıklı).
+#[cfg(target_os = "windows")]
+fn toggle_login_item() {
+    use windows::core::PCWSTR;
+    use windows::Win32::Foundation::ERROR_SUCCESS;
+    use windows::Win32::System::Registry::{
+        RegCloseKey, RegDeleteValueW, RegOpenKeyExW, RegQueryValueExW, RegSetValueExW, HKEY,
+        HKEY_CURRENT_USER, KEY_READ, KEY_WRITE, REG_SZ,
+    };
+
+    fn to_wide(s: &str) -> Vec<u16> {
+        let mut v: Vec<u16> = s.encode_utf16().collect();
+        v.push(0);
+        v
+    }
+
+    const SUBKEY: &str = r"Software\Microsoft\Windows\CurrentVersion\Run";
+    const VALUE: &str = "HekaDrop";
+
+    let subkey_w = to_wide(SUBKEY);
+    let value_w = to_wide(VALUE);
+
+    // Mevcut durumu yokla (varsa sil → toggle off).
+    let mut hkey = HKEY::default();
+    let exists = unsafe {
+        let rc = RegOpenKeyExW(
+            HKEY_CURRENT_USER,
+            PCWSTR(subkey_w.as_ptr()),
+            0,
+            KEY_READ,
+            &mut hkey,
+        );
+        if rc != ERROR_SUCCESS {
+            false
+        } else {
+            let mut size: u32 = 0;
+            let q = RegQueryValueExW(
+                hkey,
+                PCWSTR(value_w.as_ptr()),
+                None,
+                None,
+                None,
+                Some(&mut size),
+            );
+            let _ = RegCloseKey(hkey);
+            q == ERROR_SUCCESS
+        }
+    };
+
+    if exists {
+        let mut hkey = HKEY::default();
+        unsafe {
+            let rc = RegOpenKeyExW(
+                HKEY_CURRENT_USER,
+                PCWSTR(subkey_w.as_ptr()),
+                0,
+                KEY_WRITE,
+                &mut hkey,
+            );
+            if rc == ERROR_SUCCESS {
+                let _ = RegDeleteValueW(hkey, PCWSTR(value_w.as_ptr()));
+                let _ = RegCloseKey(hkey);
+                ui::notify(
+                    "HekaDrop",
+                    "Otomatik başlatma kapatıldı (Registry Run anahtarı kaldırıldı)",
+                );
+                return;
+            }
+        }
+        ui::show_info(
+            "HekaDrop",
+            "Registry anahtarına yazma hakkı yok (HKCU normalde açık olur).",
+        );
+        return;
+    }
+
+    // Yoksa ekle — current_exe path'ini tırnak içine al.
+    let exe = match std::env::current_exe() {
+        Ok(p) => p,
+        Err(e) => {
+            ui::show_info(
+                "HekaDrop — otomatik başlatma",
+                &format!("current_exe alınamadı: {}", e),
+            );
+            return;
+        }
+    };
+    let cmdline = format!("\"{}\"", exe.display());
+    let cmdline_w = to_wide(&cmdline);
+    // REG_SZ: byte uzunluğu (null dahil).
+    let byte_len = cmdline_w.len() * std::mem::size_of::<u16>();
+
+    unsafe {
+        let mut hkey = HKEY::default();
+        let rc = RegOpenKeyExW(
+            HKEY_CURRENT_USER,
+            PCWSTR(subkey_w.as_ptr()),
+            0,
+            KEY_WRITE,
+            &mut hkey,
+        );
+        if rc != ERROR_SUCCESS {
+            ui::show_info(
+                "HekaDrop",
+                &format!("Registry Run anahtarı açılamadı (err={:?})", rc),
+            );
+            return;
+        }
+        let set_rc = RegSetValueExW(
+            hkey,
+            PCWSTR(value_w.as_ptr()),
+            0,
+            REG_SZ,
+            Some(std::slice::from_raw_parts(
+                cmdline_w.as_ptr() as *const u8,
+                byte_len,
+            )),
+        );
+        let _ = RegCloseKey(hkey);
+        if set_rc == ERROR_SUCCESS {
+            ui::notify(
+                "HekaDrop",
+                "Otomatik başlatma açıldı (Registry Run anahtarı yazıldı)",
+            );
+        } else {
+            ui::show_info(
+                "HekaDrop",
+                &format!("Registry değeri yazılamadı (err={:?})", set_rc),
+            );
+        }
+    }
 }
 
 /// Linux: systemd --user tabanlı otomatik başlatma.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1007,7 +1007,7 @@ fn toggle_login_item() {
         let rc = RegOpenKeyExW(
             HKEY_CURRENT_USER,
             PCWSTR(subkey_w.as_ptr()),
-            0,
+            None,
             KEY_READ,
             &mut hkey,
         );
@@ -1034,7 +1034,7 @@ fn toggle_login_item() {
             let rc = RegOpenKeyExW(
                 HKEY_CURRENT_USER,
                 PCWSTR(subkey_w.as_ptr()),
-                0,
+                None,
                 KEY_WRITE,
                 &mut hkey,
             );
@@ -1076,7 +1076,7 @@ fn toggle_login_item() {
         let rc = RegOpenKeyExW(
             HKEY_CURRENT_USER,
             PCWSTR(subkey_w.as_ptr()),
-            0,
+            None,
             KEY_WRITE,
             &mut hkey,
         );
@@ -1090,7 +1090,7 @@ fn toggle_login_item() {
         let set_rc = RegSetValueExW(
             hkey,
             PCWSTR(value_w.as_ptr()),
-            0,
+            None,
             REG_SZ,
             Some(std::slice::from_raw_parts(
                 cmdline_w.as_ptr() as *const u8,

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -431,9 +431,13 @@ mod win {
         unsafe {
             let mut size: u32 = 256;
             let mut buf = vec![0u16; size as usize];
-            // windows-rs 0.60: PWSTR doğrudan geçilir (Option değil).
-            if GetComputerNameExW(ComputerNameDnsHostname, PWSTR(buf.as_mut_ptr()), &mut size)
-                .is_err()
+            // windows-rs 0.60: lpbuffer `Option<PWSTR>` (NULL desteği için).
+            if GetComputerNameExW(
+                ComputerNameDnsHostname,
+                Some(PWSTR(buf.as_mut_ptr())),
+                &mut size,
+            )
+            .is_err()
             {
                 return None;
             }
@@ -516,8 +520,8 @@ mod win {
             // Clipboard sahipliğini al (owner HWND = None, process-wide).
             OpenClipboard(None)?;
             let _ = EmptyClipboard();
-            // windows-rs 0.60 Param<HANDLE> — HANDLE doğrudan geçilir, Option DEĞİL.
-            let result = SetClipboardData(CF_UNICODETEXT, HANDLE(hmem.0 as _));
+            // windows-rs 0.60: hmem `Option<HANDLE>` (NULL = clear format data).
+            let result = SetClipboardData(CF_UNICODETEXT, Some(HANDLE(hmem.0 as _)));
             let _ = CloseClipboard();
             result.map(|_| ())
         }

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -325,11 +325,9 @@ pub fn open_url(url: &str) {
 pub fn copy_to_clipboard(text: &str) {
     #[cfg(target_os = "windows")]
     {
-        if win::clipboard_set(text).is_ok() {
-            return;
+        if win::clipboard_set(text).is_err() {
+            tracing::warn!("panoya kopyalama başarısız — Win32 SetClipboardData hata döndü");
         }
-        tracing::warn!("panoya kopyalama başarısız — Win32 SetClipboardData hata döndü");
-        return;
     }
 
     #[cfg(not(target_os = "windows"))]

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -2,36 +2,58 @@
 //! dosya/URL açma, panoya kopyalama, otomatik başlatma.
 //!
 //! Bu modül tek giriş noktasıdır; çağıranlar (`settings`, `stats`, `main`,
-//! `connection`, `ui`) platforma göre ayrım yapmaz. Linux portu yeni target'lar
-//! eklerken sadece burası genişletilir.
+//! `connection`, `ui`) platforma göre ayrım yapmaz. Yeni target'lar (Linux,
+//! Windows) eklerken sadece burası genişletilir.
+//!
+//! Windows implementasyonu `windows-rs` binding'ini kullanır; external
+//! process spawn (cmd/explorer/clip) yerine native Win32 API'lerine
+//! doğrudan çağrı yapar — bu sayede UTF-16 doğruluğu, düşük gecikme ve
+//! temiz hata yolları sağlanır.
 
 use std::path::{Path, PathBuf};
+#[cfg(not(target_os = "windows"))]
 use std::process::Command;
 
-/// `$HOME` değerini al; tanımlı değilse `/tmp` fallback (macOS/Linux'ta
-/// pratikte gerçekleşmez ama daemon/systemd ortamlarında tekil bir senaryo
-/// olabilir — panic yerine degraded mode'a düşmek daha sağlıklı).
+/// Kullanıcı home dizini.
+///
+/// - macOS / Linux: `$HOME` (tanımsızsa `/tmp` fallback)
+/// - Windows: `%USERPROFILE%` (tanımsızsa `C:\Users\Default` fallback)
+#[cfg(not(target_os = "windows"))]
 fn home_dir() -> PathBuf {
     std::env::var_os("HOME")
         .map(PathBuf::from)
         .unwrap_or_else(|| PathBuf::from("/tmp"))
 }
 
+#[cfg(target_os = "windows")]
+fn home_dir() -> PathBuf {
+    win::known_folder(&windows::Win32::UI::Shell::FOLDERID_Profile)
+        .or_else(|| std::env::var_os("USERPROFILE").map(PathBuf::from))
+        .unwrap_or_else(|| PathBuf::from(r"C:\Users\Default"))
+}
+
 /// Uygulamanın kalıcı ayar dizini.
 ///
 /// - macOS: `~/Library/Application Support/HekaDrop`
 /// - Linux: `$XDG_CONFIG_HOME/HekaDrop` → `~/.config/HekaDrop`
+/// - Windows: `FOLDERID_RoamingAppData\HekaDrop` (genelde `%APPDATA%\HekaDrop`)
 pub fn config_dir() -> PathBuf {
     #[cfg(target_os = "macos")]
     {
         home_dir().join("Library/Application Support/HekaDrop")
     }
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(target_os = "linux")]
     {
         if let Some(xdg) = std::env::var_os("XDG_CONFIG_HOME").filter(|v| !v.is_empty()) {
             return PathBuf::from(xdg).join("HekaDrop");
         }
         home_dir().join(".config/HekaDrop")
+    }
+    #[cfg(target_os = "windows")]
+    {
+        win::known_folder(&windows::Win32::UI::Shell::FOLDERID_RoamingAppData)
+            .map(|p| p.join("HekaDrop"))
+            .unwrap_or_else(|| home_dir().join(r"AppData\Roaming\HekaDrop"))
     }
 }
 
@@ -39,25 +61,35 @@ pub fn config_dir() -> PathBuf {
 ///
 /// - macOS: `~/Library/Logs/HekaDrop`
 /// - Linux: `$XDG_STATE_HOME/HekaDrop/logs` → `~/.local/state/HekaDrop/logs`
+/// - Windows: `FOLDERID_LocalAppData\HekaDrop\logs` — log'lar roam etmesin.
 pub fn logs_dir() -> PathBuf {
     #[cfg(target_os = "macos")]
     {
         home_dir().join("Library/Logs/HekaDrop")
     }
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(target_os = "linux")]
     {
         if let Some(xdg) = std::env::var_os("XDG_STATE_HOME").filter(|v| !v.is_empty()) {
             return PathBuf::from(xdg).join("HekaDrop/logs");
         }
         home_dir().join(".local/state/HekaDrop/logs")
     }
+    #[cfg(target_os = "windows")]
+    {
+        win::known_folder(&windows::Win32::UI::Shell::FOLDERID_LocalAppData)
+            .map(|p| p.join(r"HekaDrop\logs"))
+            .unwrap_or_else(|| home_dir().join(r"AppData\Local\HekaDrop\logs"))
+    }
 }
 
 /// Varsayılan indirme klasörü.
 ///
-/// Linux'ta önce `xdg-user-dir DOWNLOAD` denenir; başarısızsa `~/Downloads`.
+/// - Linux: `xdg-user-dir DOWNLOAD` → fallback `$HOME/Downloads`
+/// - macOS: `$HOME/Downloads`
+/// - Windows: `FOLDERID_Downloads` (kullanıcının özel konuma taşımış olması
+///   durumunda da doğru yolu döner)
 pub fn default_download_dir() -> PathBuf {
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(target_os = "linux")]
     {
         if let Ok(out) = Command::new("xdg-user-dir").arg("DOWNLOAD").output() {
             if out.status.success() {
@@ -70,13 +102,21 @@ pub fn default_download_dir() -> PathBuf {
             }
         }
     }
+    #[cfg(target_os = "windows")]
+    {
+        if let Some(p) = win::known_folder(&windows::Win32::UI::Shell::FOLDERID_Downloads) {
+            return p;
+        }
+    }
     home_dir().join("Downloads")
 }
 
 /// mDNS / UI için gösterilecek cihaz adı.
 ///
 /// - macOS: `scutil --get ComputerName`
-/// - Linux: `hostname` / `/etc/hostname` → fallback "HekaDrop Linux"
+/// - Linux: `/etc/hostname` → `hostname` komutu → fallback "HekaDrop Linux"
+/// - Windows: `GetComputerNameExW(ComputerNameDnsHostname)` → fallback
+///   `%COMPUTERNAME%` → "HekaDrop PC"
 pub fn device_name() -> String {
     if let Ok(v) = std::env::var("HEKADROP_NAME") {
         if !v.is_empty() {
@@ -100,7 +140,7 @@ pub fn device_name() -> String {
         "HekaDrop Mac".to_string()
     }
 
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(target_os = "linux")]
     {
         if let Ok(h) = std::fs::read_to_string("/etc/hostname") {
             let t = h.trim();
@@ -118,24 +158,45 @@ pub fn device_name() -> String {
         }
         "HekaDrop Linux".to_string()
     }
+
+    #[cfg(target_os = "windows")]
+    {
+        if let Some(name) = win::computer_name() {
+            return format!("HekaDrop {}", name);
+        }
+        if let Ok(v) = std::env::var("COMPUTERNAME") {
+            let t = v.trim();
+            if !t.is_empty() {
+                return format!("HekaDrop {}", t);
+            }
+        }
+        "HekaDrop PC".to_string()
+    }
 }
 
 /// Verilen dosyayı/dizini işletim sisteminin varsayılan programıyla açar.
 pub fn open_path(path: &Path) {
     #[cfg(target_os = "macos")]
-    let tool = "open";
-    #[cfg(not(target_os = "macos"))]
-    let tool = "xdg-open";
-    let _ = Command::new(tool).arg(path).spawn();
+    {
+        let _ = Command::new("open").arg(path).spawn();
+    }
+    #[cfg(target_os = "linux")]
+    {
+        let _ = Command::new("xdg-open").arg(path).spawn();
+    }
+    #[cfg(target_os = "windows")]
+    {
+        win::shell_execute_open(path.as_os_str());
+    }
 }
 
-/// Dosyayı dosya yöneticisinde (Finder / Nautilus) seçili olarak gösterir.
+/// Dosyayı dosya yöneticisinde (Finder / Nautilus / Explorer) seçili olarak gösterir.
 pub fn reveal_path(path: &Path) {
     #[cfg(target_os = "macos")]
     {
         let _ = Command::new("open").arg("-R").arg(path).spawn();
     }
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(target_os = "linux")]
     {
         // D-Bus FileManager1 çoğu Linux DE'de mevcut; başarısızsa parent dizini açarız.
         // RFC 3986: file:// URI'sinde boşluk / `#` / `?` / `%` / non-ASCII vb.
@@ -159,6 +220,16 @@ pub fn reveal_path(path: &Path) {
         let parent = path.parent().unwrap_or(path);
         let _ = Command::new("xdg-open").arg(parent).spawn();
     }
+    #[cfg(target_os = "windows")]
+    {
+        // `SHOpenFolderAndSelectItems` native API — dosyayı içeren klasörü
+        // açar ve dosyayı seçili hale getirir. Başarısızsa parent dizini
+        // ShellExecute ile aç.
+        if win::select_in_explorer(path).is_err() {
+            let parent = path.parent().unwrap_or(path);
+            win::shell_execute_open(parent.as_os_str());
+        }
+    }
 }
 
 /// Bir dosya yolunu `file://` URI'sine çevirir (RFC 3986 percent-encoding).
@@ -167,7 +238,7 @@ pub fn reveal_path(path: &Path) {
 /// ve path ayırıcı `/`. Diğer her şey — boşluk, `#`, `?`, `%`, Türkçe karakter
 /// vb. — `%XX` olarak kodlanır. Bayt seviyesinde çalışır; UTF-8 sequence'ları
 /// doğru biçimde kodlanır.
-#[cfg(not(target_os = "macos"))]
+#[cfg(target_os = "linux")]
 fn path_to_file_uri(path: &Path) -> String {
     let bytes = path.as_os_str().as_encoded_bytes();
     let mut out = String::from("file://");
@@ -184,7 +255,7 @@ fn path_to_file_uri(path: &Path) -> String {
     out
 }
 
-#[cfg(all(test, not(target_os = "macos")))]
+#[cfg(all(test, target_os = "linux"))]
 mod tests {
     use super::*;
 
@@ -232,46 +303,231 @@ mod tests {
 /// URL'i tarayıcıda açar.
 pub fn open_url(url: &str) {
     #[cfg(target_os = "macos")]
-    let tool = "open";
-    #[cfg(not(target_os = "macos"))]
-    let tool = "xdg-open";
-    let _ = Command::new(tool).arg(url).spawn();
+    {
+        let _ = Command::new("open").arg(url).spawn();
+    }
+    #[cfg(target_os = "linux")]
+    {
+        let _ = Command::new("xdg-open").arg(url).spawn();
+    }
+    #[cfg(target_os = "windows")]
+    {
+        win::shell_execute_open(std::ffi::OsStr::new(url));
+    }
 }
 
 /// Metni sistem panosuna kopyalar.
 ///
-/// Linux'ta Wayland (wl-copy) ve X11 (xclip/xsel) sırayla denenir.
+/// - macOS: `pbcopy`
+/// - Linux: Wayland (`wl-copy`) → X11 (`xclip` → `xsel`) sırayla
+/// - Windows: `OpenClipboard` + `SetClipboardData(CF_UNICODETEXT)` — UTF-16 LE,
+///   `clip.exe`'nin ANSI-yorumu yüzünden Türkçe/non-ASCII bozulmasın
 pub fn copy_to_clipboard(text: &str) {
-    use std::io::Write;
-    use std::process::Stdio;
-
-    #[cfg(target_os = "macos")]
-    let candidates: &[&[&str]] = &[&["pbcopy"]];
-    #[cfg(not(target_os = "macos"))]
-    let candidates: &[&[&str]] = &[
-        &["wl-copy"],
-        &["xclip", "-selection", "clipboard"],
-        &["xsel", "--clipboard", "--input"],
-    ];
-
-    for args in candidates {
-        let mut cmd = Command::new(args[0]);
-        if args.len() > 1 {
-            cmd.args(&args[1..]);
+    #[cfg(target_os = "windows")]
+    {
+        if win::clipboard_set(text).is_ok() {
+            return;
         }
-        let child = cmd.stdin(Stdio::piped()).stderr(Stdio::null()).spawn();
-        if let Ok(mut c) = child {
-            if let Some(stdin) = c.stdin.as_mut() {
-                let _ = stdin.write_all(text.as_bytes());
+        tracing::warn!("panoya kopyalama başarısız — Win32 SetClipboardData hata döndü");
+        return;
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        use std::io::Write;
+        use std::process::Stdio;
+
+        #[cfg(target_os = "macos")]
+        let candidates: &[&[&str]] = &[&["pbcopy"]];
+        #[cfg(target_os = "linux")]
+        let candidates: &[&[&str]] = &[
+            &["wl-copy"],
+            &["xclip", "-selection", "clipboard"],
+            &["xsel", "--clipboard", "--input"],
+        ];
+
+        for args in candidates {
+            let mut cmd = Command::new(args[0]);
+            if args.len() > 1 {
+                cmd.args(&args[1..]);
             }
-            if let Ok(status) = c.wait() {
-                if status.success() {
-                    return;
+            let child = cmd.stdin(Stdio::piped()).stderr(Stdio::null()).spawn();
+            if let Ok(mut c) = child {
+                if let Some(stdin) = c.stdin.as_mut() {
+                    let _ = stdin.write_all(text.as_bytes());
+                }
+                if let Ok(status) = c.wait() {
+                    if status.success() {
+                        return;
+                    }
+                }
+            }
+        }
+        tracing::warn!(
+            "panoya kopyalama başarısız — yardımcı araç (wl-copy/xclip/xsel/pbcopy) bulunamadı"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Windows helpers (windows-rs ile native API)
+// ---------------------------------------------------------------------------
+#[cfg(target_os = "windows")]
+mod win {
+    use super::*;
+    use windows::core::{Result, GUID, PCWSTR, PWSTR};
+    use windows::Win32::Foundation::{HANDLE, HWND};
+    use windows::Win32::System::Com::{
+        CoInitializeEx, CoTaskMemFree, COINIT_APARTMENTTHREADED, COINIT_DISABLE_OLE1DDE,
+    };
+    use windows::Win32::System::DataExchange::{
+        CloseClipboard, EmptyClipboard, OpenClipboard, SetClipboardData,
+    };
+    use windows::Win32::System::Memory::{GlobalAlloc, GlobalLock, GlobalUnlock, GMEM_MOVEABLE};
+    use windows::Win32::System::SystemInformation::{ComputerNameDnsHostname, GetComputerNameExW};
+    use windows::Win32::UI::Shell::{
+        ILCreateFromPathW, ILFree, SHGetKnownFolderPath, SHOpenFolderAndSelectItems, ShellExecuteW,
+        KF_FLAG_DEFAULT,
+    };
+    use windows::Win32::UI::WindowsAndMessaging::SW_SHOWNORMAL;
+
+    /// UTF-16 LE null-terminated vektör üretir.
+    fn to_wide(s: &str) -> Vec<u16> {
+        let mut v: Vec<u16> = s.encode_utf16().collect();
+        v.push(0);
+        v
+    }
+
+    fn to_wide_os(s: &std::ffi::OsStr) -> Vec<u16> {
+        use std::os::windows::ffi::OsStrExt;
+        let mut v: Vec<u16> = s.encode_wide().collect();
+        v.push(0);
+        v
+    }
+
+    /// `SHGetKnownFolderPath` → PathBuf. Çıktı bellek `CoTaskMemFree` ile serbest
+    /// bırakılır (aksi halde leak). Bellek tahsisi başarısızsa `None`.
+    pub(super) fn known_folder(folder: &GUID) -> Option<PathBuf> {
+        unsafe {
+            let pwstr: PWSTR = SHGetKnownFolderPath(folder, KF_FLAG_DEFAULT.0 as u32, None).ok()?;
+            if pwstr.is_null() {
+                return None;
+            }
+            // PWSTR → &[u16] → OsString
+            let len = (0..).take_while(|&i| *pwstr.0.add(i) != 0).count();
+            let slice = std::slice::from_raw_parts(pwstr.0, len);
+            let os = {
+                use std::os::windows::ffi::OsStringExt;
+                std::ffi::OsString::from_wide(slice)
+            };
+            CoTaskMemFree(Some(pwstr.0 as _));
+            Some(PathBuf::from(os))
+        }
+    }
+
+    /// Bilgisayar DNS hostname'i. Başarısızsa `None`.
+    pub(super) fn computer_name() -> Option<String> {
+        unsafe {
+            let mut size: u32 = 256;
+            let mut buf = vec![0u16; size as usize];
+            // GetComputerNameExW: size parametresi buffer kapasitesi + null için.
+            let ok = GetComputerNameExW(
+                ComputerNameDnsHostname,
+                Some(PWSTR(buf.as_mut_ptr())),
+                &mut size,
+            );
+            if ok.is_err() {
+                return None;
+            }
+            buf.truncate(size as usize);
+            let os = {
+                use std::os::windows::ffi::OsStringExt;
+                std::ffi::OsString::from_wide(&buf)
+            };
+            os.into_string().ok()
+        }
+    }
+
+    /// COM'u apartment-threaded modda başlatır (idempotent). Hata değeri
+    /// `S_FALSE`/`RPC_E_CHANGED_MODE` yoksayılabilir — zaten init edilmiş demek.
+    fn ensure_com_init() {
+        unsafe {
+            let _ = CoInitializeEx(None, COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE);
+        }
+    }
+
+    /// `ShellExecuteW` ile "open" verb'ü çağır. URL / dosya / klasör hepsi kabul.
+    pub(super) fn shell_execute_open(target: &std::ffi::OsStr) {
+        let wide = to_wide_os(target);
+        let verb = to_wide("open");
+        unsafe {
+            let _ = ShellExecuteW(
+                HWND::default(),
+                PCWSTR(verb.as_ptr()),
+                PCWSTR(wide.as_ptr()),
+                PCWSTR::null(),
+                PCWSTR::null(),
+                SW_SHOWNORMAL,
+            );
+        }
+    }
+
+    /// Dosya Explorer'da seçili olarak açılır — `SHOpenFolderAndSelectItems`.
+    /// PIDL'ı `ILCreateFromPathW` ile alır, kullanım sonrası `ILFree` ile
+    /// serbest bırakır. COM init gereklidir.
+    pub(super) fn select_in_explorer(path: &Path) -> Result<()> {
+        ensure_com_init();
+        let wide = to_wide_os(path.as_os_str());
+        unsafe {
+            let pidl = ILCreateFromPathW(PCWSTR(wide.as_ptr()));
+            if pidl.is_null() {
+                return Err(windows::core::Error::from_win32());
+            }
+            let result = SHOpenFolderAndSelectItems(pidl, None, 0);
+            ILFree(Some(pidl));
+            result
+        }
+    }
+
+    /// Clipboard'a UTF-16 metin koyar. Standart pattern:
+    /// OpenClipboard → EmptyClipboard → GlobalAlloc+Lock → copy → Unlock →
+    /// SetClipboardData(CF_UNICODETEXT) → CloseClipboard. Hatada kaynakları
+    /// serbest bırakır.
+    pub(super) fn clipboard_set(text: &str) -> Result<()> {
+        const CF_UNICODETEXT: u32 = 13;
+        let wide = to_wide(text);
+        let bytes = wide.len() * std::mem::size_of::<u16>();
+
+        unsafe {
+            let hmem = GlobalAlloc(GMEM_MOVEABLE, bytes)?;
+            if hmem.0.is_null() {
+                return Err(windows::core::Error::from_win32());
+            }
+
+            let dst = GlobalLock(hmem) as *mut u16;
+            if dst.is_null() {
+                return Err(windows::core::Error::from_win32());
+            }
+            std::ptr::copy_nonoverlapping(wide.as_ptr(), dst, wide.len());
+            let _ = GlobalUnlock(hmem);
+
+            // Clipboard sahipliğini (owner HWND = null, process-wide) al.
+            OpenClipboard(HWND::default())?;
+            let _ = EmptyClipboard();
+            // SetClipboardData başarılıysa clipboard hafızanın sahibi olur —
+            // biz artık free ETMEMELİYİZ.
+            match SetClipboardData(CF_UNICODETEXT, Some(HANDLE(hmem.0 as _))) {
+                Ok(_) => {
+                    let _ = CloseClipboard();
+                    Ok(())
+                }
+                Err(e) => {
+                    let _ = CloseClipboard();
+                    // Sahip olunamadı; belleği geri al.
+                    let _ = windows::Win32::System::Memory::GlobalFree(hmem);
+                    Err(e)
                 }
             }
         }
     }
-    tracing::warn!(
-        "panoya kopyalama başarısız — yardımcı araç (wl-copy/xclip/xsel/pbcopy) bulunamadı"
-    );
 }

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -432,12 +432,8 @@ mod win {
             let mut size: u32 = 256;
             let mut buf = vec![0u16; size as usize];
             // windows-rs 0.60: PWSTR doğrudan geçilir (Option değil).
-            if GetComputerNameExW(
-                ComputerNameDnsHostname,
-                PWSTR(buf.as_mut_ptr()),
-                &mut size,
-            )
-            .is_err()
+            if GetComputerNameExW(ComputerNameDnsHostname, PWSTR(buf.as_mut_ptr()), &mut size)
+                .is_err()
             {
                 return None;
             }

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -409,7 +409,8 @@ mod win {
     /// bırakılır (aksi halde leak). Bellek tahsisi başarısızsa `None`.
     pub(super) fn known_folder(folder: &GUID) -> Option<PathBuf> {
         unsafe {
-            let pwstr: PWSTR = SHGetKnownFolderPath(folder, KF_FLAG_DEFAULT.0 as u32, None).ok()?;
+            // windows-rs 0.60: flag enum doğrudan geçilir (eski sürümlerde u32).
+            let pwstr: PWSTR = SHGetKnownFolderPath(folder, KF_FLAG_DEFAULT, None).ok()?;
             if pwstr.is_null() {
                 return None;
             }
@@ -430,13 +431,14 @@ mod win {
         unsafe {
             let mut size: u32 = 256;
             let mut buf = vec![0u16; size as usize];
-            // GetComputerNameExW: size parametresi buffer kapasitesi + null için.
-            let ok = GetComputerNameExW(
+            // windows-rs 0.60: PWSTR doğrudan geçilir (Option değil).
+            if GetComputerNameExW(
                 ComputerNameDnsHostname,
-                Some(PWSTR(buf.as_mut_ptr())),
+                PWSTR(buf.as_mut_ptr()),
                 &mut size,
-            );
-            if ok.is_err() {
+            )
+            .is_err()
+            {
                 return None;
             }
             buf.truncate(size as usize);
@@ -462,7 +464,7 @@ mod win {
         let verb = to_wide("open");
         unsafe {
             let _ = ShellExecuteW(
-                HWND::default(),
+                Some(HWND::default()),
                 PCWSTR(verb.as_ptr()),
                 PCWSTR(wide.as_ptr()),
                 PCWSTR::null(),
@@ -491,8 +493,12 @@ mod win {
 
     /// Clipboard'a UTF-16 metin koyar. Standart pattern:
     /// OpenClipboard → EmptyClipboard → GlobalAlloc+Lock → copy → Unlock →
-    /// SetClipboardData(CF_UNICODETEXT) → CloseClipboard. Hatada kaynakları
-    /// serbest bırakır.
+    /// SetClipboardData(CF_UNICODETEXT) → CloseClipboard.
+    ///
+    /// SetClipboardData başarılı olduğunda hafızanın sahipliği clipboard'a
+    /// geçer; biz free etmemeliyiz. Hata yolunda pragmatik olarak hafıza
+    /// leak'i kabul edilir (windows-rs 0.60'ta `GlobalFree` feature'ı bu
+    /// modülde sağlanmıyor; her hata ~ metin boyutu kadar küçük).
     pub(super) fn clipboard_set(text: &str) -> Result<()> {
         const CF_UNICODETEXT: u32 = 13;
         let wide = to_wide(text);
@@ -511,23 +517,13 @@ mod win {
             std::ptr::copy_nonoverlapping(wide.as_ptr(), dst, wide.len());
             let _ = GlobalUnlock(hmem);
 
-            // Clipboard sahipliğini (owner HWND = null, process-wide) al.
-            OpenClipboard(HWND::default())?;
+            // Clipboard sahipliğini al (owner HWND = None, process-wide).
+            OpenClipboard(None)?;
             let _ = EmptyClipboard();
-            // SetClipboardData başarılıysa clipboard hafızanın sahibi olur —
-            // biz artık free ETMEMELİYİZ.
-            match SetClipboardData(CF_UNICODETEXT, Some(HANDLE(hmem.0 as _))) {
-                Ok(_) => {
-                    let _ = CloseClipboard();
-                    Ok(())
-                }
-                Err(e) => {
-                    let _ = CloseClipboard();
-                    // Sahip olunamadı; belleği geri al.
-                    let _ = windows::Win32::System::Memory::GlobalFree(hmem);
-                    Err(e)
-                }
-            }
+            // windows-rs 0.60 Param<HANDLE> — HANDLE doğrudan geçilir, Option DEĞİL.
+            let result = SetClipboardData(CF_UNICODETEXT, HANDLE(hmem.0 as _));
+            let _ = CloseClipboard();
+            result.map(|_| ())
         }
     }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -254,53 +254,61 @@ pub fn notify_file_received(title: &str, body: &str, path: std::path::PathBuf) {
         // destekler; modern Windows 10+ toast stili gösterir.
         let title = title.to_string();
         let body = body.to_string();
+        #[cfg(target_os = "linux")]
         let spawned = std::thread::Builder::new()
             .name("hekadrop-notify".into())
             .spawn(move || {
                 use notify_rust::Notification;
-                let handle = Notification::new()
+                let handle = match Notification::new()
                     .appname("HekaDrop")
                     .summary(&title)
                     .body(&body)
                     .action("default", "Aç")
                     .action("reveal", "Klasörde göster")
                     .timeout(10_000)
-                    .show();
-                let handle = match handle {
+                    .show()
+                {
                     Ok(h) => h,
                     Err(e) => {
                         tracing::warn!("notify-rust gösterim hatası: {}", e);
-                        #[cfg(target_os = "linux")]
-                        {
-                            // Linux: notify-send aksiyonsuz ama en azından görünsün.
-                            let _ = std::process::Command::new("notify-send")
-                                .args(["--app-name=HekaDrop", &title, &body])
-                                .status();
-                        }
+                        // Linux: notify-send aksiyonsuz ama en azından görünsün.
+                        let _ = std::process::Command::new("notify-send")
+                            .args(["--app-name=HekaDrop", &title, &body])
+                            .status();
                         return;
                     }
                 };
-                // `wait_for_action` hem Linux hem Windows'ta aynı API.
-                #[cfg(target_os = "linux")]
                 handle.wait_for_action(|action| match action {
                     "default" => crate::platform::open_path(&path),
                     "reveal" => crate::platform::reveal_path(&path),
                     _ => {}
                 });
-                // Windows'ta action handler'ları farklı API ile bağlanır
-                // (wait_for_action Linux-özel). Toast otomatik kapanır.
-                #[cfg(target_os = "windows")]
+            });
+
+        // Windows: notify-rust WinRT backend `show()` unit döner; `wait_for_action`
+        // Linux-özel. Toast otomatik kapanır. Action callback (Aç/Reveal
+        // tıklama) ileride COM ile bağlanacak — şimdilik toast görünür,
+        // tıklanınca HekaDrop'a bir şey iletmez.
+        #[cfg(target_os = "windows")]
+        let spawned = std::thread::Builder::new()
+            .name("hekadrop-notify".into())
+            .spawn(move || {
+                let _ = &path; // ileride callback için korunuyor
+                use notify_rust::Notification;
+                if let Err(e) = Notification::new()
+                    .appname("HekaDrop")
+                    .summary(&title)
+                    .body(&body)
+                    .action("default", "Aç")
+                    .action("reveal", "Klasörde göster")
+                    .timeout(10_000)
+                    .show()
                 {
-                    // path closure'a move ile geldi ama şimdilik Windows
-                    // branch'inde toast callback bağlanmadığı için kullanılmıyor.
-                    // Unused-variable warning'ini bastır.
-                    let _ = &path;
-                    let _ = handle;
+                    tracing::warn!("notify-rust gösterim hatası: {}", e);
                 }
             });
+
         if let Err(e) = spawned {
-            // title/body closure'a taşındı; fallback için kullanamayız. Thread
-            // spawn'ı sistemsel bir hata — sadece warn ve geç.
             tracing::warn!("bildirim thread'i başlatılamadı: {}", e);
         }
     }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -138,7 +138,7 @@ fn prompt_accept_blocking(
 
     let result = unsafe {
         MessageBoxW(
-            HWND::default(),
+            Some(HWND::default()),
             PCWSTR(msg_w.as_ptr()),
             PCWSTR(title_w.as_ptr()),
             MB_YESNOCANCEL | MB_ICONINFORMATION | MB_SYSTEMMODAL,

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,17 +1,17 @@
 //! Kullanıcı arayüzü yardımcıları — cross-platform dialog ve bildirimler.
 //!
-//! macOS'ta `osascript` (AppKit dialog'u), Linux'ta `zenity` tercih edilir.
-//! Zenity yoksa `kdialog`'a düşer; ikisi de yoksa stderr'e log bırakıp kalıcı
-//! başarısızlık yerine "Reject/None" döner — böylece uygulama headless
-//! ortamda bile çökmez.
+//! - macOS: `osascript` (AppKit dialog)
+//! - Linux: `zenity` (yoksa `kdialog`)
+//! - Windows: native `MessageBoxW` / `windows-rs`, file/folder dialog'u için
+//!   PowerShell (`System.Windows.Forms`) fallback
 //!
-//! tray-icon / objc2 yerine external process tercih edildi çünkü tokio
-//! runtime ile sürtünmesi az, tek komutla native dialog açar.
+//! Dialog aracı yoksa veya headless ortamsa `Reject`/`None` döner; uygulama
+//! çökmek yerine güvenli default davranışa geçer.
 
 use anyhow::Result;
 #[cfg(target_os = "macos")]
 use std::process::Command;
-#[cfg(not(target_os = "macos"))]
+#[cfg(any(target_os = "linux", target_os = "windows"))]
 use std::process::{Command, Stdio};
 use tokio::task;
 
@@ -97,7 +97,62 @@ fn prompt_accept_blocking(
     }
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(target_os = "windows")]
+fn prompt_accept_blocking(
+    device: &str,
+    pin: &str,
+    files: &[(String, i64)],
+    text_count: usize,
+) -> AcceptResult {
+    // Windows MessageBoxW ile 3 seçenekli dialog:
+    //   Evet  = Kabul + güven   (MB_YESNOCANCEL → IDYES)
+    //   Hayır = Kabul            (→ IDNO)
+    //   İptal = Reddet           (→ IDCANCEL)
+    //
+    // Not: Sistem dilini takip eden buton etiketleri "Evet/Hayır/İptal"
+    // olur. Mesaj metninde kullanıcıya hangi butonun ne anlama geldiği
+    // açıkça yazılır.
+    use windows::core::PCWSTR;
+    use windows::Win32::Foundation::HWND;
+    use windows::Win32::UI::WindowsAndMessaging::{
+        MessageBoxW, IDCANCEL, IDNO, IDYES, MB_ICONINFORMATION, MB_SYSTEMMODAL, MB_YESNOCANCEL,
+    };
+
+    fn to_wide(s: &str) -> Vec<u16> {
+        let mut v: Vec<u16> = s.encode_utf16().collect();
+        v.push(0);
+        v
+    }
+
+    let files_str = format_payload_lines(files, text_count);
+    let message = format!(
+        "{} cihazından dosya gönderiliyor.\n\nPIN: {}\n\n{}\n\n\
+         Evet  = Kabul et + güven listesine ekle\n\
+         Hayır = Sadece bu seferlik kabul et\n\
+         İptal = Reddet",
+        device, pin, files_str
+    );
+    let title = "HekaDrop";
+    let msg_w = to_wide(&message);
+    let title_w = to_wide(title);
+
+    let result = unsafe {
+        MessageBoxW(
+            HWND::default(),
+            PCWSTR(msg_w.as_ptr()),
+            PCWSTR(title_w.as_ptr()),
+            MB_YESNOCANCEL | MB_ICONINFORMATION | MB_SYSTEMMODAL,
+        )
+    };
+    match result {
+        r if r == IDYES => AcceptResult::AcceptAndTrust,
+        r if r == IDNO => AcceptResult::Accept,
+        r if r == IDCANCEL => AcceptResult::Reject,
+        _ => AcceptResult::Reject,
+    }
+}
+
+#[cfg(target_os = "linux")]
 fn prompt_accept_blocking(
     device: &str,
     pin: &str,
@@ -180,21 +235,23 @@ fn prompt_accept_blocking(
 /// macOS'ta aksiyon butonu desteklenmez — düz bildirim + tıklanınca Finder'da
 /// açma için fallback uygulanır (bkz. `NotificationCenter` gelecek iş).
 pub fn notify_file_received(title: &str, body: &str, path: std::path::PathBuf) {
-    #[cfg(not(target_os = "linux"))]
+    #[cfg(target_os = "macos")]
     {
-        let _ = path; // macOS/Windows: şimdilik plain notify.
+        let _ = path; // macOS'ta aksiyon butonlu notify henüz yok.
         notify(title, body);
     }
 
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "windows"))]
     {
         // notify-rust blocking API'si var; ayrı thread'de başlatıp dialog
         // kapanana kadar bekletiyoruz. Fire-and-forget — tokio runtime'ı
         // bloklamaz.
         //
-        // `default` aksiyonu freedesktop spec'inde bildirim gövdesine
-        // tıklayınca tetiklenir (buton göstermez); "Klasörde göster" tek
-        // ek buton olarak kalır — aksi halde iki "Aç" butonu duplike görünür.
+        // Linux (freedesktop): `default` aksiyonu body tıklamasına, `reveal`
+        // ek butona bağlanır (duplicate "Aç" butonu oluşmasın diye tek buton).
+        //
+        // Windows (WinRT Toast): notify-rust WinRT backend action butonlarını
+        // destekler; modern Windows 10+ toast stili gösterir.
         let title = title.to_string();
         let body = body.to_string();
         let spawned = std::thread::Builder::new()
@@ -213,22 +270,29 @@ pub fn notify_file_received(title: &str, body: &str, path: std::path::PathBuf) {
                     Ok(h) => h,
                     Err(e) => {
                         tracing::warn!("notify-rust gösterim hatası: {}", e);
-                        // notify-send fallback'i — aksiyonsuz ama en azından görünsün.
-                        let _ = std::process::Command::new("notify-send")
-                            .args(["--app-name=HekaDrop", &title, &body])
-                            .status();
+                        #[cfg(target_os = "linux")]
+                        {
+                            // Linux: notify-send aksiyonsuz ama en azından görünsün.
+                            let _ = std::process::Command::new("notify-send")
+                                .args(["--app-name=HekaDrop", &title, &body])
+                                .status();
+                        }
                         return;
                     }
                 };
+                // `wait_for_action` hem Linux hem Windows'ta aynı API.
+                #[cfg(target_os = "linux")]
                 handle.wait_for_action(|action| match action {
-                    "default" => {
-                        crate::platform::open_path(&path);
-                    }
-                    "reveal" => {
-                        crate::platform::reveal_path(&path);
-                    }
+                    "default" => crate::platform::open_path(&path),
+                    "reveal" => crate::platform::reveal_path(&path),
                     _ => {}
                 });
+                // Windows'ta action handler'ları farklı API ile bağlanır
+                // (wait_for_action Linux-özel). Toast otomatik kapanır.
+                #[cfg(target_os = "windows")]
+                {
+                    let _ = handle;
+                }
             });
         if let Err(e) = spawned {
             // title/body closure'a taşındı; fallback için kullanamayız. Thread
@@ -249,7 +313,7 @@ pub fn notify(title: &str, body: &str) {
         );
         let _ = Command::new("osascript").arg("-e").arg(&script).spawn();
     }
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(target_os = "linux")]
     {
         // notify-send en yaygın; yoksa sessizce log'a yaz.
         let spawned = Command::new("notify-send")
@@ -258,6 +322,20 @@ pub fn notify(title: &str, body: &str) {
             .spawn();
         if spawned.is_err() {
             tracing::info!("[notify] {}: {}", title, body);
+        }
+    }
+    #[cfg(target_os = "windows")]
+    {
+        // Windows Toast — notify-rust'ın WinRT backend'i. Win 10+'da çalışır.
+        use notify_rust::Notification;
+        let r = Notification::new()
+            .appname("HekaDrop")
+            .summary(title)
+            .body(body)
+            .timeout(7_000)
+            .show();
+        if let Err(e) = r {
+            tracing::info!("[notify-toast hata] {}: {} ({})", title, body, e);
         }
     }
 }
@@ -273,7 +351,7 @@ pub fn show_info(title: &str, body: &str) {
         );
         let _ = Command::new("osascript").arg("-e").arg(&script).spawn();
     }
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(target_os = "linux")]
     {
         if have("zenity") {
             let _ = Command::new("zenity")
@@ -293,6 +371,36 @@ pub fn show_info(title: &str, body: &str) {
             // Dialog yoksa en azından bir masaüstü bildirimi gönder.
             notify(title, body);
         }
+    }
+    #[cfg(target_os = "windows")]
+    {
+        // MessageBoxW blocks; fire-and-forget için ayrı thread'de çalıştır.
+        let title = title.to_string();
+        let body = body.to_string();
+        let _ = std::thread::Builder::new()
+            .name("hekadrop-showinfo".into())
+            .spawn(move || {
+                use windows::core::PCWSTR;
+                use windows::Win32::Foundation::HWND;
+                use windows::Win32::UI::WindowsAndMessaging::{
+                    MessageBoxW, MB_ICONINFORMATION, MB_OK, MB_SYSTEMMODAL,
+                };
+                fn to_wide(s: &str) -> Vec<u16> {
+                    let mut v: Vec<u16> = s.encode_utf16().collect();
+                    v.push(0);
+                    v
+                }
+                let body_w = to_wide(&body);
+                let title_w = to_wide(&title);
+                unsafe {
+                    MessageBoxW(
+                        HWND::default(),
+                        PCWSTR(body_w.as_ptr()),
+                        PCWSTR(title_w.as_ptr()),
+                        MB_OK | MB_ICONINFORMATION | MB_SYSTEMMODAL,
+                    );
+                }
+            });
     }
 }
 
@@ -341,7 +449,48 @@ pathList
     }
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(target_os = "windows")]
+fn choose_files_blocking() -> Option<Vec<std::path::PathBuf>> {
+    // PowerShell + System.Windows.Forms.OpenFileDialog — cargo-install'suz,
+    // her Windows 10/11'de hazır gelir. Multi-select, ardından path'leri
+    // satır satır yazdırır. Hata durumunda None.
+    let script = r#"
+Add-Type -AssemblyName System.Windows.Forms | Out-Null
+$dlg = New-Object System.Windows.Forms.OpenFileDialog
+$dlg.Title = 'Gönderilecek dosyaları seçin'
+$dlg.Multiselect = $true
+if ($dlg.ShowDialog() -eq 'OK') { $dlg.FileNames -join "`n" }
+"#;
+    let out = Command::new("powershell")
+        .args([
+            "-NoProfile",
+            "-NonInteractive",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-Command",
+            script,
+        ])
+        .stderr(Stdio::null())
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let text = String::from_utf8_lossy(&out.stdout);
+    let paths: Vec<_> = text
+        .lines()
+        .map(|l| l.trim())
+        .filter(|l| !l.is_empty())
+        .map(std::path::PathBuf::from)
+        .collect();
+    if paths.is_empty() {
+        None
+    } else {
+        Some(paths)
+    }
+}
+
+#[cfg(target_os = "linux")]
 fn choose_files_blocking() -> Option<Vec<std::path::PathBuf>> {
     if have("zenity") {
         let out = Command::new("zenity")
@@ -430,7 +579,39 @@ fn choose_folder_blocking() -> Option<std::path::PathBuf> {
     }
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(target_os = "windows")]
+fn choose_folder_blocking() -> Option<std::path::PathBuf> {
+    let script = r#"
+Add-Type -AssemblyName System.Windows.Forms | Out-Null
+$dlg = New-Object System.Windows.Forms.FolderBrowserDialog
+$dlg.Description = 'İndirme klasörünü seçin'
+$dlg.ShowNewFolderButton = $true
+if ($dlg.ShowDialog() -eq 'OK') { $dlg.SelectedPath }
+"#;
+    let out = Command::new("powershell")
+        .args([
+            "-NoProfile",
+            "-NonInteractive",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-Command",
+            script,
+        ])
+        .stderr(Stdio::null())
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let path = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    if path.is_empty() {
+        None
+    } else {
+        Some(std::path::PathBuf::from(path))
+    }
+}
+
+#[cfg(target_os = "linux")]
 fn choose_folder_blocking() -> Option<std::path::PathBuf> {
     if have("zenity") {
         let out = Command::new("zenity")
@@ -511,7 +692,75 @@ fn choose_device_blocking(labels: &[String]) -> Option<String> {
     Some(result)
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(target_os = "windows")]
+fn choose_device_blocking(labels: &[String]) -> Option<String> {
+    // PowerShell ile minimal ListBox dialog'u. `Out-GridView -PassThru` de
+    // kullanılabilirdi ama standart PowerShell'da ayrı modül gerekir;
+    // System.Windows.Forms her kurulumda hazır.
+    let items = labels
+        .iter()
+        .map(|s| format!("'{}'", s.replace('\'', "''")))
+        .collect::<Vec<_>>()
+        .join(",");
+    let script = format!(
+        r#"
+Add-Type -AssemblyName System.Windows.Forms | Out-Null
+Add-Type -AssemblyName System.Drawing | Out-Null
+$form = New-Object System.Windows.Forms.Form
+$form.Text = 'HekaDrop'
+$form.Size = New-Object System.Drawing.Size(480, 360)
+$form.StartPosition = 'CenterScreen'
+$form.TopMost = $true
+$label = New-Object System.Windows.Forms.Label
+$label.Text = 'Hedef cihaz'
+$label.Location = New-Object System.Drawing.Point(10, 10)
+$label.Size = New-Object System.Drawing.Size(440, 20)
+$form.Controls.Add($label)
+$listbox = New-Object System.Windows.Forms.ListBox
+$listbox.Location = New-Object System.Drawing.Point(10, 35)
+$listbox.Size = New-Object System.Drawing.Size(440, 230)
+@({items}) | ForEach-Object {{ [void]$listbox.Items.Add($_) }}
+if ($listbox.Items.Count -gt 0) {{ $listbox.SelectedIndex = 0 }}
+$form.Controls.Add($listbox)
+$ok = New-Object System.Windows.Forms.Button
+$ok.Text = 'Gönder'
+$ok.Location = New-Object System.Drawing.Point(280, 280)
+$ok.DialogResult = 'OK'
+$form.AcceptButton = $ok
+$form.Controls.Add($ok)
+$cancel = New-Object System.Windows.Forms.Button
+$cancel.Text = 'İptal'
+$cancel.Location = New-Object System.Drawing.Point(370, 280)
+$cancel.DialogResult = 'Cancel'
+$form.CancelButton = $cancel
+$form.Controls.Add($cancel)
+if ($form.ShowDialog() -eq 'OK') {{ $listbox.SelectedItem }}
+"#
+    );
+    let out = Command::new("powershell")
+        .args([
+            "-NoProfile",
+            "-NonInteractive",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-Command",
+            &script,
+        ])
+        .stderr(Stdio::null())
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let result = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    if result.is_empty() {
+        None
+    } else {
+        Some(result)
+    }
+}
+
+#[cfg(target_os = "linux")]
 fn choose_device_blocking(labels: &[String]) -> Option<String> {
     if have("zenity") {
         // zenity --list --radiolist: her satır [TRUE/FALSE, label]
@@ -583,7 +832,9 @@ fn escape_applescript(s: &str) -> String {
     s.replace('\\', "\\\\").replace('"', "\\\"")
 }
 
-#[cfg(not(target_os = "macos"))]
+/// Bir ikili (binary) PATH'te mevcut mu? Linux-only helper (zenity/kdialog
+/// varlık kontrolü). Windows'ta kullanılmaz — MessageBoxW her zaman var.
+#[cfg(target_os = "linux")]
 fn have(bin: &str) -> bool {
     Command::new("sh")
         .arg("-c")

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -291,6 +291,10 @@ pub fn notify_file_received(title: &str, body: &str, path: std::path::PathBuf) {
                 // (wait_for_action Linux-özel). Toast otomatik kapanır.
                 #[cfg(target_os = "windows")]
                 {
+                    // path closure'a move ile geldi ama şimdilik Windows
+                    // branch'inde toast callback bağlanmadığı için kullanılmıyor.
+                    // Unused-variable warning'ini bastır.
+                    let _ = &path;
                     let _ = handle;
                 }
             });
@@ -394,7 +398,7 @@ pub fn show_info(title: &str, body: &str) {
                 let title_w = to_wide(&title);
                 unsafe {
                     MessageBoxW(
-                        HWND::default(),
+                        Some(HWND::default()),
                         PCWSTR(body_w.as_ptr()),
                         PCWSTR(title_w.as_ptr()),
                         MB_OK | MB_ICONINFORMATION | MB_SYSTEMMODAL,


### PR DESCRIPTION
## Özet
Windows portu — platform abstraction'a native Win32 + WinRT dalı. Çekirdek Quick Share protokolü değişmedi.

## Yaklaşım
External process spawn (`cmd /c start`, `explorer /select`, `clip.exe`) yerine `windows-rs` ile native API çağrıları. Sebep:
- **UTF-16 doğruluğu**: `clip.exe` ANSI sayar, Türkçe/non-ASCII bozulur. `SetClipboardData(CF_UNICODETEXT)` doğru.
- **Düşük gecikme**: Process spawn cold start ~200-500ms; native API <10ms.
- **Temiz hata yolları**: `HRESULT` ile strüktürlü; shell komutunun stdin/stderr kapanması değil.

## Yeni dosya/değişiklik
- `src/platform.rs` — yeni `mod win` native helpers (SHGetKnownFolderPath, GetComputerNameExW, ShellExecuteW, SHOpenFolderAndSelectItems, OpenClipboard/SetClipboardData)
- `src/main.rs` — `toggle_login_item` Windows: `HKCU\...\Run` Registry
- `src/ui.rs` — Windows `MessageBoxW` PIN dialog, PowerShell file/folder picker, `notify-rust` WinRT toast
- `Cargo.toml` — `windows` 0.58 feature-gated; `notify-rust` Windows-target eklendi
- `.github/workflows/ci.yml` — `test-windows` job (windows-latest)

## Test planı
- [x] Linux build + clippy + 137 test geçiyor (Windows dalı cfg-out, Linux'u etkilemez)
- [ ] CI **test-windows** job'u — ilk gerçek Windows derleme (PR açıldıktan sonra)
- [ ] macOS CI — regresyonsuz kalmalı
- [ ] Gerçek Windows cihazda manuel smoke test (Android'den alım) — PR merge sonrası

## Bilinen eksikler / sonraki PR'lar
- MSIX / winget paketleme yok (ilk release için `.exe` artifact yeterli)
- `choose_device_blocking` Windows'ta PowerShell spawn ediyor; yüksek sıklıkta çağrılmıyor ama native `ListBox` dialog ileride `windows-rs` ile yazılabilir
- Windows toast action callback'leri henüz bağlanmadı (notify-rust `wait_for_action` Windows'ta mevcut değil; toast tıklama ileride COM ile)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
