### PR TITLE
fix(windows): review fixes (PR #4 sonrası)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -39,10 +39,10 @@ pub const DEVICE_TYPE_COMPUTER: u8 = 3;
 
 /// EndpointInfo yapısı — TXT record `n=` değerinin base64'ten öncesi.
 /// Yerleşim:
-///   [0]      bitmap: (sürüm<<5)|(görünürlük<<4)|(cihaz_tipi<<1)|rez
-///   [1..17]  16 bayt rastgele
-///   [17]     ad uzunluğu (u8)
-///   [18..]   UTF-8 cihaz adı
+///   `[0]`      bitmap: (sürüm<<5)|(görünürlük<<4)|(cihaz_tipi<<1)|rez
+///   `[1..17]`  16 bayt rastgele
+///   `[17]`     ad uzunluğu (u8)
+///   `[18..]`   UTF-8 cihaz adı
 pub fn endpoint_info(device_name: &str) -> Vec<u8> {
     let mut out = Vec::with_capacity(18 + device_name.len());
     out.push(DEVICE_TYPE_COMPUTER << 1);

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,17 +32,38 @@ mod ukey2;
 
 static RUNTIME: OnceLock<Handle> = OnceLock::new();
 
-#[allow(clippy::all, non_snake_case, non_camel_case_types, dead_code)]
+#[allow(
+    clippy::all,
+    non_snake_case,
+    non_camel_case_types,
+    dead_code,
+    rustdoc::invalid_html_tags,
+    rustdoc::broken_intra_doc_links
+)]
 pub mod securegcm {
     include!(concat!(env!("OUT_DIR"), "/securegcm.rs"));
 }
 
-#[allow(clippy::all, non_snake_case, non_camel_case_types, dead_code)]
+#[allow(
+    clippy::all,
+    non_snake_case,
+    non_camel_case_types,
+    dead_code,
+    rustdoc::invalid_html_tags,
+    rustdoc::broken_intra_doc_links
+)]
 pub mod securemessage {
     include!(concat!(env!("OUT_DIR"), "/securemessage.rs"));
 }
 
-#[allow(clippy::all, non_snake_case, non_camel_case_types, dead_code)]
+#[allow(
+    clippy::all,
+    non_snake_case,
+    non_camel_case_types,
+    dead_code,
+    rustdoc::invalid_html_tags,
+    rustdoc::broken_intra_doc_links
+)]
 pub mod location {
     pub mod nearby {
         pub mod connections {
@@ -59,7 +80,14 @@ pub mod location {
     }
 }
 
-#[allow(clippy::all, non_snake_case, non_camel_case_types, dead_code)]
+#[allow(
+    clippy::all,
+    non_snake_case,
+    non_camel_case_types,
+    dead_code,
+    rustdoc::invalid_html_tags,
+    rustdoc::broken_intra_doc_links
+)]
 pub mod sharing {
     pub mod nearby {
         include!(concat!(env!("OUT_DIR"), "/sharing.nearby.rs"));

--- a/src/main.rs
+++ b/src/main.rs
@@ -982,18 +982,14 @@ fn toggle_login_item() {
 /// boşluklu yollara dayanıklı).
 #[cfg(target_os = "windows")]
 fn toggle_login_item() {
+    use crate::platform::win::to_wide;
+    use std::os::windows::ffi::OsStrExt;
     use windows::core::PCWSTR;
     use windows::Win32::Foundation::ERROR_SUCCESS;
     use windows::Win32::System::Registry::{
         RegCloseKey, RegDeleteValueW, RegOpenKeyExW, RegQueryValueExW, RegSetValueExW, HKEY,
         HKEY_CURRENT_USER, KEY_READ, KEY_WRITE, REG_SZ,
     };
-
-    fn to_wide(s: &str) -> Vec<u16> {
-        let mut v: Vec<u16> = s.encode_utf16().collect();
-        v.push(0);
-        v
-    }
 
     const SUBKEY: &str = r"Software\Microsoft\Windows\CurrentVersion\Run";
     const VALUE: &str = "HekaDrop";
@@ -1039,12 +1035,19 @@ fn toggle_login_item() {
                 &mut hkey,
             );
             if rc == ERROR_SUCCESS {
-                let _ = RegDeleteValueW(hkey, PCWSTR(value_w.as_ptr()));
+                let del_rc = RegDeleteValueW(hkey, PCWSTR(value_w.as_ptr()));
                 let _ = RegCloseKey(hkey);
-                ui::notify(
-                    "HekaDrop",
-                    "Otomatik başlatma kapatıldı (Registry Run anahtarı kaldırıldı)",
-                );
+                if del_rc == ERROR_SUCCESS {
+                    ui::notify(
+                        "HekaDrop",
+                        "Otomatik başlatma kapatıldı (Registry Run anahtarı kaldırıldı)",
+                    );
+                } else {
+                    ui::show_info(
+                        "HekaDrop",
+                        &format!("Registry değeri silinemedi (err={:?})", del_rc),
+                    );
+                }
                 return;
             }
         }
@@ -1056,6 +1059,8 @@ fn toggle_login_item() {
     }
 
     // Yoksa ekle — current_exe path'ini tırnak içine al.
+    // path.display() UTF-8 olmayan byte'ları lossy dönüştürebilir; OsStr'in
+    // wide encoding'ini kullanarak lossless UTF-16 üretiyoruz.
     let exe = match std::env::current_exe() {
         Ok(p) => p,
         Err(e) => {
@@ -1066,8 +1071,11 @@ fn toggle_login_item() {
             return;
         }
     };
-    let cmdline = format!("\"{}\"", exe.display());
-    let cmdline_w = to_wide(&cmdline);
+    let mut cmdline_w: Vec<u16> = Vec::with_capacity(exe.as_os_str().len() + 3);
+    cmdline_w.push(b'"' as u16);
+    cmdline_w.extend(exe.as_os_str().encode_wide());
+    cmdline_w.push(b'"' as u16);
+    cmdline_w.push(0);
     // REG_SZ: byte uzunluğu (null dahil).
     let byte_len = cmdline_w.len() * std::mem::size_of::<u16>();
 

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -375,16 +375,14 @@ pub(crate) mod win {
     use super::*;
     use std::cell::Cell;
     use windows::core::{Result, GUID, PCWSTR, PWSTR};
-    use windows::Win32::Foundation::HANDLE;
+    use windows::Win32::Foundation::{GlobalFree, HANDLE};
     use windows::Win32::System::Com::{
         CoInitializeEx, CoTaskMemFree, COINIT_APARTMENTTHREADED, COINIT_DISABLE_OLE1DDE,
     };
     use windows::Win32::System::DataExchange::{
         CloseClipboard, EmptyClipboard, OpenClipboard, SetClipboardData,
     };
-    use windows::Win32::System::Memory::{
-        GlobalAlloc, GlobalFree, GlobalLock, GlobalUnlock, GMEM_MOVEABLE,
-    };
+    use windows::Win32::System::Memory::{GlobalAlloc, GlobalLock, GlobalUnlock, GMEM_MOVEABLE};
     use windows::Win32::System::SystemInformation::{ComputerNameDnsHostname, GetComputerNameExW};
     use windows::Win32::UI::Shell::{
         ILCreateFromPathW, ILFree, SHGetKnownFolderPath, SHOpenFolderAndSelectItems, ShellExecuteW,

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -462,18 +462,29 @@ pub(crate) mod win {
     }
 
     /// COM'u apartment-threaded modda thread başına bir kez başlatır.
-    /// Hata değeri (`S_FALSE`/`RPC_E_CHANGED_MODE`) zaten init edilmiş anlamına
-    /// gelir — sessizce geçeriz. Process yaşam süresi boyunca init kalır;
-    /// `CoUninitialize` çağırmayız (uygulama kapanışında OS temizler).
+    ///
+    /// `S_OK` (ilk init) veya `S_FALSE` (zaten init) veya `RPC_E_CHANGED_MODE`
+    /// (başka modda init) kabul edilir; OOM vb. gerçek hata durumlarında
+    /// `COM_INITED` flag `true` yapılmaz, sonraki çağrı retry eder.
+    /// Process yaşam süresi boyunca init kalır; `CoUninitialize` çağırmayız
+    /// (uygulama kapanışında OS temizler).
     fn ensure_com_init() {
         COM_INITED.with(|flag| {
             if flag.get() {
                 return;
             }
-            unsafe {
-                let _ = CoInitializeEx(None, COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE);
+            let hr =
+                unsafe { CoInitializeEx(None, COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE) };
+            // windows-rs `HRESULT` → `ok()` S_OK/S_FALSE'ı tamam sayar,
+            // gerçek hataları `Err` olarak geri verir. RPC_E_CHANGED_MODE da
+            // kabul: COM zaten farklı modda init — bizim için OK.
+            const RPC_E_CHANGED_MODE: windows::core::HRESULT =
+                windows::core::HRESULT(0x80010106u32 as i32);
+            if hr.is_ok() || hr == RPC_E_CHANGED_MODE {
+                flag.set(true);
+            } else {
+                tracing::warn!("CoInitializeEx başarısız: {:?}", hr);
             }
-            flag.set(true);
         });
     }
 
@@ -519,6 +530,10 @@ pub(crate) mod win {
     /// biz free ETMEYİZ. Her hata yolunda `GlobalFree` ile kaynak serbest
     /// bırakılır; `OpenClipboard` başarısız olursa da alloc'u temizleriz.
     pub(super) fn clipboard_set(text: &str) -> Result<()> {
+        // `CF_UNICODETEXT = 13` — Windows clipboard formatı, MSDN'de stabil
+        // dokümante. windows-rs 0.60'ta `Win32::System::Ole` modülünde ama
+        // `Win32_System_Ole` feature ağır; bu tek sabit için dep bloat'ına
+        // değmez. Hardcoded sabit korunur.
         const CF_UNICODETEXT: u32 = 13;
         let wide = to_wide(text);
         let bytes = wide.len() * std::mem::size_of::<u16>();
@@ -543,7 +558,13 @@ pub(crate) mod win {
                 let _ = GlobalFree(Some(hmem));
                 return Err(e);
             }
-            let _ = EmptyClipboard();
+            // EmptyClipboard hata yoluyla SetClipboardData da bozulur;
+            // failure olursa kaynakları temiz bırak.
+            if let Err(e) = EmptyClipboard() {
+                let _ = CloseClipboard();
+                let _ = GlobalFree(Some(hmem));
+                return Err(e);
+            }
             // windows-rs 0.60: hmem `Option<HANDLE>` (NULL = clear format data).
             match SetClipboardData(CF_UNICODETEXT, Some(HANDLE(hmem.0 as _))) {
                 Ok(_) => {

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -371,17 +371,20 @@ pub fn copy_to_clipboard(text: &str) {
 // Windows helpers (windows-rs ile native API)
 // ---------------------------------------------------------------------------
 #[cfg(target_os = "windows")]
-mod win {
+pub(crate) mod win {
     use super::*;
+    use std::cell::Cell;
     use windows::core::{Result, GUID, PCWSTR, PWSTR};
-    use windows::Win32::Foundation::{HANDLE, HWND};
+    use windows::Win32::Foundation::HANDLE;
     use windows::Win32::System::Com::{
         CoInitializeEx, CoTaskMemFree, COINIT_APARTMENTTHREADED, COINIT_DISABLE_OLE1DDE,
     };
     use windows::Win32::System::DataExchange::{
         CloseClipboard, EmptyClipboard, OpenClipboard, SetClipboardData,
     };
-    use windows::Win32::System::Memory::{GlobalAlloc, GlobalLock, GlobalUnlock, GMEM_MOVEABLE};
+    use windows::Win32::System::Memory::{
+        GlobalAlloc, GlobalFree, GlobalLock, GlobalUnlock, GMEM_MOVEABLE,
+    };
     use windows::Win32::System::SystemInformation::{ComputerNameDnsHostname, GetComputerNameExW};
     use windows::Win32::UI::Shell::{
         ILCreateFromPathW, ILFree, SHGetKnownFolderPath, SHOpenFolderAndSelectItems, ShellExecuteW,
@@ -390,12 +393,15 @@ mod win {
     use windows::Win32::UI::WindowsAndMessaging::SW_SHOWNORMAL;
 
     /// UTF-16 LE null-terminated vektör üretir.
-    fn to_wide(s: &str) -> Vec<u16> {
+    /// `pub(crate)` — ui.rs (MessageBoxW) ve main.rs (Registry) de kullanır.
+    pub(crate) fn to_wide(s: &str) -> Vec<u16> {
         let mut v: Vec<u16> = s.encode_utf16().collect();
         v.push(0);
         v
     }
 
+    /// `OsStr` → UTF-16 LE null-terminated. `encode_wide()` lossless (path'te
+    /// non-UTF8 byte'lar da doğru kodlanır); `path.display()` lossy olabilir.
     fn to_wide_os(s: &std::ffi::OsStr) -> Vec<u16> {
         use std::os::windows::ffi::OsStrExt;
         let mut v: Vec<u16> = s.encode_wide().collect();
@@ -412,8 +418,8 @@ mod win {
             if pwstr.is_null() {
                 return None;
             }
-            // PWSTR → &[u16] → OsString
-            let len = (0..).take_while(|&i| *pwstr.0.add(i) != 0).count();
+            // PCWSTR::from_raw(...).len() — null'a kadar sayan idiomatic yol.
+            let len = windows::core::PCWSTR::from_raw(pwstr.0).len();
             let slice = std::slice::from_raw_parts(pwstr.0, len);
             let os = {
                 use std::os::windows::ffi::OsStringExt;
@@ -448,12 +454,29 @@ mod win {
         }
     }
 
-    /// COM'u apartment-threaded modda başlatır (idempotent). Hata değeri
-    /// `S_FALSE`/`RPC_E_CHANGED_MODE` yoksayılabilir — zaten init edilmiş demek.
+    thread_local! {
+        /// Bu thread'de `CoInitializeEx` çağrıldı mı?
+        ///
+        /// `CoInitializeEx` S_OK/S_FALSE döndüğünde thread-başına ref count
+        /// artırıyor. Tekrar çağrı ref count'u şişirir; `CoUninitialize`
+        /// çağırmadığımız için birikmesin diye flag tutup bir kez çağırıyoruz.
+        static COM_INITED: Cell<bool> = const { Cell::new(false) };
+    }
+
+    /// COM'u apartment-threaded modda thread başına bir kez başlatır.
+    /// Hata değeri (`S_FALSE`/`RPC_E_CHANGED_MODE`) zaten init edilmiş anlamına
+    /// gelir — sessizce geçeriz. Process yaşam süresi boyunca init kalır;
+    /// `CoUninitialize` çağırmayız (uygulama kapanışında OS temizler).
     fn ensure_com_init() {
-        unsafe {
-            let _ = CoInitializeEx(None, COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE);
-        }
+        COM_INITED.with(|flag| {
+            if flag.get() {
+                return;
+            }
+            unsafe {
+                let _ = CoInitializeEx(None, COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE);
+            }
+            flag.set(true);
+        });
     }
 
     /// `ShellExecuteW` ile "open" verb'ü çağır. URL / dosya / klasör hepsi kabul.
@@ -462,7 +485,7 @@ mod win {
         let verb = to_wide("open");
         unsafe {
             let _ = ShellExecuteW(
-                Some(HWND::default()),
+                None,
                 PCWSTR(verb.as_ptr()),
                 PCWSTR(wide.as_ptr()),
                 PCWSTR::null(),
@@ -489,14 +512,14 @@ mod win {
         }
     }
 
-    /// Clipboard'a UTF-16 metin koyar. Standart pattern:
-    /// OpenClipboard → EmptyClipboard → GlobalAlloc+Lock → copy → Unlock →
-    /// SetClipboardData(CF_UNICODETEXT) → CloseClipboard.
+    /// Clipboard'a UTF-16 metin koyar.
     ///
-    /// SetClipboardData başarılı olduğunda hafızanın sahipliği clipboard'a
-    /// geçer; biz free etmemeliyiz. Hata yolunda pragmatik olarak hafıza
-    /// leak'i kabul edilir (windows-rs 0.60'ta `GlobalFree` feature'ı bu
-    /// modülde sağlanmıyor; her hata ~ metin boyutu kadar küçük).
+    /// Akış: OpenClipboard → EmptyClipboard → GlobalAlloc+Lock → copy →
+    /// Unlock → SetClipboardData(CF_UNICODETEXT) → CloseClipboard.
+    ///
+    /// SetClipboardData başarılıysa hafızanın sahipliği clipboard'a geçer —
+    /// biz free ETMEYİZ. Her hata yolunda `GlobalFree` ile kaynak serbest
+    /// bırakılır; `OpenClipboard` başarısız olursa da alloc'u temizleriz.
     pub(super) fn clipboard_set(text: &str) -> Result<()> {
         const CF_UNICODETEXT: u32 = 13;
         let wide = to_wide(text);
@@ -510,18 +533,33 @@ mod win {
 
             let dst = GlobalLock(hmem) as *mut u16;
             if dst.is_null() {
+                let _ = GlobalFree(Some(hmem));
                 return Err(windows::core::Error::from_win32());
             }
             std::ptr::copy_nonoverlapping(wide.as_ptr(), dst, wide.len());
             let _ = GlobalUnlock(hmem);
 
-            // Clipboard sahipliğini al (owner HWND = None, process-wide).
-            OpenClipboard(None)?;
+            // Clipboard sahipliğini al. Başarısızsa hafıza sızmasın diye
+            // GlobalFree ile kapat.
+            if let Err(e) = OpenClipboard(None) {
+                let _ = GlobalFree(Some(hmem));
+                return Err(e);
+            }
             let _ = EmptyClipboard();
             // windows-rs 0.60: hmem `Option<HANDLE>` (NULL = clear format data).
-            let result = SetClipboardData(CF_UNICODETEXT, Some(HANDLE(hmem.0 as _)));
-            let _ = CloseClipboard();
-            result.map(|_| ())
+            match SetClipboardData(CF_UNICODETEXT, Some(HANDLE(hmem.0 as _))) {
+                Ok(_) => {
+                    // Sahipliği clipboard aldı; free ETMEYİZ.
+                    let _ = CloseClipboard();
+                    Ok(())
+                }
+                Err(e) => {
+                    // Sahipliği transfer başarısız — biz free ederiz.
+                    let _ = CloseClipboard();
+                    let _ = GlobalFree(Some(hmem));
+                    Err(e)
+                }
+            }
         }
     }
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -87,7 +87,7 @@ impl Settings {
     ///   * Kaydın `id` alanı boşsa (legacy kayıt) **yalnız ad** eşleşmesi yeter
     ///     — bu, config migrasyonu sırasında eski güven kararlarını kaybetmemek
     ///     için bilinçli bir taviz. Kullanıcı aynı cihazı tekrar "Kabul + güven"
-    ///     seçerse [`add_trusted`] kaydı gerçek id'yle günceller.
+    ///     seçerse [`Self::add_trusted`] kaydı gerçek id'yle günceller.
     pub fn is_trusted(&self, device_name: &str, id: &str) -> bool {
         if device_name.is_empty() {
             return false;
@@ -137,7 +137,7 @@ impl Settings {
     /// UI katmanı (main.rs) "trust_remove::NAME" IPC mesajıyla sadece adı
     /// iletir; geriye dönük uyum için bu imza korunur. Aynı adın birden çok
     /// id ile kaydı varsa hepsi silinir. ID tabanlı hassas silme için
-    /// [`remove_trusted_by_id`] kullanın.
+    /// [`Self::remove_trusted_by_id`] kullanın.
     pub fn remove_trusted(&mut self, device_name: &str) {
         self.trusted_devices.retain(|d| d.name != device_name);
     }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -280,11 +280,11 @@ pub fn notify_file_received(title: &str, body: &str, path: std::path::PathBuf) {
                 });
             });
 
-        // Windows: notify-rust WinRT backend toast gösterir ama callback
-        // API'si (activation) henüz bağlanmadı. "Aç"/"Klasörde göster"
-        // butonları eklemiyoruz — kullanıcıya ölü butonlar göstermek
-        // yerine sade bildirim tercih ediyoruz. Toast tıklama eylemi
-        // ileride COM activation ile bağlanacak.
+        // Windows: notify-rust WinRT backend toast'ı aksiyon butonu ile
+        // render edebilir ama callback/activation mekanizması bu crate
+        // sürümünde expose edilmediği için buton tıklaması Rust tarafına
+        // iletilmiyor. Ölü buton göstermemek için düz bildirim tercih
+        // ediliyor; COM activation ile bağlantı ileride eklenebilir.
         #[cfg(target_os = "windows")]
         let spawned = std::thread::Builder::new()
             .name("hekadrop-notify".into())

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -112,17 +112,12 @@ fn prompt_accept_blocking(
     // Not: Sistem dilini takip eden buton etiketleri "Evet/Hayır/İptal"
     // olur. Mesaj metninde kullanıcıya hangi butonun ne anlama geldiği
     // açıkça yazılır.
+    use crate::platform::win::to_wide;
     use windows::core::PCWSTR;
     use windows::Win32::Foundation::HWND;
     use windows::Win32::UI::WindowsAndMessaging::{
         MessageBoxW, IDCANCEL, IDNO, IDYES, MB_ICONINFORMATION, MB_SYSTEMMODAL, MB_YESNOCANCEL,
     };
-
-    fn to_wide(s: &str) -> Vec<u16> {
-        let mut v: Vec<u16> = s.encode_utf16().collect();
-        v.push(0);
-        v
-    }
 
     let files_str = format_payload_lines(files, text_count);
     let message = format!(
@@ -285,10 +280,11 @@ pub fn notify_file_received(title: &str, body: &str, path: std::path::PathBuf) {
                 });
             });
 
-        // Windows: notify-rust WinRT backend `show()` unit döner; `wait_for_action`
-        // Linux-özel. Toast otomatik kapanır. Action callback (Aç/Reveal
-        // tıklama) ileride COM ile bağlanacak — şimdilik toast görünür,
-        // tıklanınca HekaDrop'a bir şey iletmez.
+        // Windows: notify-rust WinRT backend toast gösterir ama callback
+        // API'si (activation) henüz bağlanmadı. "Aç"/"Klasörde göster"
+        // butonları eklemiyoruz — kullanıcıya ölü butonlar göstermek
+        // yerine sade bildirim tercih ediyoruz. Toast tıklama eylemi
+        // ileride COM activation ile bağlanacak.
         #[cfg(target_os = "windows")]
         let spawned = std::thread::Builder::new()
             .name("hekadrop-notify".into())
@@ -299,8 +295,6 @@ pub fn notify_file_received(title: &str, body: &str, path: std::path::PathBuf) {
                     .appname("HekaDrop")
                     .summary(&title)
                     .body(&body)
-                    .action("default", "Aç")
-                    .action("reveal", "Klasörde göster")
                     .timeout(10_000)
                     .show()
                 {
@@ -392,16 +386,12 @@ pub fn show_info(title: &str, body: &str) {
         let _ = std::thread::Builder::new()
             .name("hekadrop-showinfo".into())
             .spawn(move || {
+                use crate::platform::win::to_wide;
                 use windows::core::PCWSTR;
                 use windows::Win32::Foundation::HWND;
                 use windows::Win32::UI::WindowsAndMessaging::{
                     MessageBoxW, MB_ICONINFORMATION, MB_OK, MB_SYSTEMMODAL,
                 };
-                fn to_wide(s: &str) -> Vec<u16> {
-                    let mut v: Vec<u16> = s.encode_utf16().collect();
-                    v.push(0);
-                    v
-                }
                 let body_w = to_wide(&body);
                 let title_w = to_wide(&title);
                 unsafe {
@@ -467,6 +457,7 @@ fn choose_files_blocking() -> Option<Vec<std::path::PathBuf>> {
     // her Windows 10/11'de hazır gelir. Multi-select, ardından path'leri
     // satır satır yazdırır. Hata durumunda None.
     let script = r#"
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
 Add-Type -AssemblyName System.Windows.Forms | Out-Null
 $dlg = New-Object System.Windows.Forms.OpenFileDialog
 $dlg.Title = 'Gönderilecek dosyaları seçin'
@@ -594,6 +585,7 @@ fn choose_folder_blocking() -> Option<std::path::PathBuf> {
 #[cfg(target_os = "windows")]
 fn choose_folder_blocking() -> Option<std::path::PathBuf> {
     let script = r#"
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
 Add-Type -AssemblyName System.Windows.Forms | Out-Null
 $dlg = New-Object System.Windows.Forms.FolderBrowserDialog
 $dlg.Description = 'İndirme klasörünü seçin'
@@ -716,6 +708,7 @@ fn choose_device_blocking(labels: &[String]) -> Option<String> {
         .join(",");
     let script = format!(
         r#"
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
 Add-Type -AssemblyName System.Windows.Forms | Out-Null
 Add-Type -AssemblyName System.Drawing | Out-Null
 $form = New-Object System.Windows.Forms.Form


### PR DESCRIPTION
## Özet
PR #4 merge'den az önce push ettiğim review-fixes commit'i merge'e dahil olmadı.
Bu PR onları getiriyor — kod değişikliği yalnızca Windows dalları.

## İçerik (Gemini + Copilot review'larından kabul edilenler)

**HIGH:**
- PowerShell scriptlerinde `[Console]::OutputEncoding = UTF8` — Türkçe/non-ASCII dosya & klasör adları stdout'ta mojibake olmuyor artık (3 script)

**MEDIUM:**
- `clipboard_set` tüm hata yollarında `GlobalFree` çağrısı (alloc→lock, OpenClipboard, SetClipboardData fail paths)
- `CoInitializeEx` `thread_local!` `Cell<bool>` guard ile thread başına tek çağrı (ref count şişmesin)
- `mod win` ve `to_wide` `pub(crate)` — `main.rs` ve `ui.rs` artık merkezi helper kullanır, local duplicate'ler silindi
- `SHGetKnownFolderPath` çıktısının uzunluğu `PCWSTR::len()` ile (idiomatic)
- Registry `ExecStart` path'i `exe.as_os_str().encode_wide()` ile lossless UTF-16 (display() lossy olabiliyordu)
- `RegDeleteValueW` rc kontrolü — silme başarısızsa `show_info` ile hata
- Windows toast'dan aksiyon butonları kaldırıldı — callback bağlanmadığı için ölü butonlar vardı

## Test planı
- [x] `cargo fmt --all -- --check` temiz
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — 0 uyarı
- [x] `cargo test --all` — 137 test geçiyor
- [ ] Windows CI PR açıldıktan sonra doğrulanacak

🤖 Generated with [Claude Code](https://claude.com/claude-code)
