### PR TITLE
packaging: Homebrew cask + Scoop manifest (v0.4.0)

### DIFF
--- a/Casks/hekadrop.rb
+++ b/Casks/hekadrop.rb
@@ -1,10 +1,10 @@
 cask "hekadrop" do
-  version "0.1.0"
-  sha256 :no_check # İlk release sonrası gerçek hash ile değiştirilecek
+  version "0.4.0"
+  sha256 "f2f2122e2e82b9af465fe3682c06aae45c0039cae789b2a239202aae3516b1ad"
 
-  url "https://github.com/YatogamiRaito/HekaDrop/releases/download/v#{version}/HekaDrop-#{version}.dmg"
+  url "https://github.com/YatogamiRaito/HekaDrop/releases/download/v#{version}/HekaDrop-#{version}-macos.zip"
   name "HekaDrop"
-  desc "Google Quick Share (Nearby Share) client for macOS — Rust"
+  desc "Google Quick Share (Nearby Share) client — Rust, cross-platform"
   homepage "https://github.com/YatogamiRaito/HekaDrop"
 
   auto_updates false

--- a/README.md
+++ b/README.md
@@ -58,21 +58,33 @@ doğrudan — bulut yok, hesap yok, tracker yok.
 
 ## Kurulum
 
-### Homebrew (önerilen — yakında)
+### Homebrew (macOS — yakında)
 
 ```bash
 brew install --cask yatogamiraito/tap/hekadrop
 ```
 
 > Tap (`yatogamiraito/homebrew-tap`) henüz yayında değil — **coming soon**.
-> O zamana kadar DMG veya kaynaktan kurulum yolunu kullanın.
+> `Casks/hekadrop.rb` dosyası repoda hazır (v0.4.0 zip + SHA ile); tap repo'ya kopyalandığında doğrudan çalışır.
 
-### DMG (GitHub Releases)
+### Releases (zip / deb / exe)
 
-1. [Releases](https://github.com/YatogamiRaito/HekaDrop/releases) sayfasından en güncel
-   `HekaDrop-<version>.dmg` dosyasını indirin.
-2. DMG'yi açın ve **HekaDrop.app**'i **Applications** klasörüne sürükleyin.
-3. İlk açılışta macOS Gatekeeper uyarısı gelirse: **Ayarlar → Gizlilik & Güvenlik → Yine de Aç**.
+| Platform | Asset | Kurulum |
+|---|---|---|
+| macOS | `HekaDrop-x.y.z-macos.zip` | Zip'i aç, `HekaDrop.app`'i `Applications`'a taşı. İlk açılışta Gatekeeper uyarısı için: **Ayarlar → Gizlilik & Güvenlik → Yine de Aç** |
+| Ubuntu/Debian | `HekaDrop-x.y.z.deb` | `sudo apt install ./HekaDrop-x.y.z.deb` |
+| Windows | `HekaDrop-x.y.z.exe` | İndir → çalıştır (unsigned; Defender "Run anyway") |
+
+[Releases sayfası](https://github.com/YatogamiRaito/HekaDrop/releases/latest) — çekilmiş tag için artifact + checksum.
+
+### Scoop (Windows)
+
+```powershell
+scoop bucket add yatogamiraito https://github.com/YatogamiRaito/HekaDrop
+scoop install hekadrop
+```
+
+> Manifest repoda (`scoop/hekadrop.json`); bucket aktifleşince tek komutla kurulur.
 
 ### Kaynaktan derleme
 

--- a/scoop/hekadrop.json
+++ b/scoop/hekadrop.json
@@ -1,0 +1,30 @@
+{
+  "version": "0.4.0",
+  "description": "Google Quick Share (Nearby Share) client — Rust, cross-platform",
+  "homepage": "https://github.com/YatogamiRaito/HekaDrop",
+  "license": "MIT",
+  "url": "https://github.com/YatogamiRaito/HekaDrop/releases/download/v0.4.0/HekaDrop-0.4.0.exe",
+  "hash": "01a98c98d42a05d8e0215edb73dfda77bbf82533ec44ca4a22dfcebf4f92e7fb",
+  "bin": [
+    [
+      "HekaDrop-0.4.0.exe",
+      "hekadrop"
+    ]
+  ],
+  "shortcuts": [
+    [
+      "HekaDrop-0.4.0.exe",
+      "HekaDrop"
+    ]
+  ],
+  "checkver": {
+    "github": "https://github.com/YatogamiRaito/HekaDrop"
+  },
+  "autoupdate": {
+    "url": "https://github.com/YatogamiRaito/HekaDrop/releases/download/v$version/HekaDrop-$version.exe",
+    "hash": {
+      "url": "$baseurl/v$version",
+      "regex": "(?s)<code>([a-f0-9]{64})\\s+HekaDrop-$version\\.exe"
+    }
+  }
+}


### PR DESCRIPTION
## Özet
v0.4.0 için paket manifest'leri güncelleniyor.

### Değişenler
- **`Casks/hekadrop.rb`** — v0.1.0 placeholder'dan v0.4.0'a:
  - URL `.dmg` → `-macos.zip` (CI `.app.zip` üretir)
  - `sha256` gerçek değer: `f2f2122e2e82b9af...`
  - `desc` "cross-platform" (yalnız macOS değil)
- **`scoop/hekadrop.json`** (yeni) — Windows için Scoop manifest
  - `.exe` URL + SHA (`01a98c98d42a05d8...`)
  - `checkver` + `autoupdate` GitHub releases yolu ile sürümü otomatik çeker
- **`README.md`**
  - Homebrew bölümü: zip kullanımı, cask'ın hazır olduğu
  - Eski "DMG" bölümü → **Releases tablosu** (macOS zip / Debian deb / Windows exe)
  - Yeni **Scoop (Windows)** bölümü

### Bilinen şey
Tap repo'su (`yatogamiraito/homebrew-tap`) ve Scoop bucket henüz yayında değil; manifestler burada referans. Repo'lar açılınca cask ve bucket satırı direkt çalışacak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
