### PR TITLE
docs: public release hazırlık (community health + i18n)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -62,7 +62,10 @@ body:
         Linux: `~/.local/state/HekaDrop/logs/`
         Windows: `%LOCALAPPDATA%\HekaDrop\logs\`
 
-        `RUST_LOG=hekadrop=debug hekadrop` ile detaylı log alabilirsiniz.
+        Detaylı log için:
+          - macOS/Linux: `RUST_LOG=hekadrop=debug hekadrop`
+          - Windows (PowerShell): `$env:RUST_LOG='hekadrop=debug'; .\hekadrop.exe`
+          - Windows (CMD): `set RUST_LOG=hekadrop=debug && hekadrop.exe`
       render: shell
   - type: checkboxes
     id: checks

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,75 @@
+name: Hata raporu
+description: Beklenmeyen bir davranış, çökme veya protokol uyumsuzluğu
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Bildirdiğiniz için teşekkürler. Güvenlik açığı içeriyorsa public issue
+        açmayın — `SECURITY.md` dosyasındaki özel bildirim yolunu kullanın.
+  - type: input
+    id: version
+    attributes:
+      label: HekaDrop sürümü
+      description: "`hekadrop --version` ya da Ayarlar → Hakkında"
+      placeholder: "0.4.0"
+    validations:
+      required: true
+  - type: dropdown
+    id: os
+    attributes:
+      label: İşletim sistemi
+      multiple: true
+      options:
+        - macOS
+        - Linux (Ubuntu/Debian)
+        - Linux (Fedora)
+        - Linux (Arch)
+        - Linux (diğer)
+        - Windows 10
+        - Windows 11
+    validations:
+      required: true
+  - type: input
+    id: peer
+    attributes:
+      label: Karşı cihaz (opsiyonel)
+      description: Aktarım yapıyorsanız karşı taraf cihazın OS/marka/modeli
+      placeholder: "Android 14, Pixel 8"
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: Ne oldu?
+      description: Beklenen davranış ile gözlemlenen arasındaki fark.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Yeniden üretim adımları
+      placeholder: |
+        1. HekaDrop'u aç
+        2. Android'den dosya gönder
+        3. PIN görünmeden uygulama donuyor
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Loglar
+      description: |
+        macOS: `~/Library/Logs/HekaDrop/hekadrop.log`
+        Linux: `~/.local/state/HekaDrop/logs/`
+        Windows: `%LOCALAPPDATA%\HekaDrop\logs\`
+
+        `RUST_LOG=hekadrop=debug hekadrop` ile detaylı log alabilirsiniz.
+      render: shell
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Ön kontroller
+      options:
+        - label: Mevcut issue'ları taradım; tekrar eden kayıt yok
+          required: true
+        - label: En son sürümde (veya main branch'te) tekrar ürettim
+          required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Güvenlik açığı bildirimi
+    url: https://github.com/YatogamiRaito/HekaDrop/security/advisories/new
+    about: Güvenlik açıkları public issue olarak açılmaz. SECURITY.md'deki kanalı kullanın.
+  - name: Soru / destek
+    url: https://github.com/YatogamiRaito/HekaDrop/discussions
+    about: Hata değil, kullanım / yapılandırma sorusu varsa Discussions'a yazın.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,47 @@
+name: Özellik önerisi
+description: Yeni bir özellik, UX iyileştirmesi veya davranış değişikliği önerisi
+labels: ["enhancement", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Önerinizi tartışmaya açmadan önce mevcut issue / PR listesini ve
+        README'deki yol haritasını kontrol etmenizi rica ederiz — benzer
+        fikirler mevcut olabilir.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Hangi problemi çözüyor?
+      description: Kullanıcı hikayesi veya somut senaryo yazın. ("X yapmaya çalışıyorum ama Y eksik.")
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Önerilen çözüm
+      description: UI akışı, API, komut satırı flag'i vs. — nasıl olmalı?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Değerlendirilen alternatifler
+      description: Başka yolları düşündünüz mü? Neden bu tercih?
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Kapsam
+      options:
+        - Tüm platformlar
+        - Sadece macOS
+        - Sadece Linux
+        - Sadece Windows
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Ön kontroller
+      options:
+        - label: Mevcut issue/PR'ları taradım; benzer öneri yok
+          required: true
+        - label: Yol haritası (README "Yol haritası" bölümü) kapsamında değil ya da değişiklik öneriyorum
+          required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,36 @@
+<!--
+HekaDrop'a katkı için teşekkürler! Aşağıdaki alanları doldurun.
+Büyük değişiklikler için önce issue açmanızı rica ediyoruz (CONTRIBUTING.md).
+-->
+
+## Özet
+
+<!-- Ne değişti, neden? Bir-iki cümle. -->
+
+## Tür
+
+<!-- Uygun olanları işaretleyin ([x]) -->
+
+- [ ] Hata düzeltmesi
+- [ ] Yeni özellik
+- [ ] Protokol / kripto değişikliği (güvenlik gözden geçirmesi gerekir)
+- [ ] Refactor / temizlik (davranış değişmedi)
+- [ ] Dokümantasyon
+- [ ] CI / paketleme
+
+## Test
+
+<!-- Yerel olarak ne test ettiniz? CI otomatik çalıştırır ama anlamlı ek adımlar varsa yazın. -->
+
+- [ ] `cargo fmt --all -- --check` temiz
+- [ ] `cargo clippy --all-targets --all-features -- -D warnings` temiz
+- [ ] `cargo test --all` — tümü geçiyor
+- [ ] Gerçek cihazla manuel test (özellikle protokol/UI değişiklikleriyse)
+
+## İlgili issue(lar)
+
+<!-- Closes #N, Fixes #N, Relates #N -->
+
+## Notlar
+
+<!-- Breaking change var mı? Migrasyon gereksin mi? Ek risk/takip var mı? -->

--- a/CODE_OF_CONDUCT.en.md
+++ b/CODE_OF_CONDUCT.en.md
@@ -1,0 +1,72 @@
+# Contributor Covenant Code of Conduct
+
+> 🇹🇷 Türkçe sürüm: [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md)
+
+## Our Pledge
+
+We as HekaDrop maintainers and community members pledge to make
+participation in our community a harassment-free experience for everyone,
+regardless of age, body size, visible or invisible disability, ethnicity,
+sex characteristics, gender identity and expression, level of experience,
+education, socio-economic status, nationality, personal appearance, race,
+religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints, perspectives, and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior:
+
+- The use of sexualized language or imagery and unwelcome sexual attention
+  or advances
+- Trolling, insulting/derogatory comments, and personal or political
+  attacks
+- Public or private harassment
+- Publishing others' physical or electronic addresses without explicit
+  permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action
+in response to any instances of unacceptable behavior. This includes
+removing, editing, or rejecting comments, commits, code, wiki edits,
+issues, and other contributions that are not aligned with this Code of
+Conduct, or to ban temporarily or permanently any contributor for other
+behaviors that they deem inappropriate, threatening, offensive, or
+harmful.
+
+## Scope
+
+This Code of Conduct applies within all project spaces (repo, issue
+tracker, PRs) and in public spaces when an individual is representing the
+project or its community.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may
+be reported by contacting **destek@sourvice.com**. All complaints will be
+reviewed and investigated and will result in a response that is deemed
+necessary and appropriate to the circumstances.
+
+Maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by
+other members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1.
+
+[homepage]: https://www.contributor-covenant.org
+
+For Community Impact Guidelines, see:
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,5 +1,7 @@
 # Katılımcı Sözleşmesi — Davranış Kuralları
 
+> 🇬🇧 English version: [`CODE_OF_CONDUCT.en.md`](CODE_OF_CONDUCT.en.md)
+
 ## Sözümüz
 
 HekaDrop sürdürücüleri ve topluluk üyeleri olarak; yaş, beden ölçüsü,

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,64 @@
+# Katılımcı Sözleşmesi — Davranış Kuralları
+
+## Sözümüz
+
+HekaDrop sürdürücüleri ve topluluk üyeleri olarak; yaş, beden ölçüsü,
+görünmez/görünür engel, etnik köken, cinsiyet kimliği ve ifadesi, tecrübe
+seviyesi, eğitim, sosyo-ekonomik durum, milliyet, fiziksel görünüm, ırk,
+din ya da cinsel kimlik ve yönelim gözetmeksizin herkes için taciz
+içermeyen, kapsayıcı bir topluluk oluşturmayı taahhüt ediyoruz.
+
+## Standartlarımız
+
+Pozitif bir ortam oluşturmaya katkı sağlayan davranışlar:
+
+- Empatik dil kullanmak
+- Farklı görüşlere, bakış açılarına ve deneyimlere saygı duymak
+- Yapıcı eleştiri vermek ve almak
+- Topluluk için en iyi olana odaklanmak
+- Diğer üyelere karşı empati göstermek
+
+Kabul edilemez davranışlar:
+
+- Cinsel dil veya imge kullanımı, istenmeyen cinsel ilgi ya da yaklaşım
+- Trolleme, aşağılama/hakaret içeren yorumlar ve kişisel/politik saldırılar
+- Kamuya açık veya özel taciz
+- Başkalarının fiziksel ya da elektronik adres gibi özel bilgilerini
+  açık onay olmadan yayınlamak
+- Profesyonel bir ortamda makul sayılmayacak diğer davranışlar
+
+## Sorumluluk
+
+Sürdürücüler davranış kurallarını uygulamaktan ve uygun göreceği her türlü
+düzeltici önlemi almaktan sorumludur. Buna yorumları, commit'leri, kodu,
+wiki düzenlemelerini, issue ve diğer katkıları bu davranış kurallarına
+uygun olmayan biçimde kaldırma, düzenleme veya reddetme; ya da uygun gördüğü
+durumlarda, katkıda bulunanları geçici ya da kalıcı olarak yasaklama hakkı
+dahildir.
+
+## Kapsam
+
+Bu davranış kuralları hem proje alanlarında (repo, issue tracker, PR'lar)
+hem de bir bireyin projeyi veya topluluğu temsil ettiği kamu alanlarında
+geçerlidir.
+
+## Bildirim
+
+Taciz edici, rahatsız edici veya başka bir şekilde kabul edilemez
+davranışla karşılaşırsanız **destek@sourvice.com** adresine e-posta atarak
+bildirebilirsiniz. Tüm şikayetler gizlilik içinde incelenecek ve olaya
+göre gerekli ve uygun yanıt verilecektir.
+
+Davranış kurallarını iyi niyetle uygulamayan/izlemeyen sürdürücüler proje
+liderliğinin diğer üyeleri tarafından belirlenen geçici veya kalıcı
+yaptırımlarla karşılaşabilirler.
+
+## Atıf
+
+Bu davranış kuralları [Contributor Covenant][homepage] sürüm 2.1'den
+uyarlanmıştır.
+
+[homepage]: https://www.contributor-covenant.org
+
+Topluluk Etki Yönergeleri için bkz.:
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html

--- a/SECURITY.en.md
+++ b/SECURITY.en.md
@@ -1,0 +1,55 @@
+# Security Policy
+
+> 🇹🇷 Türkçe sürüm: [`SECURITY.md`](SECURITY.md)
+
+## Supported versions
+
+Only the latest minor release receives security fixes. The 0.x line is
+early-access so API stability is not guaranteed — behavioral changes
+outside security fixes may ship with a minor version bump.
+
+| Version | Support              |
+|---------|----------------------|
+| 0.4.x   | ✅ active            |
+| < 0.4   | ❌ no more updates   |
+
+## Responsible disclosure
+
+HekaDrop speaks a network protocol, so vulnerabilities can have serious
+impact. Please reach out **before** filing a public issue:
+
+- **GitHub Private Vulnerability Reporting** (preferred):
+  https://github.com/YatogamiRaito/HekaDrop/security/advisories/new
+- **Email:** destek@sourvice.com — use the subject `[HekaDrop security]`
+
+Helpful info to include:
+
+- Affected version(s) and operating system
+- Step-by-step reproduction (PoC, logs, screenshots, etc.)
+- Your impact assessment and estimated severity
+
+We commit to replying within **72 hours**. For critical issues we'll
+prepare a fix and coordinate the public disclosure with you. We're happy
+to assist with CVE requests.
+
+## Scope
+
+HekaDrop's core protocol is reverse-engineered from Google Quick Share
+(Nearby Share). We consider reports in the following classes:
+
+- ✅ Rust memory safety (UB, UAF, double-free in unsafe blocks)
+- ✅ Crypto: UKEY2 handshake, AES-CBC + HMAC, PIN verification, replay protection
+- ✅ Network: RCE over mDNS/TCP, DoS, memory exhaustion
+- ✅ Local: filesystem path traversal, privilege escalation
+- ✅ Third-party dependency vulnerabilities (`cargo audit`)
+
+Out of scope:
+
+- Attacks requiring root/admin on the victim device
+- Social engineering (voluntarily sharing the PIN, etc.)
+- Security issues in the Android counterpart (report to Google)
+
+## Credit
+
+With the reporter's permission, we credit contributions in `CHANGELOG.md`
+and release notes.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,7 @@
 # Güvenlik politikası
 
+> 🇬🇧 English version: [`SECURITY.en.md`](SECURITY.en.md)
+
 ## Desteklenen sürümler
 
 Yalnızca son minor sürüm güvenlik düzeltmeleri alır. 0.x serisi "early access"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,52 @@
+# Güvenlik politikası
+
+## Desteklenen sürümler
+
+Yalnızca son minor sürüm güvenlik düzeltmeleri alır. 0.x serisi "early access"
+olduğundan API stabilitesi garanti değil — güvenlik açıkları dışındaki
+davranış değişiklikleri minor sürüm bump'ı ile gelebilir.
+
+| Sürüm   | Destek                |
+|---------|-----------------------|
+| 0.4.x   | ✅ aktif              |
+| < 0.4   | ❌ güncelleme yok     |
+
+## Açık bildirme (responsible disclosure)
+
+HekaDrop bir ağ protokolü konuştuğu için güvenlik açıkları ciddi etki
+doğurabilir. Lütfen **public issue açmadan** önce bize ulaşın:
+
+- **GitHub Private Vulnerability Reporting** (tercih edilen):
+  https://github.com/YatogamiRaito/HekaDrop/security/advisories/new
+- **E-posta:** destek@sourvice.com — konu satırına `[HekaDrop security]` yazın
+
+Şunları dahil etmeniz yardımcı olur:
+
+- Etkilenen sürüm(ler) ve işletim sistemi
+- Adım adım yeniden üretim (PoC, log, ekran görüntüsü vs.)
+- Sizce risk seviyesi ve etki analizi
+
+En geç **72 saat** içinde yanıt vermeyi taahhüt ediyoruz. Kritik bir açık ise
+düzeltme hazırlayıp public duyurudan önce sizinle koordine ederiz. CVE
+talebine yardımcı oluruz.
+
+## Kapsam
+
+HekaDrop'un çekirdek protokolü Google Quick Share (Nearby Share) tersine
+mühendisliğine dayanır. Aşağıdaki sınıflarda raporları değerlendiriyoruz:
+
+- ✅ Rust memory safety (unsafe bloklarında UB, UAF, double-free vb.)
+- ✅ Kripto: UKEY2 handshake, AES-CBC HMAC, PIN doğrulama, replay koruması
+- ✅ Ağ: mDNS/tcp ile uzaktan kod yürütme, DoS, bellek tüketimi
+- ✅ Local: dosya sistemi path traversal, yetki yükseltme
+- ✅ Üçüncü parti bağımlılık açıkları (`cargo audit`)
+
+Kapsam dışı:
+
+- Kullanıcı cihazında root/admin erişimi gerektiren saldırılar
+- Sosyal mühendislik (PIN'i gönüllü paylaşmak vb.)
+- Karşı taraf Android cihazın güvenlik zafiyetleri (Google'a bildirin)
+
+## Teşekkür
+
+Bildirimcinin izniyle `CHANGELOG.md` ve release notes'ta teşekkür ederiz.

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -182,7 +182,7 @@ fn lookup_tr(key: &str) -> Option<&'static str> {
         "dialog.history.title" => "Son aktarımlar",
         "dialog.update.latest" => "En güncel sürümü kullanıyorsun (v{0}).",
         "dialog.update.available" => "Mevcut: v{0}\nYeni sürüm: {1}\n\n{2}",
-        "dialog.update.failed" => "Güncelleme kontrolü başarısız.\n\nHenüz yayınlanmış bir release yoksa (repo özel ise) bu normal.\nİnternet bağlantını kontrol edip tekrar dene.",
+        "dialog.update.failed" => "Güncelleme kontrolü başarısız.\n\nGitHub API'ye ulaşılamamış olabilir; internet bağlantını kontrol edip tekrar dene.",
         "dialog.update.title" => "HekaDrop — Güncelleme var",
 
         // Accept dialog
@@ -263,7 +263,7 @@ fn lookup_en(key: &str) -> Option<&'static str> {
         "dialog.history.title" => "Recent transfers",
         "dialog.update.latest" => "You're on the latest version (v{0}).",
         "dialog.update.available" => "Current: v{0}\nNew version: {1}\n\n{2}",
-        "dialog.update.failed" => "Update check failed.\n\nIf no release is published yet (private repo) this is normal.\nCheck your internet connection and retry.",
+        "dialog.update.failed" => "Update check failed.\n\nCould not reach GitHub API; check your internet connection and retry.",
         "dialog.update.title" => "HekaDrop — Update available",
 
         // Accept dialog


### PR DESCRIPTION
## Özet
Repo public'e açılmadan önce gerekli minimum güncellemeler. **Kod davranışında değişiklik yok** — sadece dokümantasyon, community templates ve bir kullanıcıya gösterilen string düzeltmesi.

### Eklenen community dosyaları (GitHub standart set)
- `SECURITY.md` — güvenlik bildirim kanalı, kapsam, response time
- `CODE_OF_CONDUCT.md` — Contributor Covenant v2.1
- `.github/ISSUE_TEMPLATE/bug_report.yml` — hata raporu formu
- `.github/ISSUE_TEMPLATE/feature_request.yml` — özellik öneri formu
- `.github/ISSUE_TEMPLATE/config.yml` — blank issue devre dışı, Advisories + Discussions yönlendirmesi
- `.github/PULL_REQUEST_TEMPLATE.md` — standart PR checklist

### String düzeltmesi
- `dialog.update.failed` artık "repo özel ise bu normal" demiyor. Tr + En

### Public öncesi audit
- Git history'de leaked token/secret taraması yapıldı → temiz
- `ghp_*`, `ghs_*` pattern'leri, `password`, `api_key` vb. içeren dosya yok
- `.env`, `.key`, `.pem` gibi dosya tracked değil
- Badge linkleri zaten public path kullanıyor
- `CODECOV_TOKEN` secret'i: public repo'lar için opsiyonel (tokenless çalışır)

## Sonrası
Merge → repo public → Actions quota sınırı kalkar → PR #10 (ui-i18n) CI'sı otomatik geçer → v0.5.0 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
