### PR TITLE
chore: sürüm drift (Cask/Scoop/Info.plist) + bundle.sh auto-inject

### DIFF
--- a/Casks/hekadrop.rb
+++ b/Casks/hekadrop.rb
@@ -1,6 +1,6 @@
 cask "hekadrop" do
-  version "0.4.0"
-  sha256 "f2f2122e2e82b9af465fe3682c06aae45c0039cae789b2a239202aae3516b1ad"
+  version "0.5.1"
+  sha256 "5507c34078353041834de83a06b1afa219df7ac6158864fdc372cb8cc63c6052"
 
   url "https://github.com/YatogamiRaito/HekaDrop/releases/download/v#{version}/HekaDrop-#{version}-macos.zip"
   name "HekaDrop"

--- a/resources/Info.plist
+++ b/resources/Info.plist
@@ -11,9 +11,9 @@
     <key>CFBundleDisplayName</key>
     <string>HekaDrop</string>
     <key>CFBundleVersion</key>
-    <string>0.1.0</string>
+    <string>0.5.1</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.1.0</string>
+    <string>0.5.1</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleInfoDictionaryVersion</key>

--- a/scoop/hekadrop.json
+++ b/scoop/hekadrop.json
@@ -1,19 +1,19 @@
 {
-  "version": "0.4.0",
+  "version": "0.5.1",
   "description": "Google Quick Share (Nearby Share) client — Rust, cross-platform",
   "homepage": "https://github.com/YatogamiRaito/HekaDrop",
   "license": "MIT",
-  "url": "https://github.com/YatogamiRaito/HekaDrop/releases/download/v0.4.0/HekaDrop-0.4.0.exe",
-  "hash": "01a98c98d42a05d8e0215edb73dfda77bbf82533ec44ca4a22dfcebf4f92e7fb",
+  "url": "https://github.com/YatogamiRaito/HekaDrop/releases/download/v0.5.1/HekaDrop-0.5.1.exe",
+  "hash": "2ab318e54b7dce9d4b046a8fece5fa1cc2d69e7b1995a3b631f2c63eabfda0be",
   "bin": [
     [
-      "HekaDrop-0.4.0.exe",
+      "HekaDrop-0.5.1.exe",
       "hekadrop"
     ]
   ],
   "shortcuts": [
     [
-      "HekaDrop-0.4.0.exe",
+      "HekaDrop-0.5.1.exe",
       "HekaDrop"
     ]
   ],

--- a/scoop/hekadrop.json
+++ b/scoop/hekadrop.json
@@ -3,17 +3,17 @@
   "description": "Google Quick Share (Nearby Share) client — Rust, cross-platform",
   "homepage": "https://github.com/YatogamiRaito/HekaDrop",
   "license": "MIT",
-  "url": "https://github.com/YatogamiRaito/HekaDrop/releases/download/v0.5.1/HekaDrop-0.5.1.exe",
+  "url": "https://github.com/YatogamiRaito/HekaDrop/releases/download/v$version/HekaDrop-$version.exe",
   "hash": "2ab318e54b7dce9d4b046a8fece5fa1cc2d69e7b1995a3b631f2c63eabfda0be",
   "bin": [
     [
-      "HekaDrop-0.5.1.exe",
+      "HekaDrop-$version.exe",
       "hekadrop"
     ]
   ],
   "shortcuts": [
     [
-      "HekaDrop-0.5.1.exe",
+      "HekaDrop-$version.exe",
       "HekaDrop"
     ]
   ],

--- a/scripts/bundle.sh
+++ b/scripts/bundle.sh
@@ -35,7 +35,9 @@ cp resources/Info.plist "${CONTENTS}/Info.plist"
 
 # Cargo.toml'daki sürümü Info.plist'e enjekte et — resources/Info.plist
 # içindeki sabit değer stale olsa bile bundle doğru sürümü gösterir.
-CARGO_VERSION=$(grep -E '^version = "' Cargo.toml | head -1 | sed -E 's/^version = "([^"]+)"/\1/')
+# `^version = "X"` satırını tırnak içindeki değeri yakalayarak ayıkla.
+# Trailing yorum (`# comment`) ya da ek boşluk stringe sızmaz.
+CARGO_VERSION=$(sed -nE 's/^version[[:space:]]*=[[:space:]]*"([^"]*)".*/\1/p' Cargo.toml | head -n 1)
 if [ -n "$CARGO_VERSION" ]; then
     echo "==> Info.plist sürümü güncelleniyor: ${CARGO_VERSION}"
     /usr/libexec/PlistBuddy -c "Set :CFBundleVersion ${CARGO_VERSION}" "${CONTENTS}/Info.plist"

--- a/scripts/bundle.sh
+++ b/scripts/bundle.sh
@@ -33,6 +33,15 @@ chmod +x "${MACOS}/hekadrop"
 echo "==> Info.plist kopyalanıyor"
 cp resources/Info.plist "${CONTENTS}/Info.plist"
 
+# Cargo.toml'daki sürümü Info.plist'e enjekte et — resources/Info.plist
+# içindeki sabit değer stale olsa bile bundle doğru sürümü gösterir.
+CARGO_VERSION=$(grep -E '^version = "' Cargo.toml | head -1 | sed -E 's/^version = "([^"]+)"/\1/')
+if [ -n "$CARGO_VERSION" ]; then
+    echo "==> Info.plist sürümü güncelleniyor: ${CARGO_VERSION}"
+    /usr/libexec/PlistBuddy -c "Set :CFBundleVersion ${CARGO_VERSION}" "${CONTENTS}/Info.plist"
+    /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString ${CARGO_VERSION}" "${CONTENTS}/Info.plist"
+fi
+
 if [ -f "resources/AppIcon.icns" ]; then
     echo "==> uygulama ikonu ekleniyor (AppIcon.icns)"
     cp resources/AppIcon.icns "${RESOURCES}/AppIcon.icns"


### PR DESCRIPTION
## Özet
Research agent'ın "version drift" HIGH bulgusuna fix.

Beş release (v0.1.0 → v0.5.1) boyunca paket manifestleri ve bundle metadata güncellenmedi:

| Dosya | Eskide | Şimdi |
|---|---|---|
| `Casks/hekadrop.rb` | 0.4.0 | **0.5.1** + yeni SHA |
| `scoop/hekadrop.json` | 0.4.0 | **0.5.1** + yeni SHA |
| `resources/Info.plist` | **0.1.0** | **0.5.1** |

### Kalıcı çözüm
`scripts/bundle.sh` artık `Cargo.toml`'dan version çekip `PlistBuddy` ile `CFBundleVersion` + `CFBundleShortVersionString` alanlarına enjekte eder — gelecekteki release'lerde Info.plist manuel güncellenmesi gerekmeyecek.

### Kapsam
Kod davranış değişikliği yok. Paketleme/metadata fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
