### PR TITLE
security: research v2 hotfix — slow-loris, TOCTOU, prost flood, seq o…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security (research v2 hotfix batch)
+- **[High] Slow-loris DoS**: `frame::read_frame` deadline'sız `read_exact`
+  kullanıyordu; saldırgan bağlantı açıp hiçbir şey göndermezsen tokio task'ı
+  sonsuza kadar asılı kalıyordu. Handshake frame'lerine 30sn, steady-loop
+  frame'lerine 60sn `tokio::time::timeout` eklendi (`HekaError::ReadTimeout`).
+- **[High] Protobuf cardinality flood**: `prost` default'u `repeated` alan
+  boyutuna sınır koymuyor. `Ukey2ClientInit.cipher_commitments` ≤8,
+  `Introduction.file_metadata` ≤1000, `text_metadata` ≤64 guard'ı eklendi.
+- **[High] `unique_downloads_path` TOCTOU**: İki paralel receiver aynı
+  dosya adını "mevcut değil" görüp aynı path'e `File::create` (O_TRUNC)
+  yapabiliyordu — ilki yazdığı veriyi ikincisi siliyordu. Artık
+  `OpenOptions::create_new(true)` ile **atomik** reserve (POSIX `O_EXCL` /
+  Win `CREATE_NEW`) yapılıyor; ikinci alıcı bir sonraki isme geçiyor.
+- **[High] `Settings::save` + `Stats::save` atomic değildi + RwLock
+  write guard altında senkron disk I/O yapıyordu.** `atomic_write()`
+  (tmp+rename) helper'ı eklendi; tüm callsite'lar snapshot-clone-then-save
+  pattern'ine geçirildi (yavaş diskte UI event loop donmasın).
+- **[Medium] `SecureCtx` sequence counter i32 overflow**: Saldırgan
+  `sequence_number = i32::MAX` yollayıp debug build'i panic'letebilir
+  veya release'te wrap'letebilirdi. `checked_add` ile bail.
+- **[Medium] Duplicate `payload_id` silent overwrite**: Saldırgan
+  Introduction'da aynı id ile iki FileMetadata yollayıp UI'ın "legit.pdf"
+  onayını "_evil.sh" yazmaya çevirebilirdi. `register_file_destination`
+  artık ikinci kaydı reddediyor.
+- **[Medium] Payload overrun / silent truncation**: `total_size` header
+  deklare edilirken sonraki chunk'larda doğrulanmıyordu; saldırgan
+  `total_size=10` deklare edip gigabaytlarca disk doldurabilirdi veya
+  `last_chunk=true` + az bayt ile yarım dosyayı "tamamlanmış" ilan
+  edebilirdi. Cumulative `written <= total_size` ve last-chunk eşitliği
+  kontrolü eklendi.
+
+### Added
+- 6 yeni security regression testi: `duplicate_payload_id_reddedilir`,
+  `file_overrun_reddedilir`, `file_last_chunk_truncation_reddedilir`,
+  `file_negative_total_size_reddedilir`, `encrypt_overflow_guardlu`,
+  `cipher_commitments_flood_reddedilir`. Toplam test: 108.
+
 ## [0.5.1] - 2026-04-19
 
 **⚠️ Security hotfix** — v0.5.0 kullanıcıları hemen güncellemelidir.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ notify-rust = "4"
 # trait implementasyonlarında çakışıyor); wry 0.50 şu anda 0.60 kullanıyor.
 windows = { version = "0.60", features = [
     "Win32_Foundation",
+    "Win32_Storage_FileSystem",
     "Win32_System_Com",
     "Win32_System_DataExchange",
     "Win32_System_Memory",

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -28,7 +28,7 @@ use crate::sharing::nearby::{
 use crate::state::{self, HistoryItem, ProgressState};
 use crate::ui;
 use crate::ukey2;
-use anyhow::{anyhow, Context, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use prost::Message;
 use rand::RngCore;
 use std::collections::HashMap;
@@ -39,7 +39,10 @@ use tracing::{info, warn};
 
 pub async fn handle(mut socket: TcpStream, peer: SocketAddr) -> Result<()> {
     // 1) plain ConnectionRequest
-    let req = frame::read_frame(&mut socket)
+    // SECURITY: Handshake fazındaki tüm frame okumaları slow-loris DoS'a karşı
+    // 30 sn timeout ile sarmalanır; aksi halde saldırgan TCP bağlantı açıp
+    // veri göndermeden tokio task'ını sonsuza kadar tutabilir.
+    let req = frame::read_frame_timeout(&mut socket, frame::HANDSHAKE_READ_TIMEOUT)
         .await
         .context("ConnectionRequest okunamadı")?;
     let offline = OfflineFrame::decode(req.as_ref()).context("OfflineFrame decode")?;
@@ -87,7 +90,7 @@ pub async fn handle(mut socket: TcpStream, peer: SocketAddr) -> Result<()> {
     }
 
     // 2) UKEY2 ClientInit
-    let ci = frame::read_frame(&mut socket)
+    let ci = frame::read_frame_timeout(&mut socket, frame::HANDSHAKE_READ_TIMEOUT)
         .await
         .context("Ukey2ClientInit okunamadı")?;
     let state = ukey2::process_client_init(&ci).context("ClientInit")?;
@@ -98,7 +101,7 @@ pub async fn handle(mut socket: TcpStream, peer: SocketAddr) -> Result<()> {
         .context("ServerInit yazılamadı")?;
 
     // 4) UKEY2 ClientFinished
-    let cf = frame::read_frame(&mut socket)
+    let cf = frame::read_frame_timeout(&mut socket, frame::HANDSHAKE_READ_TIMEOUT)
         .await
         .context("Ukey2ClientFinished okunamadı")?;
     let keys = ukey2::process_client_finish(&cf, &state).context("ClientFinish")?;
@@ -112,7 +115,7 @@ pub async fn handle(mut socket: TcpStream, peer: SocketAddr) -> Result<()> {
     );
 
     // 5) plain ConnectionResponse (karşı taraftan)
-    let resp_in = frame::read_frame(&mut socket)
+    let resp_in = frame::read_frame_timeout(&mut socket, frame::HANDSHAKE_READ_TIMEOUT)
         .await
         .context("peer ConnectionResponse okunamadı")?;
     let peer_resp =
@@ -171,7 +174,10 @@ pub async fn handle(mut socket: TcpStream, peer: SocketAddr) -> Result<()> {
             break;
         }
 
-        let raw = match frame::read_frame(&mut socket).await {
+        // Steady-loop timeout: peer Quick Share spec'i gereği ~30s'de bir
+        // KeepAlive gönderir. 60 sn içinde hiçbir frame gelmezse bağlantıyı
+        // ölü kabul ediyoruz — idle TCP task sızıntısını önler.
+        let raw = match frame::read_frame_timeout(&mut socket, frame::STEADY_READ_TIMEOUT).await {
             Ok(b) => b,
             Err(e) => {
                 warn!("[{}] bağlantı sonlandı: {:?}", peer, e);
@@ -279,10 +285,16 @@ pub async fn handle(mut socket: TcpStream, peer: SocketAddr) -> Result<()> {
                                 sha_hex
                             );
                             {
+                                // PERF/SAFETY: RwLock write guard altında senkron disk I/O
+                                // yapılmamalı — yavaş diskte tüm okuyucular (UI event loop)
+                                // bloklanır. Snapshot clone + drop guard + lock-dışı save.
                                 let st = state::get();
-                                let mut s = st.stats.write();
-                                s.record_received(&remote_name_shared, total_size as u64);
-                                let _ = s.save();
+                                let snap = {
+                                    let mut s = st.stats.write();
+                                    s.record_received(&remote_name_shared, total_size as u64);
+                                    s.clone()
+                                };
+                                let _ = snap.save();
                             }
                             let file_name = path
                                 .file_name()
@@ -328,7 +340,7 @@ pub async fn handle(mut socket: TcpStream, peer: SocketAddr) -> Result<()> {
                         ..Default::default()
                     }),
                 };
-                let enc = ctx.encrypt(&reply.encode_to_vec());
+                let enc = ctx.encrypt(&reply.encode_to_vec())?;
                 frame::write_frame(&mut socket, &enc).await?;
             }
             Some(v1_frame::FrameType::Disconnection) => {
@@ -442,6 +454,20 @@ async fn handle_sharing_frame(
                 .ok_or_else(|| anyhow!("introduction yok"))?;
             let file_count = intro.file_metadata.len();
             let text_count = intro.text_metadata.len();
+
+            // SECURITY: `prost` repeated alan cardinality sınırlaması uygulamıyor;
+            // saldırgan milyonlarca `file_metadata` göndererek UI dialog'u
+            // donduracak kadar Vec allocation + `prompt_accept` summary render
+            // maliyeti yaratabilir. Quick Share pratikte tek aktarımda
+            // yüzlerce dosya yeterli — 1000 cömert üst sınır.
+            if file_count > 1000 || text_count > 64 {
+                bail!(
+                    "Introduction cardinality flood: {} dosya, {} metin (limit 1000/64)",
+                    file_count,
+                    text_count
+                );
+            }
+
             info!(
                 "[{}] Introduction: {} dosya, {} metin",
                 peer, file_count, text_count
@@ -496,9 +522,12 @@ async fn handle_sharing_frame(
 
             if matches!(decision, ui::AcceptResult::AcceptAndTrust) {
                 let st = state::get();
-                let mut s = st.settings.write();
-                s.add_trusted(remote_name, remote_id);
-                let _ = s.save();
+                let snap = {
+                    let mut s = st.settings.write();
+                    s.add_trusted(remote_name, remote_id);
+                    s.clone()
+                };
+                let _ = snap.save();
                 info!(
                     "[{}] cihaz trusted listeye eklendi: {} (id: {})",
                     peer,
@@ -517,7 +546,9 @@ async fn handle_sharing_frame(
 
             if ok {
                 for (pid, path, display_name) in planned_files {
-                    assembler.register_file_destination(pid, path);
+                    assembler
+                        .register_file_destination(pid, path)
+                        .context("dosya hedefi kaydı")?;
                     pending_names.insert(pid, display_name);
                 }
                 for (pid, kind) in planned_texts {
@@ -607,7 +638,7 @@ pub(crate) async fn send_disconnection(socket: &mut TcpStream, ctx: &mut SecureC
             ..Default::default()
         }),
     };
-    let enc = ctx.encrypt(&f.encode_to_vec());
+    let enc = ctx.encrypt(&f.encode_to_vec())?;
     frame::write_frame(socket, &enc).await?;
     Ok(())
 }
@@ -637,10 +668,34 @@ fn unique_downloads_path(name: &str) -> Result<PathBuf> {
     // reserved adları (CON, PRN…) yeniden adlandırılır.
     let safe = sanitize_received_name(name);
 
-    let mut candidate = base.join(&safe);
-    if !candidate.exists() {
-        return Ok(candidate);
+    // SECURITY/TOCTOU: Önceki sürüm `Path::exists()` + sonra `File::create`
+    // kullanıyordu. İki paralel alıcı (server.rs `MAX_CONCURRENT_CONNECTIONS=32`)
+    // aynı ismi aynı anda "mevcut değil" görüp aynı `candidate`'i seçebilir;
+    // sonraki `File::create` ikinci alıcının verisini `O_TRUNC` ile silerek
+    // birincinin yazdığını yok ederdi.
+    // Çözüm: `OpenOptions::create_new(true)` ile **atomic** reserve — işletim
+    // sistemi düzeyinde `O_EXCL` (POSIX) / `CREATE_NEW` (Windows). İlk sahibin
+    // placeholder'ı kazanır; ikincisi `AlreadyExists` alıp sonraki isme geçer.
+    // Placeholder sıfır bayt olarak diskte kalır; `PayloadAssembler::ingest_file`
+    // onu `OpenOptions::write(true).truncate(true)` ile yeniden açarak gerçek
+    // veriyle doldurur (aynı path, aynı inode).
+    fn try_reserve(candidate: &std::path::Path) -> std::io::Result<()> {
+        std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(candidate)
+            .map(|_| ())
     }
+
+    let candidate = base.join(&safe);
+    match try_reserve(&candidate) {
+        Ok(()) => return Ok(candidate),
+        Err(e) if e.kind() != std::io::ErrorKind::AlreadyExists => {
+            return Err(anyhow!("dosya rezerve edilemedi: {}", e));
+        }
+        Err(_) => {}
+    }
+
     let (stem, ext) = split_name(&safe);
     let mut n = 1;
     loop {
@@ -649,11 +704,18 @@ fn unique_downloads_path(name: &str) -> Result<PathBuf> {
         } else {
             format!("{} ({}).{}", stem, n, ext)
         };
-        candidate = base.join(filename);
-        if !candidate.exists() {
-            return Ok(candidate);
+        let next = base.join(filename);
+        match try_reserve(&next) {
+            Ok(()) => return Ok(next),
+            Err(e) if e.kind() != std::io::ErrorKind::AlreadyExists => {
+                return Err(anyhow!("dosya rezerve edilemedi: {}", e));
+            }
+            Err(_) => {}
         }
         n += 1;
+        if n > 10_000 {
+            bail!("uygun dosya adı bulunamadı (10k deneme)");
+        }
     }
 }
 
@@ -842,12 +904,12 @@ pub(crate) async fn send_sharing_frame(
 
     // İlk chunk: tam gövde, offset=0, flags=0
     let first = wrap_payload_transfer(payload_id, total, 0, 0, body.clone());
-    let enc1 = ctx.encrypt(&first.encode_to_vec());
+    let enc1 = ctx.encrypt(&first.encode_to_vec())?;
     frame::write_frame(socket, &enc1).await?;
 
     // Son chunk: boş gövde, flags=1 (last)
     let last = wrap_payload_transfer(payload_id, total, total, 1, Vec::new());
-    let enc2 = ctx.encrypt(&last.encode_to_vec());
+    let enc2 = ctx.encrypt(&last.encode_to_vec())?;
     frame::write_frame(socket, &enc2).await?;
     Ok(())
 }
@@ -1008,8 +1070,8 @@ mod tests {
             let mut f2 = std::fs::File::create(&p2).unwrap();
             f2.write_all(b"half").unwrap();
         }
-        asm.register_file_destination(101, p1.clone());
-        asm.register_file_destination(202, p2.clone());
+        asm.register_file_destination(101, p1.clone()).unwrap();
+        asm.register_file_destination(202, p2.clone()).unwrap();
         names.insert(101, "a.bin".into());
         names.insert(202, "b.bin".into());
         texts.insert(303, TextType::Text);
@@ -1035,7 +1097,7 @@ mod tests {
         let mut texts: HashMap<i64, TextType> = HashMap::new();
 
         let p = unique_tmp("partial.bin");
-        asm.register_file_destination(777, p.clone());
+        asm.register_file_destination(777, p.clone()).unwrap();
         names.insert(777, "partial.bin".into());
 
         // İlk chunk'ı simüle et (100 bayt toplam, 10 bayt body, last=false).

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -557,6 +557,23 @@ async fn handle_sharing_frame(
                 send_sharing_frame(socket, ctx, &build_consent_accept()).await?;
                 info!("[{}] ✓ kullanıcı kabul etti", peer);
             } else {
+                // Reject: `unique_downloads_path` her `planned_files` için
+                // `create_new(true)` ile 0-bayt placeholder rezerve etmişti.
+                // Hiçbirini PayloadAssembler'a kaydetmediğimiz için normal
+                // cleanup yolu bunları bilmiyor — burada elle siliyoruz,
+                // aksi halde indirme klasöründe sahipsiz boş dosyalar birikir
+                // (review-18 MED).
+                for (_pid, path, _name) in &planned_files {
+                    if let Err(e) = std::fs::remove_file(path) {
+                        if e.kind() != std::io::ErrorKind::NotFound {
+                            tracing::debug!(
+                                "reject cleanup: placeholder silinemedi {}: {}",
+                                path.display(),
+                                e
+                            );
+                        }
+                    }
+                }
                 send_sharing_frame(socket, ctx, &build_consent_reject()).await?;
                 info!("[{}] ✗ kullanıcı reddetti", peer);
                 ui::notify("HekaDrop", &format!("{}: aktarım reddedildi", remote_name));

--- a/src/error.rs
+++ b/src/error.rs
@@ -11,4 +11,6 @@ pub enum HekaError {
     FrameTooLarge(usize),
     #[error("beklenmeyen bağlantı sonu")]
     UnexpectedEof,
+    #[error("frame okuma zaman aşımı ({0:?})")]
+    ReadTimeout(std::time::Duration),
 }

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -1,9 +1,21 @@
 use crate::error::HekaError;
 use bytes::{BufMut, Bytes, BytesMut};
+use std::time::Duration;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
 
 const MAX_FRAME_SIZE: usize = 16 * 1024 * 1024;
+
+/// Handshake fazında (ConnectionRequest, UKEY2) slow-loris saldırılarına karşı
+/// frame okuma süresinin üst sınırı. 30 sn gerçek peer için fazlasıyla yeter;
+/// bu sürede tek bir frame bile gelmezse saldırgan ya da ağ arızası varsayılır.
+pub const HANDSHAKE_READ_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Şifreli loop (PayloadTransfer / KeepAlive) fazında idle üst sınır.
+/// Quick Share peer'ları periyodik KeepAlive gönderdiği için 60 sn sessizlik
+/// ölü bağlantı olarak kabul edilir; slow-loris tokio task sızıntısı
+/// engellenir.
+pub const STEADY_READ_TIMEOUT: Duration = Duration::from_secs(60);
 
 pub async fn read_frame(stream: &mut TcpStream) -> Result<Bytes, HekaError> {
     let mut len_buf = [0u8; 4];
@@ -15,6 +27,18 @@ pub async fn read_frame(stream: &mut TcpStream) -> Result<Bytes, HekaError> {
     let mut buf = vec![0u8; len];
     stream.read_exact(&mut buf).await?;
     Ok(Bytes::from(buf))
+}
+
+/// `read_frame` + deadline. Timeout → `HekaError::ReadTimeout`; böylece
+/// çağıran taraf tokio task'ını bitirebilir ve socket kapatılır.
+pub async fn read_frame_timeout(
+    stream: &mut TcpStream,
+    deadline: Duration,
+) -> Result<Bytes, HekaError> {
+    match tokio::time::timeout(deadline, read_frame(stream)).await {
+        Ok(res) => res,
+        Err(_) => Err(HekaError::ReadTimeout(deadline)),
+    }
 }
 
 pub async fn write_frame(stream: &mut TcpStream, data: &[u8]) -> Result<(), HekaError> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -416,9 +416,12 @@ fn run_app() -> ! {
                 let new_val = auto_accept_item.is_checked();
                 {
                     let st = state::get();
-                    let mut s = st.settings.write();
-                    s.auto_accept = new_val;
-                    let _ = s.save();
+                    let snap = {
+                        let mut s = st.settings.write();
+                        s.auto_accept = new_val;
+                        s.clone()
+                    };
+                    let _ = snap.save();
                 }
                 info!("auto_accept → {}", new_val);
                 ui::notify(
@@ -452,10 +455,12 @@ fn handle_ipc(cmd: &str) {
     }
     if let Some(name) = cmd.strip_prefix("trust_remove::") {
         let st = state::get();
-        let mut s = st.settings.write();
-        s.remove_trusted(name);
-        let _ = s.save();
-        drop(s);
+        let snap = {
+            let mut s = st.settings.write();
+            s.remove_trusted(name);
+            s.clone()
+        };
+        let _ = snap.save();
         push_trusted_to_ui();
         ui::notify(
             i18n::t("notify.app_name"),
@@ -477,10 +482,12 @@ fn handle_ipc(cmd: &str) {
         "stats_refresh" => push_stats_to_ui(),
         "stats_reset" => {
             let st = state::get();
-            let mut s = st.stats.write();
-            *s = stats::Stats::default();
-            let _ = s.save();
-            drop(s);
+            let snap = {
+                let mut s = st.stats.write();
+                *s = stats::Stats::default();
+                s.clone()
+            };
+            let _ = snap.save();
             push_stats_to_ui();
             ui::notify(i18n::t("notify.app_name"), i18n::t("notify.stats_reset"));
         }
@@ -494,10 +501,12 @@ fn handle_ipc(cmd: &str) {
         }
         "trusted_clear" => {
             let st = state::get();
-            let mut s = st.settings.write();
-            s.trusted_devices.clear();
-            let _ = s.save();
-            drop(s);
+            let snap = {
+                let mut s = st.settings.write();
+                s.trusted_devices.clear();
+                s.clone()
+            };
+            let _ = snap.save();
             push_trusted_to_ui();
             ui::notify(i18n::t("notify.app_name"), i18n::t("notify.trust_cleared"));
         }
@@ -542,11 +551,14 @@ fn handle_settings_save(json: &str) {
     };
     {
         let st = state::get();
-        let mut s = st.settings.write();
-        s.device_name = parsed.device_name.filter(|x| !x.is_empty());
-        s.download_dir = parsed.download_dir.map(std::path::PathBuf::from);
-        s.auto_accept = parsed.auto_accept;
-        let _ = s.save();
+        let snap = {
+            let mut s = st.settings.write();
+            s.device_name = parsed.device_name.filter(|x| !x.is_empty());
+            s.download_dir = parsed.download_dir.map(std::path::PathBuf::from);
+            s.auto_accept = parsed.auto_accept;
+            s.clone()
+        };
+        let _ = snap.save();
     }
     info!("[ui] ayarlar güncellendi");
     state::enqueue_js("window.showSaved && window.showSaved()".into());

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -112,13 +112,18 @@ impl PayloadAssembler {
     /// Onaylanmayan (örn. Bytes olup bilinmeyen) bir payload'ı temizler.
     ///
     /// Açıksa dosya kulpunu düşürür ve yarım yazılmış `.part` dosyasını siler.
+    /// Hiç chunk gelmemiş pending destination kayıtları için de diskteki
+    /// 0-bayt placeholder'ı siler — aksi halde iptal sonrası indirme
+    /// klasöründe sahibsiz sıfır bayt dosyalar birikir (review-18 MED).
     #[allow(dead_code)]
     pub fn cancel(&mut self, payload_id: i64) {
         self.bytes_buffers.remove(&payload_id);
         if let Some(sink) = self.file_sinks.remove(&payload_id) {
             remove_partial_file(&sink.path);
         }
-        self.pending_destinations.remove(&payload_id);
+        if let Some(dest) = self.pending_destinations.remove(&payload_id) {
+            remove_partial_file(&dest.path);
+        }
     }
 
     /// Belirli süreden uzun sessiz kalmış partial'ları düşürür.
@@ -284,6 +289,43 @@ impl PayloadAssembler {
             if total_size < 0 {
                 bail!("total_size negatif: {}", total_size);
             }
+            // Quick Share pratikte 1 TiB'den büyük tek dosya göndermez —
+            // 1 TiB üstü değer neredeyse kesin kötü niyetli / broken peer.
+            // Bu sınırı koymadan `(written*100)/total` progress aritmetiği ve
+            // `i64 → u64` cast'lerde sürpriz davranışlara yol açar.
+            const MAX_FILE_BYTES: i64 = 1 << 40; // 1 TiB
+            if total_size > MAX_FILE_BYTES {
+                bail!(
+                    "total_size absürt büyük: {} bayt (>1 TiB limit)",
+                    total_size
+                );
+            }
+            // SECURITY: Hedef yol symlink ise saldırgan (veya TOCTOU race ile
+            // üçüncü taraf) placeholder'ı symlink'e çevirip bizi keyfi dosyaya
+            // yazmaya zorlayabilir. `symlink_metadata` link'i resolve etmez;
+            // symlink tespit edersek işlemi iptal ederiz.
+            // NOT: Placeholder'ın olmaması yasal bir durum (test/legacy kod
+            // `register_file_destination`'ı bir path ile çağırıp diske
+            // placeholder yaratmadan `ingest` çağırabilir — `create:true`
+            // fallback'i bu yol için mevcut). Bu yüzden NotFound'u tolere et.
+            match std::fs::symlink_metadata(&dest.path) {
+                Ok(md) => {
+                    if md.file_type().is_symlink() {
+                        bail!(
+                            "hedef symlink — reddedildi (TOCTOU koruması): {}",
+                            dest.path.display()
+                        );
+                    }
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                    // Placeholder yok → legacy/test kodu; `create:true` aşağıda yaratacak.
+                }
+                Err(e) => {
+                    return Err(anyhow::Error::from(e)).with_context(|| {
+                        format!("hedef metadata okunamadı: {}", dest.path.display())
+                    });
+                }
+            }
             let file = std::fs::OpenOptions::new()
                 .write(true)
                 .create(true)
@@ -342,7 +384,17 @@ impl PayloadAssembler {
                     sink.total_size
                 );
             }
-            sink.file.sync_all().ok();
+            // Durability: sync_all hatası yutulursa peer'a başarı mesajı
+            // gönderebiliriz ama disk'te veri henüz yok → crash durumunda
+            // dosya boş/yarım kalır. Hatayı propagate et ki user retry'la
+            // anlamlı bir sonuç alabilsin.
+            sink.file.sync_all().with_context(|| {
+                format!(
+                    "dosya senkronize edilemedi: id={} path={}",
+                    id,
+                    sink.path.display()
+                )
+            })?;
             let digest = sink.hasher.finalize();
             let mut sha256 = [0u8; 32];
             sha256.copy_from_slice(&digest);
@@ -538,21 +590,25 @@ mod tests {
     #[test]
     fn cancel_removes_bytes_file_and_pending() {
         let pid = std::process::id();
-        let tmp = std::env::temp_dir().join(format!("hekadrop-cancel-test-{}.part", pid));
+        let rnd: u32 = rand::random();
+        let tmp = std::env::temp_dir().join(format!("hekadrop-cancel-test-{}-{}.part", pid, rnd));
         let _ = std::fs::remove_file(&tmp);
         let mut a = PayloadAssembler::new();
 
         // bytes buffer
         a.ingest(&make_frame(1, PbPayloadType::Bytes, b"x", false))
             .unwrap();
-        // file sink
+        // file sink (total_size=big enough for one-byte body)
         a.register_file_destination(2, tmp.clone()).unwrap();
-        a.ingest(&make_frame(2, PbPayloadType::File, b"y", false))
+        a.ingest(&make_frame_total(2, PbPayloadType::File, b"y", false, 10))
             .unwrap();
         assert!(tmp.exists());
-        // pending destination
-        let tmp2 = std::env::temp_dir().join(format!("hekadrop-cancel-pending-{}.part", pid));
-        a.register_file_destination(3, tmp2).unwrap();
+        // pending destination — review-18 MED: cancel artık placeholder'ı da silmeli.
+        let tmp2 =
+            std::env::temp_dir().join(format!("hekadrop-cancel-pending-{}-{}.part", pid, rnd));
+        // Diskte sıfır bayt placeholder simulate et (unique_downloads_path davranışı).
+        std::fs::write(&tmp2, b"").expect("placeholder yarat");
+        a.register_file_destination(3, tmp2.clone()).unwrap();
 
         assert_eq!(a.partial_count(), 3);
         a.cancel(1);
@@ -563,6 +619,68 @@ mod tests {
             !tmp.exists(),
             "cancel file sink'in diskteki dosyasını silmeli"
         );
+        assert!(
+            !tmp2.exists(),
+            "cancel pending destination placeholder'ını diskten silmeli"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn ingest_file_symlink_destination_reddeder() {
+        // review-18: dest.path symlink'e dönüştüyse (TOCTOU) ingest_file
+        // reddetmelidir.
+        let pid = std::process::id();
+        let rnd: u32 = rand::random();
+        let real = std::env::temp_dir().join(format!("hekadrop-symlink-real-{}-{}.bin", pid, rnd));
+        let link = std::env::temp_dir().join(format!("hekadrop-symlink-link-{}-{}.bin", pid, rnd));
+        let _ = std::fs::remove_file(&real);
+        let _ = std::fs::remove_file(&link);
+        std::fs::write(&real, b"").expect("real yarat");
+        std::os::unix::fs::symlink(&real, &link).expect("symlink yarat");
+
+        let mut a = PayloadAssembler::new();
+        a.register_file_destination(42, link.clone()).unwrap();
+        let err = a
+            .ingest(&make_frame_total(42, PbPayloadType::File, b"y", false, 10))
+            .expect_err("symlink hedef reddedilmeli");
+        assert!(
+            err.to_string().contains("symlink"),
+            "hata mesajı symlink belirtmeli, aldı: {}",
+            err
+        );
+
+        let _ = std::fs::remove_file(&link);
+        let _ = std::fs::remove_file(&real);
+    }
+
+    #[test]
+    fn ingest_file_total_size_absurd_buyuk_reddeder() {
+        // review-18: 1 TiB üstü bildirilen dosya başlamadan reddedilmeli.
+        let pid = std::process::id();
+        let rnd: u32 = rand::random();
+        let tmp = std::env::temp_dir().join(format!("hekadrop-absurd-{}-{}.bin", pid, rnd));
+        let _ = std::fs::remove_file(&tmp);
+        std::fs::write(&tmp, b"").expect("placeholder");
+
+        let mut a = PayloadAssembler::new();
+        a.register_file_destination(42, tmp.clone()).unwrap();
+        let absurd = (1i64 << 40) + 1; // 1 TiB + 1
+        let err = a
+            .ingest(&make_frame_total(
+                42,
+                PbPayloadType::File,
+                b"x",
+                false,
+                absurd,
+            ))
+            .expect_err("absurd total_size reddedilmeli");
+        assert!(
+            err.to_string().contains("absürt") || err.to_string().contains("1 TiB"),
+            "hata mesajı limit belirtmeli, aldı: {}",
+            err
+        );
+        let _ = std::fs::remove_file(&tmp);
     }
 
     #[test]
@@ -574,8 +692,14 @@ mod tests {
         a.register_file_destination(200, tmp.clone()).unwrap();
         // İki chunk'lı dosya — total_size=6 (foo+bar). Her iki frame aynı
         // total'ı deklare etmeli yoksa overrun/truncation validasyonu patlar.
-        a.ingest(&make_frame_total(200, PbPayloadType::File, b"foo", false, 6))
-            .unwrap();
+        a.ingest(&make_frame_total(
+            200,
+            PbPayloadType::File,
+            b"foo",
+            false,
+            6,
+        ))
+        .unwrap();
         let out = a
             .ingest(&make_frame_total(200, PbPayloadType::File, b"bar", true, 6))
             .unwrap()
@@ -649,8 +773,7 @@ mod tests {
     #[test]
     fn file_overrun_reddedilir() {
         // total_size=5 iken 10 bayt body → overrun hatası, disk sızıntısı yok.
-        let tmp = std::env::temp_dir()
-            .join(format!("hd-overrun-{}.bin", std::process::id()));
+        let tmp = std::env::temp_dir().join(format!("hd-overrun-{}.bin", std::process::id()));
         let _ = std::fs::remove_file(&tmp);
         let mut a = PayloadAssembler::new();
         a.register_file_destination(1, tmp.clone()).unwrap();
@@ -665,8 +788,7 @@ mod tests {
     fn file_last_chunk_truncation_reddedilir() {
         // last_chunk=true geldiğinde written != total_size → hata.
         // Peer 10 bayt deklare edip 3 bayt + last_chunk yollayamaz.
-        let tmp = std::env::temp_dir()
-            .join(format!("hd-trunc-{}.bin", std::process::id()));
+        let tmp = std::env::temp_dir().join(format!("hd-trunc-{}.bin", std::process::id()));
         let _ = std::fs::remove_file(&tmp);
         let mut a = PayloadAssembler::new();
         a.register_file_destination(7, tmp.clone()).unwrap();
@@ -678,8 +800,7 @@ mod tests {
 
     #[test]
     fn file_negative_total_size_reddedilir() {
-        let tmp = std::env::temp_dir()
-            .join(format!("hd-negtotal-{}.bin", std::process::id()));
+        let tmp = std::env::temp_dir().join(format!("hd-negtotal-{}.bin", std::process::id()));
         let _ = std::fs::remove_file(&tmp);
         let mut a = PayloadAssembler::new();
         a.register_file_destination(9, tmp.clone()).unwrap();

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -15,7 +15,7 @@
 use crate::location::nearby::connections::{
     payload_transfer_frame::payload_header::PayloadType, PayloadTransferFrame,
 };
-use anyhow::{anyhow, Context, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::fs::File;
@@ -58,6 +58,8 @@ struct FileSink {
     file: File,
     path: PathBuf,
     total_size: i64,
+    /// Toplam yazılmış bayt — `total_size`'a karşı overrun doğrulaması için.
+    written: i64,
     hasher: Sha256,
     last_chunk_at: Instant,
 }
@@ -82,7 +84,21 @@ impl PayloadAssembler {
 
     /// Introduction sırasında onaylanan dosya için diskteki hedef yolu kaydeder.
     /// İlk chunk geldiğinde bu yol kullanılarak dosya `std::fs::File::create` ile açılır.
-    pub fn register_file_destination(&mut self, payload_id: i64, path: PathBuf) {
+    ///
+    /// SECURITY: Aynı `payload_id` ile iki kez kayıt → önceki hedef **silent
+    /// overwrite** olurdu (HashMap::insert). Saldırgan Introduction'da
+    /// `id=X → legit.pdf` + aynı Introduction'da `id=X → _evil.sh` yollayarak
+    /// UI'ın kullanıcıya `legit.pdf`'i göstermesini ama gerçekte `_evil.sh`'in
+    /// yazılmasını sağlayabilirdi. İkinci register artık hata döner.
+    pub fn register_file_destination(&mut self, payload_id: i64, path: PathBuf) -> Result<()> {
+        if self.pending_destinations.contains_key(&payload_id)
+            || self.file_sinks.contains_key(&payload_id)
+        {
+            bail!(
+                "duplicate payload_id={} — destination overwrite reddedildi",
+                payload_id
+            );
+        }
         self.pending_destinations.insert(
             payload_id,
             PendingDest {
@@ -90,6 +106,7 @@ impl PayloadAssembler {
                 registered_at: Instant::now(),
             },
         );
+        Ok(())
     }
 
     /// Onaylanmayan (örn. Bytes olup bilinmeyen) bir payload'ı temizler.
@@ -250,17 +267,34 @@ impl PayloadAssembler {
         use std::collections::hash_map::Entry;
 
         // İlk chunk: dosyayı aç.
+        // NOT: `connection::unique_downloads_path` dosyayı `create_new(true)`
+        // ile **placeholder** olarak zaten oluşturmuş oldu (TOCTOU fix).
+        // Burada aynı path'i `write(true).truncate(true)` ile yeniden açıyoruz
+        // — aynı inode, sıfırdan yazma. Eğer placeholder yoksa (test kodu,
+        // legacy çağrı) create'e fallback ediyoruz.
         if let Entry::Vacant(slot) = self.file_sinks.entry(id) {
             let dest = self
                 .pending_destinations
                 .remove(&id)
                 .ok_or_else(|| anyhow!("payload_id={} için destination kayıtlı değil", id))?;
-            let file = File::create(&dest.path)
-                .with_context(|| format!("dosya oluşturulamadı: {}", dest.path.display()))?;
+            // SECURITY: `total_size` negatif ya da absürt büyükse en başta reddet.
+            // Aksi halde `(written*100)/total` integer aritmetiği taşar ve
+            // saldırgan terabaytlık disk doldurma isteği UI/progress yoluyla
+            // sessizce kabul edilir.
+            if total_size < 0 {
+                bail!("total_size negatif: {}", total_size);
+            }
+            let file = std::fs::OpenOptions::new()
+                .write(true)
+                .create(true)
+                .truncate(true)
+                .open(&dest.path)
+                .with_context(|| format!("dosya açılamadı: {}", dest.path.display()))?;
             slot.insert(FileSink {
                 file,
                 path: dest.path,
                 total_size,
+                written: 0,
                 hasher: Sha256::new(),
                 last_chunk_at: Instant::now(),
             });
@@ -271,8 +305,24 @@ impl PayloadAssembler {
                 .file_sinks
                 .get_mut(&id)
                 .ok_or_else(|| anyhow!("file_sink kayıp: id={}", id))?;
+            // SECURITY: Cumulative overrun koruması — saldırgan `total_size=10`
+            // deklare edip gigabaytlarca chunk yollayarak disk doldurabilir.
+            let body_len = body.len() as i64;
+            let new_written = sink
+                .written
+                .checked_add(body_len)
+                .ok_or_else(|| anyhow!("yazım toplamı taştı (id={})", id))?;
+            if new_written > sink.total_size {
+                bail!(
+                    "payload overrun: id={} written={} > total_size={}",
+                    id,
+                    new_written,
+                    sink.total_size
+                );
+            }
             sink.file.write_all(body).context("disk yazma")?;
             sink.hasher.update(body);
+            sink.written = new_written;
             sink.last_chunk_at = Instant::now();
         }
 
@@ -281,6 +331,17 @@ impl PayloadAssembler {
                 .file_sinks
                 .remove(&id)
                 .ok_or_else(|| anyhow!("son chunk ama sink yok: id={}", id))?;
+            // SECURITY: Peer `last_chunk=true` gönderip yarım dosyayı tamamlanmış
+            // gibi onaylatabilir (silent truncation). Toplam byte sayısı
+            // bildirilen total_size ile eşleşmezse reddet.
+            if sink.written != sink.total_size {
+                bail!(
+                    "truncated payload: id={} written={} total_size={}",
+                    id,
+                    sink.written,
+                    sink.total_size
+                );
+            }
             sink.file.sync_all().ok();
             let digest = sink.hasher.finalize();
             let mut sha256 = [0u8; 32];
@@ -322,12 +383,22 @@ mod tests {
 
     /// Test helper: minimal `PayloadTransferFrame` inşa et.
     fn make_frame(id: i64, ptype: PbPayloadType, body: &[u8], last: bool) -> PayloadTransferFrame {
+        make_frame_total(id, ptype, body, last, body.len() as i64)
+    }
+
+    fn make_frame_total(
+        id: i64,
+        ptype: PbPayloadType,
+        body: &[u8],
+        last: bool,
+        total_size: i64,
+    ) -> PayloadTransferFrame {
         PayloadTransferFrame {
             packet_type: None,
             payload_header: Some(PayloadHeader {
                 id: Some(id),
                 r#type: Some(ptype as i32),
-                total_size: Some(body.len() as i64),
+                total_size: Some(total_size),
                 is_sensitive: None,
                 file_name: None,
                 parent_folder: None,
@@ -409,7 +480,7 @@ mod tests {
         let _ = std::fs::remove_file(&tmp);
 
         let mut a = PayloadAssembler::new();
-        a.register_file_destination(100, tmp.clone());
+        a.register_file_destination(100, tmp.clone()).unwrap();
         // İlk (ve sadece) chunk: dosya açılır, disk'e yazılır, last=false.
         let f = make_frame(100, PbPayloadType::File, b"partial-data", false);
         a.ingest(&f).unwrap();
@@ -429,7 +500,7 @@ mod tests {
         // Dosya oluşturmuyoruz; sadece path kaydı GC'de silinecek.
         let tmp =
             std::env::temp_dir().join(format!("hekadrop-pending-test-{}.part", std::process::id()));
-        a.register_file_destination(55, tmp);
+        a.register_file_destination(55, tmp).unwrap();
         assert_eq!(a.partial_count(), 1);
 
         std::thread::sleep(Duration::from_millis(15));
@@ -475,13 +546,13 @@ mod tests {
         a.ingest(&make_frame(1, PbPayloadType::Bytes, b"x", false))
             .unwrap();
         // file sink
-        a.register_file_destination(2, tmp.clone());
+        a.register_file_destination(2, tmp.clone()).unwrap();
         a.ingest(&make_frame(2, PbPayloadType::File, b"y", false))
             .unwrap();
         assert!(tmp.exists());
         // pending destination
         let tmp2 = std::env::temp_dir().join(format!("hekadrop-cancel-pending-{}.part", pid));
-        a.register_file_destination(3, tmp2);
+        a.register_file_destination(3, tmp2).unwrap();
 
         assert_eq!(a.partial_count(), 3);
         a.cancel(1);
@@ -500,12 +571,13 @@ mod tests {
             std::env::temp_dir().join(format!("hekadrop-finalize-test-{}.bin", std::process::id()));
         let _ = std::fs::remove_file(&tmp);
         let mut a = PayloadAssembler::new();
-        a.register_file_destination(200, tmp.clone());
-        // İki chunk'lı dosya.
-        a.ingest(&make_frame(200, PbPayloadType::File, b"foo", false))
+        a.register_file_destination(200, tmp.clone()).unwrap();
+        // İki chunk'lı dosya — total_size=6 (foo+bar). Her iki frame aynı
+        // total'ı deklare etmeli yoksa overrun/truncation validasyonu patlar.
+        a.ingest(&make_frame_total(200, PbPayloadType::File, b"foo", false, 6))
             .unwrap();
         let out = a
-            .ingest(&make_frame(200, PbPayloadType::File, b"bar", true))
+            .ingest(&make_frame_total(200, PbPayloadType::File, b"bar", true, 6))
             .unwrap()
             .expect("son chunk tamamlar");
         match out {
@@ -517,9 +589,10 @@ mod tests {
             } => {
                 assert_eq!(id, 200);
                 assert_eq!(path, tmp);
-                // "bar" frame'in total_size'ı 3 — son gelen header kazanır
-                // (orijinal davranış, dokunmuyoruz).
-                assert_eq!(total_size, 3);
+                // Her iki frame de total_size=6 ("foo"+"bar") deklare ediyor
+                // (overrun validasyonu için zorunlu). İlk chunk'ta açılan
+                // FileSink.total_size korunur.
+                assert_eq!(total_size, 6);
                 // "foobar"ın beklenen SHA-256'sı
                 let expected = {
                     let mut h = Sha256::new();
@@ -555,5 +628,63 @@ mod tests {
         // 10 yıl gibi absürt timeout.
         let n = a.gc(Duration::from_secs(60 * 60 * 24 * 365 * 10));
         assert_eq!(n, 0, "çok büyük timeout'ta hiçbir şey silinmemeli");
+    }
+
+    // ---- SECURITY: payload overrun + truncation + duplicate id guards ----
+
+    #[test]
+    fn duplicate_payload_id_reddedilir() {
+        // Saldırgan Introduction'da aynı id ile iki FileMetadata yollarsa
+        // ikinci register_file_destination silent overwrite yerine hata dönmeli.
+        let mut a = PayloadAssembler::new();
+        let p1 = std::env::temp_dir().join(format!("hd-dup1-{}.bin", std::process::id()));
+        let p2 = std::env::temp_dir().join(format!("hd-dup2-{}.bin", std::process::id()));
+        assert!(a.register_file_destination(42, p1.clone()).is_ok());
+        let err = a
+            .register_file_destination(42, p2.clone())
+            .expect_err("duplicate red");
+        assert!(err.to_string().contains("duplicate"));
+    }
+
+    #[test]
+    fn file_overrun_reddedilir() {
+        // total_size=5 iken 10 bayt body → overrun hatası, disk sızıntısı yok.
+        let tmp = std::env::temp_dir()
+            .join(format!("hd-overrun-{}.bin", std::process::id()));
+        let _ = std::fs::remove_file(&tmp);
+        let mut a = PayloadAssembler::new();
+        a.register_file_destination(1, tmp.clone()).unwrap();
+        let bloat = vec![0xCDu8; 10];
+        let f = make_frame_total(1, PbPayloadType::File, &bloat, false, 5);
+        let err = a.ingest(&f).expect_err("overrun red");
+        assert!(err.to_string().contains("overrun"));
+        let _ = std::fs::remove_file(&tmp);
+    }
+
+    #[test]
+    fn file_last_chunk_truncation_reddedilir() {
+        // last_chunk=true geldiğinde written != total_size → hata.
+        // Peer 10 bayt deklare edip 3 bayt + last_chunk yollayamaz.
+        let tmp = std::env::temp_dir()
+            .join(format!("hd-trunc-{}.bin", std::process::id()));
+        let _ = std::fs::remove_file(&tmp);
+        let mut a = PayloadAssembler::new();
+        a.register_file_destination(7, tmp.clone()).unwrap();
+        let f = make_frame_total(7, PbPayloadType::File, b"abc", true, 10);
+        let err = a.ingest(&f).expect_err("truncation red");
+        assert!(err.to_string().contains("truncated"));
+        let _ = std::fs::remove_file(&tmp);
+    }
+
+    #[test]
+    fn file_negative_total_size_reddedilir() {
+        let tmp = std::env::temp_dir()
+            .join(format!("hd-negtotal-{}.bin", std::process::id()));
+        let _ = std::fs::remove_file(&tmp);
+        let mut a = PayloadAssembler::new();
+        a.register_file_destination(9, tmp.clone()).unwrap();
+        let f = make_frame_total(9, PbPayloadType::File, b"a", false, -1);
+        let err = a.ingest(&f).expect_err("negatif total red");
+        assert!(err.to_string().contains("negatif"));
     }
 }

--- a/src/secure.rs
+++ b/src/secure.rs
@@ -37,8 +37,15 @@ impl SecureCtx {
         }
     }
 
-    pub fn encrypt(&mut self, inner_plaintext: &[u8]) -> Vec<u8> {
-        self.server_seq += 1;
+    pub fn encrypt(&mut self, inner_plaintext: &[u8]) -> Result<Vec<u8>> {
+        // SECURITY: `i32` sequence counter overflow — release build'de wrap
+        // (negatif sayı → peer reject), debug'da panic. Pratikte 2^31 mesaj
+        // gerekir ama saldırgan crafted peer + debug build senaryosu için
+        // garantili olmak adına checked_add kullanılır.
+        self.server_seq = self
+            .server_seq
+            .checked_add(1)
+            .ok_or_else(|| anyhow!("server_seq overflow (i32 sınırı)"))?;
         let d2d = DeviceToDeviceMessage {
             sequence_number: Some(self.server_seq),
             message: Some(inner_plaintext.to_vec()),
@@ -71,7 +78,7 @@ impl SecureCtx {
             header_and_body: hb_bytes,
             signature: sig.to_vec(),
         };
-        smsg.encode_to_vec()
+        Ok(smsg.encode_to_vec())
     }
 
     #[cfg(test)]
@@ -110,7 +117,13 @@ impl SecureCtx {
 
         let d2d = DeviceToDeviceMessage::decode(&plaintext[..])?;
         let seq = d2d.sequence_number.ok_or_else(|| anyhow!("sequence yok"))?;
-        let expected = self.client_seq + 1;
+        // SECURITY: Saldırgan crafted peer `sequence_number = i32::MAX`
+        // gönderirse `self.client_seq + 1` bir sonraki frame'de taşar —
+        // debug build'de panic. `checked_add` ile güvenli bail.
+        let expected = self
+            .client_seq
+            .checked_add(1)
+            .ok_or_else(|| anyhow!("client_seq overflow (i32 sınırı)"))?;
         if seq != expected {
             // State'i bozma — başarısız decrypt sonrası counter artmamalı,
             // aksi halde sıralı bir retry'ı bir daha reddederdik.
@@ -145,7 +158,7 @@ mod tests {
     fn encrypt_decrypt_roundtrip() {
         let (mut a, mut b) = make_pair();
         let plaintext = b"merhaba dunya! gizli mesaj".to_vec();
-        let encrypted = a.encrypt(&plaintext);
+        let encrypted = a.encrypt(&plaintext).unwrap();
         let decrypted = b.decrypt(&encrypted).expect("decrypt");
         assert_eq!(decrypted, plaintext);
     }
@@ -155,7 +168,7 @@ mod tests {
         let (mut a, mut b) = make_pair();
         for i in 1..=5 {
             let msg = format!("mesaj {}", i);
-            let enc = a.encrypt(msg.as_bytes());
+            let enc = a.encrypt(msg.as_bytes()).unwrap();
             let dec = b.decrypt(&enc).expect("decrypt");
             assert_eq!(dec, msg.as_bytes());
         }
@@ -166,8 +179,8 @@ mod tests {
     #[test]
     fn yanlis_sira_reddedilir() {
         let (mut a, mut b) = make_pair();
-        let e1 = a.encrypt(b"first");
-        let e2 = a.encrypt(b"second");
+        let e1 = a.encrypt(b"first").unwrap();
+        let e2 = a.encrypt(b"second").unwrap();
         // İkinciyi önce decode etmeye çalış → sequence uyumsuzluğu
         assert!(b.decrypt(&e2).is_err());
         // Birinciyi yine alabiliriz (client_seq = 0 hâlâ → 1 bekler)
@@ -177,10 +190,19 @@ mod tests {
     #[test]
     fn bozulmus_hmac_reddedilir() {
         let (mut a, mut b) = make_pair();
-        let mut enc = a.encrypt(b"secret");
+        let mut enc = a.encrypt(b"secret").unwrap();
         // Son baytı bozup HMAC doğrulamasını patlat
         let last = enc.len() - 1;
         enc[last] ^= 0xFF;
         assert!(b.decrypt(&enc).is_err());
+    }
+
+    #[test]
+    fn encrypt_overflow_guardlu() {
+        // server_seq = i32::MAX iken encrypt taşma hatası döner, panic etmez.
+        let (mut a, _b) = make_pair();
+        a.server_seq = i32::MAX;
+        let err = a.encrypt(b"x").unwrap_err();
+        assert!(err.to_string().contains("overflow"));
     }
 }

--- a/src/sender.rs
+++ b/src/sender.rs
@@ -134,7 +134,8 @@ pub async fn send(req: SendRequest) -> Result<()> {
     // 4) Plain ConnectionResponse exchange
     let our_resp = connection::build_connection_response_accept();
     frame::write_frame(&mut socket, &our_resp.encode_to_vec()).await?;
-    let peer_resp_raw = frame::read_frame(&mut socket).await?;
+    let peer_resp_raw =
+        frame::read_frame_timeout(&mut socket, frame::HANDSHAKE_READ_TIMEOUT).await?;
     let _peer_resp = OfflineFrame::decode(peer_resp_raw.as_ref())?;
     info!("[sender] ConnectionResponse değişimi tamam");
 
@@ -172,7 +173,7 @@ pub async fn send(req: SendRequest) -> Result<()> {
             bail!("kullanıcı aktarımı iptal etti");
         }
 
-        let raw = frame::read_frame(&mut socket).await?;
+        let raw = frame::read_frame_timeout(&mut socket, frame::STEADY_READ_TIMEOUT).await?;
         let inner = ctx.decrypt(&raw)?;
         let offline = OfflineFrame::decode(inner.as_ref())?;
         let Some(v1) = offline.v1 else { continue };
@@ -276,13 +277,16 @@ pub async fn send(req: SendRequest) -> Result<()> {
                         // Stats'i progress güncellemesinden ÖNCE yaz — böylece UI
                         // Completed'ı gördüğünde istatistikler zaten tutarlı olur.
                         {
+                            // Save'i lock dışında çalıştır — yavaş diskte UI dondurmasın.
                             let st = state::get();
-                            let mut s = st.stats.write();
-                            for plan in &plans {
-                                // size i64 ve >= 0; `as u64` güvenli. Defansif clamp:
-                                s.record_sent(&peer_label, plan.size.max(0) as u64);
-                            }
-                            let _ = s.save();
+                            let snap = {
+                                let mut s = st.stats.write();
+                                for plan in &plans {
+                                    s.record_sent(&peer_label, plan.size.max(0) as u64);
+                                }
+                                s.clone()
+                            };
+                            let _ = snap.save();
                         }
                         // Bug #31: Completed gösteriminden sonra birkaç saniye içinde
                         // otomatik Idle'a dönsün — kullanıcı pencereyi sonra açtığında
@@ -311,7 +315,7 @@ pub async fn send(req: SendRequest) -> Result<()> {
                         ..Default::default()
                     }),
                 };
-                let enc = ctx.encrypt(&reply.encode_to_vec());
+                let enc = ctx.encrypt(&reply.encode_to_vec())?;
                 frame::write_frame(&mut socket, &enc).await?;
             }
             Some(v1_frame::FrameType::Disconnection) => {
@@ -349,7 +353,7 @@ async fn send_file_chunks(
         let n = file.read(&mut buf).await?;
         if n == 0 {
             let last = wrap_payload_transfer(payload_id, file_size, offset, 1, Vec::new());
-            let enc = ctx.encrypt(&last.encode_to_vec());
+            let enc = ctx.encrypt(&last.encode_to_vec())?;
             frame::write_frame(socket, &enc).await?;
             let digest = hasher.finalize();
             info!(
@@ -362,7 +366,7 @@ async fn send_file_chunks(
         hasher.update(&buf[..n]);
         let body = buf[..n].to_vec();
         let wrapped = wrap_payload_transfer(payload_id, file_size, offset, 0, body);
-        let enc = ctx.encrypt(&wrapped.encode_to_vec());
+        let enc = ctx.encrypt(&wrapped.encode_to_vec())?;
         frame::write_frame(socket, &enc).await?;
         offset += n as i64;
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -195,6 +195,71 @@ pub fn config_path() -> PathBuf {
     crate::platform::config_dir().join("config.json")
 }
 
+/// Tmp dosya scope-guard'ı — Drop anında `path`'i sessizce siler.
+///
+/// `atomic_write` içinde tmp dosya yaratılır; başarılı `rename`'den sonra
+/// `defuse()` çağrılarak silinme iptal edilir. Aksi takdirde (write hatası,
+/// rename hatası, paniğe neden olan bir hata) Drop çalışır ve tmp diskte
+/// sızmaz — review-18 (MED) cleanup gereksinimi.
+struct TmpCleanup {
+    path: Option<std::path::PathBuf>,
+}
+
+impl TmpCleanup {
+    fn new(path: std::path::PathBuf) -> Self {
+        Self { path: Some(path) }
+    }
+    /// Temizliği iptal et — rename başarılı olduğunda çağrılır.
+    fn defuse(mut self) {
+        self.path = None;
+    }
+}
+
+impl Drop for TmpCleanup {
+    fn drop(&mut self) {
+        if let Some(p) = self.path.take() {
+            let _ = std::fs::remove_file(p);
+        }
+    }
+}
+
+/// Cross-platform atomik replace. Unix'te `fs::rename` zaten atomik
+/// (O_RENAME) ve destination mevcutsa üzerine yazar. Windows'ta
+/// `std::fs::rename` **destination varsa hata verir** — her `save()` ikinci
+/// çağrıdan itibaren sessizce başarısız olurdu. `MoveFileExW` +
+/// `MOVEFILE_REPLACE_EXISTING` bu durumu çözer; `MOVEFILE_WRITE_THROUGH`
+/// direktori entry'sinin diske flush'unu garantiler.
+#[cfg(unix)]
+fn replace_atomic(tmp: &std::path::Path, dst: &std::path::Path) -> std::io::Result<()> {
+    std::fs::rename(tmp, dst)
+}
+
+#[cfg(windows)]
+fn replace_atomic(tmp: &std::path::Path, dst: &std::path::Path) -> std::io::Result<()> {
+    use windows::core::HSTRING;
+    use windows::Win32::Storage::FileSystem::{
+        MoveFileExW, MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH,
+    };
+    unsafe {
+        MoveFileExW(
+            &HSTRING::from(tmp.as_os_str()),
+            Some(&HSTRING::from(dst.as_os_str())),
+            MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
+        )
+        .map_err(std::io::Error::other)
+    }
+}
+
+/// Process-wide disk write lock — review-18 (HIGH) save-snapshot reordering.
+///
+/// İki concurrent `save()` çağrısı (ör. connection.rs Stats + sender.rs Stats
+/// aynı anda) diske yazılırken, yazım sırası ters dönebilirdi: geç başlayan
+/// save önce bitip eski snapshot'ı diske bırakabilirdi (kernel scheduler,
+/// disk I/O queue vb.). Settings RwLock'u artık lock dışında save yaptığımız
+/// için koruma sağlamıyor. Bu mutex her `save()`'i FIFO sırasına sokar.
+/// Settings ve Stats ayrı hot-path ancak tek bir lock yeterli ve kolay.
+static SETTINGS_DISK_LOCK: parking_lot::Mutex<()> = parking_lot::Mutex::new(());
+
 /// Atomik dosya yazma — tmp-file + rename pattern.
 ///
 /// **Neden:** `fs::write` traditionally `O_TRUNC | O_CREAT` açar; crash/panic
@@ -202,13 +267,19 @@ pub fn config_path() -> PathBuf {
 /// `Settings::default()`'e düşer, kullanıcının trusted cihaz listesi silinmiş
 /// gibi görünür). `rename` POSIX'te atomik — eski içerik ya olduğu gibi kalır
 /// ya da tamamen yeni içerikle değişir; yarım durum yoktur. Windows'ta
-/// `ReplaceFile`/`MoveFileEx` best-effort atomik (aynı volume şart).
+/// `MoveFileExW(MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH)` ile
+/// best-effort atomik replace (aynı volume şart).
 ///
-/// Aynı dizinde unique suffix'li tmp file yaratıp `persist` benzeri semantik
-/// sağlar; external `tempfile` crate'ine ihtiyaç yok çünkü süreç-içi paralel
-/// çağrı settings RwLock ile serileştirilmiş (bkz. main.rs call pattern).
+/// Tmp dosya adı `pid + rand u64` ile benzersizdir — aynı süreçte iki thread
+/// aynı anda `save()` çağırırsa da tmp dosya adları çakışmaz. Scope-guard
+/// (`TmpCleanup`) başarısız yazımlarda sızıntıyı önler. `sync_all` hataları
+/// artık yutulmuyor (durability garantisi propagate edilir).
 pub(crate) fn atomic_write(path: &std::path::Path, data: &[u8]) -> std::io::Result<()> {
+    use rand::RngCore;
     use std::io::Write as _;
+
+    let _disk_guard = SETTINGS_DISK_LOCK.lock();
+
     let parent = path.parent().ok_or_else(|| {
         std::io::Error::new(std::io::ErrorKind::InvalidInput, "path'ın parent'ı yok")
     })?;
@@ -216,28 +287,39 @@ pub(crate) fn atomic_write(path: &std::path::Path, data: &[u8]) -> std::io::Resu
         .file_name()
         .and_then(|s| s.to_str())
         .unwrap_or("config.json");
-    let tmp = parent.join(format!(
-        ".{}.{}.tmp",
-        file_name,
-        std::process::id()
-    ));
-    {
-        let mut f = std::fs::OpenOptions::new()
+
+    // Unique tmp adı: pid + rand u64 + create_new(true) retry.
+    // create_new başarısız olursa (AlreadyExists) yeni rand ile tekrar dene;
+    // başka I/O hatalarında erken çık.
+    let pid = std::process::id();
+    let mut attempts = 0u32;
+    let (mut file, tmp_path) = loop {
+        attempts += 1;
+        let r = rand::thread_rng().next_u64();
+        let tmp = parent.join(format!(".{}.{}.{:016x}.tmp", file_name, pid, r));
+        match std::fs::OpenOptions::new()
             .write(true)
-            .create(true)
-            .truncate(true)
-            .open(&tmp)?;
-        f.write_all(data)?;
-        f.sync_all().ok();
-    }
-    match std::fs::rename(&tmp, path) {
-        Ok(()) => Ok(()),
-        Err(e) => {
-            // Rename başarısızsa tmp'yi temizle — disk sızıntısını önle.
-            let _ = std::fs::remove_file(&tmp);
-            Err(e)
+            .create_new(true)
+            .open(&tmp)
+        {
+            Ok(f) => break (f, tmp),
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists && attempts < 8 => continue,
+            Err(e) => return Err(e),
         }
-    }
+    };
+
+    // Drop anında sızıntı engelle. Rename başarılı olursa defuse().
+    let cleanup = TmpCleanup::new(tmp_path.clone());
+
+    file.write_all(data)?;
+    // Durability: sync_all hatasını yutmuyoruz — kullanıcı güvenli yazımı
+    // talep etti; diskten dönüş başarısızsa save çağrısı hata dönmeli.
+    file.sync_all()?;
+    drop(file);
+
+    replace_atomic(&tmp_path, path)?;
+    cleanup.defuse();
+    Ok(())
 }
 
 /// `trusted_devices` alanı için özel deserializer — hem yeni (nesne dizisi)
@@ -528,5 +610,115 @@ mod tests {
         s.add_trusted("B", "");
         let list = s.trusted_display_list();
         assert_eq!(list, vec!["A (id-aaaaa)".to_string(), "B".to_string()]);
+    }
+
+    #[test]
+    fn atomic_write_basariyla_yazar_ve_destination_uzerine_yazar() {
+        // Review-18: Windows'ta `fs::rename` destination varsa hata verir →
+        // Regression guard: ikinci yazımın diski üzerine yazdığını doğrula.
+        let dir = std::env::temp_dir().join(format!(
+            "hekadrop-aw-overwrite-{}-{}",
+            std::process::id(),
+            rand::random::<u32>()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let p = dir.join("target.json");
+        atomic_write(&p, b"first").expect("ilk yazım");
+        atomic_write(&p, b"second").expect("ikinci yazım (overwrite)");
+        let got = std::fs::read(&p).expect("read back");
+        assert_eq!(got, b"second");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn atomic_write_tmp_sizintisi_bırakmaz_basariyla() {
+        // `atomic_write`'tan sonra parent dizinde `.target.json.<pid>.<rand>.tmp`
+        // kalan bir tmp olmamalı — defuse() sonrası dosya rename ile yok olmalı.
+        let dir = std::env::temp_dir().join(format!(
+            "hekadrop-aw-tmp-{}-{}",
+            std::process::id(),
+            rand::random::<u32>()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let p = dir.join("target.json");
+        atomic_write(&p, b"ok").expect("write");
+
+        let leftovers: Vec<_> = std::fs::read_dir(&dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_name().to_string_lossy().ends_with(".tmp"))
+            .collect();
+        assert!(
+            leftovers.is_empty(),
+            "atomic_write sonrası tmp dosya kalmamalı: {:?}",
+            leftovers.iter().map(|e| e.file_name()).collect::<Vec<_>>()
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn atomic_write_hata_durumunda_tmp_temizler() {
+        // Parent dizini olmayan bir path'e yazarsak open() ENOENT atar.
+        // Bu durumda TmpCleanup henüz yaratılmamış olur — alternatif olarak
+        // kötü bir rename hedefi vermeyi dene: geçerli tmp yaratılır ama
+        // rename path'i bir var olmayan dizine işaret eder → rename hata
+        // döner ve TmpCleanup'ın Drop'u tmp'yi silmeli.
+        let dir = std::env::temp_dir().join(format!(
+            "hekadrop-aw-err-{}-{}",
+            std::process::id(),
+            rand::random::<u32>()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        // Geçerli parent ama destination bir sub-dizin altında (yok → rename fail).
+        let bad_dst = dir.join("nope").join("target.json");
+        let res = atomic_write(&bad_dst, b"x");
+        assert!(res.is_err(), "nonexistent parent rename başarısız olmalı");
+
+        // dir içinde hiç .tmp kalmamalı (eğer tmp yaratıldıysa cleanup silmeli).
+        let leftovers: Vec<_> = std::fs::read_dir(&dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_name().to_string_lossy().ends_with(".tmp"))
+            .collect();
+        assert!(
+            leftovers.is_empty(),
+            "hatalı yazım sonrası tmp dosya kalmamalı: {:?}",
+            leftovers.iter().map(|e| e.file_name()).collect::<Vec<_>>()
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn atomic_write_concurrent_ayni_pid_collision_olmaz() {
+        // Review-18 (HIGH): Aynı süreçte iki thread aynı hedef dosyaya save
+        // çağırdığında tmp adı pid'e dayalıysa çakışır. Rand u64 suffix +
+        // SETTINGS_DISK_LOCK bu sorunu çözer; bu test "at least panic etme"
+        // düzeyinde akıllılık kontrolü.
+        use std::sync::Arc;
+        use std::thread;
+        let dir = Arc::new(std::env::temp_dir().join(format!(
+            "hekadrop-aw-conc-{}-{}",
+            std::process::id(),
+            rand::random::<u32>()
+        )));
+        std::fs::create_dir_all(&*dir).unwrap();
+        let target = Arc::new(dir.join("target.json"));
+        let handles: Vec<_> = (0..8)
+            .map(|i| {
+                let t = Arc::clone(&target);
+                thread::spawn(move || {
+                    let payload = format!("thread-{}", i);
+                    for _ in 0..16 {
+                        atomic_write(&t, payload.as_bytes()).expect("atomic_write ok");
+                    }
+                })
+            })
+            .collect();
+        for h in handles {
+            h.join().expect("thread panic etmemeli");
+        }
+        // Son içerik 8 thread'ten birinin yazdığı olmalı; hiç değilse dosya var.
+        assert!(target.exists());
+        let _ = std::fs::remove_dir_all(&*dir);
     }
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -173,7 +173,7 @@ impl Settings {
             std::fs::create_dir_all(parent).ok();
         }
         let json = serde_json::to_string_pretty(self).context("JSON serialize")?;
-        std::fs::write(&path, json).context("config.json yazılamadı")?;
+        atomic_write(&path, json.as_bytes()).context("config.json yazılamadı")?;
         Ok(())
     }
 
@@ -193,6 +193,51 @@ impl Settings {
 
 pub fn config_path() -> PathBuf {
     crate::platform::config_dir().join("config.json")
+}
+
+/// Atomik dosya yazma — tmp-file + rename pattern.
+///
+/// **Neden:** `fs::write` traditionally `O_TRUNC | O_CREAT` açar; crash/panic
+/// sırasında diskte **yarım-yazılmış** JSON kalabilir (Bug: bir sonraki `load()`
+/// `Settings::default()`'e düşer, kullanıcının trusted cihaz listesi silinmiş
+/// gibi görünür). `rename` POSIX'te atomik — eski içerik ya olduğu gibi kalır
+/// ya da tamamen yeni içerikle değişir; yarım durum yoktur. Windows'ta
+/// `ReplaceFile`/`MoveFileEx` best-effort atomik (aynı volume şart).
+///
+/// Aynı dizinde unique suffix'li tmp file yaratıp `persist` benzeri semantik
+/// sağlar; external `tempfile` crate'ine ihtiyaç yok çünkü süreç-içi paralel
+/// çağrı settings RwLock ile serileştirilmiş (bkz. main.rs call pattern).
+pub(crate) fn atomic_write(path: &std::path::Path, data: &[u8]) -> std::io::Result<()> {
+    use std::io::Write as _;
+    let parent = path.parent().ok_or_else(|| {
+        std::io::Error::new(std::io::ErrorKind::InvalidInput, "path'ın parent'ı yok")
+    })?;
+    let file_name = path
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("config.json");
+    let tmp = parent.join(format!(
+        ".{}.{}.tmp",
+        file_name,
+        std::process::id()
+    ));
+    {
+        let mut f = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(&tmp)?;
+        f.write_all(data)?;
+        f.sync_all().ok();
+    }
+    match std::fs::rename(&tmp, path) {
+        Ok(()) => Ok(()),
+        Err(e) => {
+            // Rename başarısızsa tmp'yi temizle — disk sızıntısını önle.
+            let _ = std::fs::remove_file(&tmp);
+            Err(e)
+        }
+    }
 }
 
 /// `trusted_devices` alanı için özel deserializer — hem yeni (nesne dizisi)

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -236,14 +236,22 @@ fn replace_atomic(tmp: &std::path::Path, dst: &std::path::Path) -> std::io::Resu
 
 #[cfg(windows)]
 fn replace_atomic(tmp: &std::path::Path, dst: &std::path::Path) -> std::io::Result<()> {
-    use windows::core::HSTRING;
+    use std::os::windows::ffi::OsStrExt;
+    use windows::core::PCWSTR;
     use windows::Win32::Storage::FileSystem::{
         MoveFileExW, MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH,
     };
+    // PCWSTR dizileri null-terminated olmalı — OsStr::encode_wide null
+    // katmaz, bu yüzden manuel ekliyoruz (repo içi başka Win32 çağrılarıyla
+    // aynı pattern, bkz. src/platform.rs, src/main.rs).
+    let mut src_w: Vec<u16> = tmp.as_os_str().encode_wide().collect();
+    src_w.push(0);
+    let mut dst_w: Vec<u16> = dst.as_os_str().encode_wide().collect();
+    dst_w.push(0);
     unsafe {
         MoveFileExW(
-            &HSTRING::from(tmp.as_os_str()),
-            Some(&HSTRING::from(dst.as_os_str())),
+            PCWSTR(src_w.as_ptr()),
+            PCWSTR(dst_w.as_ptr()),
             MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
         )
         .map_err(std::io::Error::other)

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -58,14 +58,20 @@ impl Stats {
     }
 
     pub fn save(&self) -> Result<()> {
+        // Process-wide Stats disk lock — review-18 (HIGH) save reordering.
+        // connection.rs (RX path) ve sender.rs (TX path) eş zamanlı
+        // `save()` çağırdığında snapshot'lar disk I/O kuyruğunda ters
+        // sırada çözülüp eski hal diske yazılabilir. Bu mutex serileştirir.
+        static DISK_LOCK: parking_lot::Mutex<()> = parking_lot::Mutex::new(());
+        let _guard = DISK_LOCK.lock();
+
         let path = stats_path();
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent).ok();
         }
         let json = serde_json::to_string_pretty(self).context("stats JSON serialize")?;
         // Atomik tmp+rename — crash sırasında yarım yazılmış JSON diske kalmaz.
-        crate::settings::atomic_write(&path, json.as_bytes())
-            .context("stats.json yazılamadı")?;
+        crate::settings::atomic_write(&path, json.as_bytes()).context("stats.json yazılamadı")?;
         Ok(())
     }
 

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -63,7 +63,9 @@ impl Stats {
             std::fs::create_dir_all(parent).ok();
         }
         let json = serde_json::to_string_pretty(self).context("stats JSON serialize")?;
-        std::fs::write(&path, json).context("stats.json yazılamadı")?;
+        // Atomik tmp+rename — crash sırasında yarım yazılmış JSON diske kalmaz.
+        crate::settings::atomic_write(&path, json.as_bytes())
+            .context("stats.json yazılamadı")?;
         Ok(())
     }
 

--- a/src/ukey2.rs
+++ b/src/ukey2.rs
@@ -97,8 +97,7 @@ pub async fn client_handshake(socket: &mut TcpStream) -> Result<DerivedKeys> {
     frame::write_frame(socket, &client_init_bytes).await?;
 
     // 4) ServerInit al — slow-loris defansı: handshake timeout
-    let server_init_raw =
-        frame::read_frame_timeout(socket, frame::HANDSHAKE_READ_TIMEOUT).await?;
+    let server_init_raw = frame::read_frame_timeout(socket, frame::HANDSHAKE_READ_TIMEOUT).await?;
     let server_init_msg = Ukey2Message::decode(server_init_raw.as_ref())?;
     if server_init_msg.message_type != Some(3) {
         bail!(

--- a/src/ukey2.rs
+++ b/src/ukey2.rs
@@ -96,8 +96,9 @@ pub async fn client_handshake(socket: &mut TcpStream) -> Result<DerivedKeys> {
 
     frame::write_frame(socket, &client_init_bytes).await?;
 
-    // 4) ServerInit al
-    let server_init_raw = frame::read_frame(socket).await?;
+    // 4) ServerInit al — slow-loris defansı: handshake timeout
+    let server_init_raw =
+        frame::read_frame_timeout(socket, frame::HANDSHAKE_READ_TIMEOUT).await?;
     let server_init_msg = Ukey2Message::decode(server_init_raw.as_ref())?;
     if server_init_msg.message_type != Some(3) {
         bail!(
@@ -245,6 +246,17 @@ pub fn process_client_init(client_init_frame: &[u8]) -> Result<ServerInitResult>
     let next_protocol = ci.next_protocol();
     if next_protocol != "AES_256_CBC-HMAC_SHA256" {
         bail!("desteklenmeyen next_protocol: {}", next_protocol);
+    }
+
+    // SECURITY: `prost` varsayılan olarak `repeated` alan boyutuna sınır
+    // uygulamıyor. Saldırgan 100k+ CipherCommitment yollayıp Vec allocation +
+    // lineer `find()` ile CPU/RAM tüketebilir. Gerçek peer en fazla 2-3
+    // cipher önerir; 8 cömert üst sınır.
+    if ci.cipher_commitments.len() > 8 {
+        bail!(
+            "cipher_commitment flood: {} eleman (max 8)",
+            ci.cipher_commitments.len()
+        );
     }
 
     tracing::debug!(
@@ -452,5 +464,39 @@ mod tests {
         assert_eq!(to_signed_bytes(&[0x80]), vec![0x00, 0x80]);
         // 0x7F en yüksek pozitif — dokunulmaz
         assert_eq!(to_signed_bytes(&[0x7F]), vec![0x7F]);
+    }
+
+    #[test]
+    fn cipher_commitments_flood_reddedilir() {
+        // SECURITY: process_client_init 8'den fazla cipher_commitment içeren
+        // ClientInit'i reddetmeli — prost default sınırsız repeated field.
+        use crate::securegcm::{
+            ukey2_client_init::CipherCommitment, Ukey2ClientInit, Ukey2HandshakeCipher,
+            Ukey2Message,
+        };
+        use prost::Message;
+
+        let mut commitments = Vec::with_capacity(16);
+        for _ in 0..16 {
+            commitments.push(CipherCommitment {
+                handshake_cipher: Some(Ukey2HandshakeCipher::P256Sha512 as i32),
+                commitment: Some(vec![0u8; 64]),
+            });
+        }
+        let ci = Ukey2ClientInit {
+            version: Some(1),
+            random: Some(vec![0u8; 32]),
+            cipher_commitments: commitments,
+            next_protocol: Some("AES_256_CBC-HMAC_SHA256".into()),
+        };
+        let msg = Ukey2Message {
+            message_type: Some(2),
+            message_data: Some(ci.encode_to_vec()),
+        };
+        let bytes = msg.encode_to_vec();
+        let res = super::process_client_init(&bytes);
+        assert!(res.is_err(), "flood reddedilmeli");
+        let err = res.err().unwrap();
+        assert!(err.to_string().contains("cipher_commitment flood"));
     }
 }


### PR DESCRIPTION
…verflow

6 yeni güvenlik bulgusunu (4 HIGH + 2 MED) adresler:

- HIGH: frame::read_frame 30/60s timeout (slow-loris DoS)
- HIGH: prost cipher_commitments ≤8 / file_metadata ≤1000 guard
- HIGH: unique_downloads_path create_new(true) ile TOCTOU kapatıldı
- HIGH: Settings/Stats atomic tmp+rename + save-outside-lock
- MED: SecureCtx seq counter checked_add (i32::MAX panic guard)
- MED: register_file_destination duplicate id reject
- MED: payload written ≤ total_size overrun + last_chunk truncation kontrol

108 test geçiyor (6 yeni regression testi).

<!--
HekaDrop'a katkı için teşekkürler! Aşağıdaki alanları doldurun.
Büyük değişiklikler için önce issue açmanızı rica ediyoruz (CONTRIBUTING.md).
-->

## Özet

<!-- Ne değişti, neden? Bir-iki cümle. -->

## Tür

<!-- Uygun olanları işaretleyin ([x]) -->

- [ ] Hata düzeltmesi
- [ ] Yeni özellik
- [ ] Protokol / kripto değişikliği (güvenlik gözden geçirmesi gerekir)
- [ ] Refactor / temizlik (davranış değişmedi)
- [ ] Dokümantasyon
- [ ] CI / paketleme

## Test

<!-- Yerel olarak ne test ettiniz? CI otomatik çalıştırır ama anlamlı ek adımlar varsa yazın. -->

- [ ] `cargo fmt --all -- --check` temiz
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` temiz
- [ ] `cargo test --all` — tümü geçiyor
- [ ] Gerçek cihazla manuel test (özellikle protokol/UI değişiklikleriyse)

## İlgili issue(lar)

<!-- Closes #N, Fixes #N, Relates #N -->

## Notlar

<!-- Breaking change var mı? Migrasyon gereksin mi? Ek risk/takip var mı? -->
