### PR TITLE
chore(cask): point to v0.5.2 .dmg with correct SHA256

### DIFF
--- a/Casks/hekadrop.rb
+++ b/Casks/hekadrop.rb
@@ -1,10 +1,8 @@
 cask "hekadrop" do
   version "0.5.2"
-  # NOTE: SHA256 will be updated post-release once the v0.5.2 macOS zip
-  # artifact is published and its checksum verified.
-  sha256 "5507c34078353041834de83a06b1afa219df7ac6158864fdc372cb8cc63c6052"
+  sha256 "a3e9612143a6811c05609369984c9eb0b49f27ef39632864b7444575392a083f"
 
-  url "https://github.com/YatogamiRaito/HekaDrop/releases/download/v#{version}/HekaDrop-#{version}-macos.zip"
+  url "https://github.com/YatogamiRaito/HekaDrop/releases/download/v#{version}/HekaDrop-#{version}.dmg"
   name "HekaDrop"
   desc "Google Quick Share (Nearby Share) client — Rust, cross-platform"
   homepage "https://github.com/YatogamiRaito/HekaDrop"


### PR DESCRIPTION
## Summary

Cask currently references an `HekaDrop-v0.5.2-macos.zip` artifact that release.yml never produces — release workflow only publishes `.dmg` (+ source tar). `brew install --cask` fails with 404 today.

### Changes
- URL: `.zip` → `.dmg` (`HekaDrop-0.5.2.dmg`, actually shipped)
- SHA256: v0.5.1 stale value → actual v0.5.2 .dmg checksum (`a3e9612...`) from `CHECKSUMS.txt`

### Pre-existing gap flagged as follow-up
- Scoop manifest references `HekaDrop-$version.exe` but release.yml is macOS-only — Windows .exe + Linux .deb artifacts should be added to the release workflow in a separate PR.

## Test plan

- [x] SHA matches `curl -sL https://github.com/.../v0.5.2/CHECKSUMS.txt`
- [x] URL resolves (follow-up: verify `brew install --cask ./Casks/hekadrop.rb` in a clean env)

🤖 Generated with [Claude Code](https://claude.com/claude-code)