### PR TITLE
chore(infra): criterion bench scaffold + pre-commit hook + mutation-survivor tests

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# HekaDrop local pre-commit — hızlı doğrulama katmanı. Tam CI'ı tekrar
+# etmez; sadece "fark ettim diye commit etmeden yakalayabileceklerim".
+#
+# Enable: `git config core.hooksPath .githooks`
+set -euo pipefail
+echo "==> cargo fmt --check"
+cargo fmt --all -- --check
+echo "==> cargo clippy -- -D warnings"
+cargo clippy --all-targets --quiet -- -D warnings
+echo "==> cargo test (library)"
+cargo test --bin hekadrop --quiet
+echo "pre-commit: OK"

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -28,16 +28,9 @@ jobs:
       - name: Install protoc
         run: brew install protobuf
 
-      # TODO: add [[bench]] targets to Cargo.toml (criterion-based) — şimdilik noop.
+      # `benches/crypto.rs` — criterion bazlı, `[[bench]] name = "crypto"`.
       - name: Run benchmarks
-        run: |
-          if cargo bench --no-run 2>&1 | grep -q "no bench target"; then
-            echo "No bench targets defined — skipping."
-            mkdir -p target/criterion
-            echo "No benchmarks yet. Add [[bench]] target in Cargo.toml and uncomment criterion dev-dependency." > target/criterion/README.txt
-          else
-            cargo bench --all-features | tee bench-output.txt
-          fi
+        run: cargo bench --all-features | tee bench-output.txt
 
       - name: Upload benchmark artifacts
         if: always()

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,18 @@
 HekaDrop topluluk katkılarına açıktır. Hata raporu, özellik önerisi ya da pull request
 göndermeden önce lütfen aşağıdaki akışı izleyin.
 
+## Local setup
+
+Once per clone:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+This enables the pre-commit hook which runs `cargo fmt`, `cargo clippy`,
+and `cargo test` before each commit. Skip with `--no-verify` only in
+emergencies — CI runs the same checks and will block your PR otherwise.
+
 ## İş akışı
 
 1. **Önce issue açın.** Yeni bir özellik / büyük refactor düşünüyorsanız, kod yazmadan

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,6 +29,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -332,6 +344,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cbc"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -373,6 +391,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -381,6 +426,31 @@ dependencies = [
  "crypto-common",
  "inout",
 ]
+
+[[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cocoa"
@@ -511,6 +581,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf7af66b0989381bd0be551bd7cc91912a655a58c6918420c9527b1fd8b4679"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "itertools 0.13.0",
+ "num-traits",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -520,10 +623,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
@@ -1337,6 +1465,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1379,6 +1518,7 @@ dependencies = [
  "bytes",
  "cbc",
  "cipher",
+ "criterion",
  "elliptic-curve",
  "hex",
  "hkdf",
@@ -1620,6 +1760,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -2054,6 +2212,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "num_enum"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2279,6 +2446,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "option-ext"
@@ -2532,6 +2705,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "png"
 version = "0.17.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2718,7 +2919,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck 0.5.0",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -2738,7 +2939,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -2863,6 +3064,26 @@ name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -3492,6 +3713,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tokio"
 version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3914,6 +4145,16 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
  "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,11 @@ prost-build = "0.13"
 # build ağırlığı önemsiz (<1 MB) ve `cargo test` cache'ine yaslanıyor.
 pretty_assertions = "1.4"
 tokio-test = "0.4"
-# criterion = "0.5"  # enable when benchmarks are added
+criterion = { version = "0.6", features = ["html_reports"] }
+
+[[bench]]
+name = "crypto"
+harness = false
 
 [profile.release]
 lto = "thin"

--- a/benches/crypto.rs
+++ b/benches/crypto.rs
@@ -1,0 +1,61 @@
+//! Criterion benchmark — kripto sıcak yolu (AES-CBC, HMAC, HKDF,
+//! session_fingerprint). 64 KiB tipik chunk boyutunu temsil ediyor.
+//!
+//! Çalıştırma: `cargo bench --bench crypto`
+//! Derleme kontrolü (CI/pre-commit): `cargo bench --no-run`
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use hekadrop::crypto;
+use std::hint::black_box;
+
+fn bench_aes_roundtrip(c: &mut Criterion) {
+    let key = [0u8; 32];
+    let iv = [0u8; 16];
+    let pt = vec![0x55u8; 64 * 1024]; // 64 KiB — typical chunk size
+    c.bench_function("aes256_cbc_encrypt/64KiB", |b| {
+        b.iter(|| crypto::aes256_cbc_encrypt(black_box(&key), black_box(&iv), black_box(&pt)))
+    });
+    let ct = crypto::aes256_cbc_encrypt(&key, &iv, &pt);
+    c.bench_function("aes256_cbc_decrypt/64KiB", |b| {
+        b.iter(|| crypto::aes256_cbc_decrypt(black_box(&key), black_box(&iv), black_box(&ct)))
+    });
+}
+
+fn bench_hmac(c: &mut Criterion) {
+    let key = [0x42u8; 32];
+    let data = vec![0xAAu8; 64 * 1024];
+    c.bench_function("hmac_sha256/64KiB", |b| {
+        b.iter(|| crypto::hmac_sha256(black_box(&key), black_box(&data)))
+    });
+}
+
+fn bench_hkdf(c: &mut Criterion) {
+    let ikm = [0x33u8; 32];
+    let salt = [0x77u8; 32];
+    c.bench_function("hkdf_sha256/32B-out", |b| {
+        b.iter(|| {
+            crypto::hkdf_sha256(
+                black_box(&ikm),
+                black_box(&salt),
+                black_box(b"UKEY2 v1 auth"),
+                32,
+            )
+        })
+    });
+}
+
+fn bench_session_fingerprint(c: &mut Criterion) {
+    let auth_key = [0xAAu8; 32];
+    c.bench_function("session_fingerprint", |b| {
+        b.iter(|| crypto::session_fingerprint(black_box(&auth_key)))
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_aes_roundtrip,
+    bench_hmac,
+    bench_hkdf,
+    bench_session_fingerprint
+);
+criterion_main!(benches);

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -109,6 +109,49 @@ mod tests {
         assert_eq!(pin.len(), 4);
     }
 
+    /// NearDrop referans PIN algoritmasına birebir KAT (known-answer test).
+    ///
+    /// Beklenen değerler NearDrop spec'indeki aynı akışı Python ile bağımsız
+    /// olarak koşturup çıkarıldı:
+    /// ```python
+    /// def pin(key):
+    ///     h, m, MOD = 0, 1, 9973
+    ///     for b in key:
+    ///         s = b if b < 128 else b - 256
+    ///         h = (h + s * m) % MOD
+    ///         m = (m * 31) % MOD
+    ///     return f"{abs(h):04d}"
+    /// ```
+    ///
+    /// Her vektör farklı bir mutation'u yakalar:
+    ///   * `hash = hash - signed*mult` (operatör flip)
+    ///   * `mult * 29` yerine `* 31` (sabit değişikliği)
+    ///   * `rem_euclid` yerine `%` (işaretli/işaretsiz fark)
+    ///   * `b as i8` yerine `b as i32` (signedness kaybı — [0xFF;32] vektörü
+    ///     negatif byte'ları teste sokar)
+    #[test]
+    fn pin_matches_near_drop_algorithm_exactly() {
+        // 0x01..=0x20 — signed byte yolu pozitif
+        let k1: [u8; 32] = [
+            0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E,
+            0x0F, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1A, 0x1B, 0x1C,
+            0x1D, 0x1E, 0x1F, 0x20,
+        ];
+        assert_eq!(pin_code_from_auth_key(&k1), "1631");
+
+        // [0x42; 32] — mevcut determinism testinin gerçek beklenen değeri
+        let k2 = [0x42u8; 32];
+        assert_eq!(pin_code_from_auth_key(&k2), "0755");
+
+        // [0xFF; 32] — signed byte yolu negatif; `b as i8` olmazsa sonuç değişir
+        let k3 = [0xFFu8; 32];
+        assert_eq!(pin_code_from_auth_key(&k3), "3464");
+
+        // [0x00; 32] — edge case: hash hiç değişmez, 4-hane zero-pad kontrolü
+        let k4 = [0x00u8; 32];
+        assert_eq!(pin_code_from_auth_key(&k4), "0000");
+    }
+
     #[test]
     fn test_aes_cbc_roundtrip() {
         let key = [0u8; 32];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,9 @@
+//! HekaDrop library surface — yalnız benchmarklar ve harici entegrasyon testleri
+//! için public re-export katmanı.
+//!
+//! Binary `src/main.rs` bu lib'e bağımlı değildir; modül ağacı ikisinde de
+//! bağımsızca derlenir (Cargo lib+bin hibrit projeyi bu şekilde ele alır).
+//! Buradaki amaç sadece `benches/crypto.rs` gibi harici consumer'lara
+//! `hekadrop::crypto` yüzeyini açmaktır.
+
+pub mod crypto;

--- a/src/ukey2.rs
+++ b/src/ukey2.rs
@@ -110,23 +110,10 @@ pub async fn client_handshake(socket: &mut TcpStream) -> Result<DerivedKeys> {
         .ok_or_else(|| anyhow!("server_init.data yok"))?;
     let server_init = Ukey2ServerInit::decode(&server_init_data[..])?;
 
-    // SECURITY (downgrade koruması): Peer'ın seçtiği cipher bizim öne
-    // sürdüğümüz P256_SHA512 olmalı. Aksi halde tanımsız/zayıf cipher'a
-    // yönlendirme saldırısına maruz kalırız. ClientInit sadece
-    // P256_SHA512 önerdi — ServerInit farklı değer dönerse reddet.
-    if server_init.handshake_cipher != Some(Ukey2HandshakeCipher::P256Sha512 as i32) {
-        bail!(
-            "ServerInit cipher downgrade reddedildi: {:?} (beklenen P256_SHA512)",
-            server_init.handshake_cipher
-        );
-    }
-    // Protocol version kontrolü — V1 dışında bir şey bekleme.
-    if server_init.version != Some(1) {
-        bail!(
-            "ServerInit version={:?} — yalnız V1 destekleniyor",
-            server_init.version
-        );
-    }
+    // SECURITY (downgrade koruması): Peer'ın seçtiği cipher + version bizim
+    // talep ettiğimizle eşleşmeli. Validasyon testlenebilmesi için saf
+    // fonksiyona ayrıldı (bkz. `validate_server_init`).
+    validate_server_init(&server_init)?;
 
     // 5) ClientFinished gönder
     frame::write_frame(socket, &client_finished_bytes).await?;
@@ -213,6 +200,34 @@ fn to_signed_bytes(v: &[u8]) -> Vec<u8> {
     } else {
         v.to_vec()
     }
+}
+
+/// `Ukey2ServerInit` üzerinde cipher + version downgrade korumasını yürütür.
+///
+/// Saldırgan bir peer, daha zayıf ya da tanımsız bir cipher (örneğin
+/// `CurveCurve25519_Sha512`, `Unknown`, ya da dağıtımdan önce kaldırılmış
+/// algoritmalar) dönerek handshake'i bilinen-zayıf bir alana yönlendirmeye
+/// çalışabilir. ClientInit sadece `P256_SHA512` öneriyor — ServerInit farklı
+/// değer dönerse hatasız kabul etmek regression olurdu.
+///
+/// `client_handshake` çağrısında inline olarak yapılıyordu; testlenebilir
+/// olması için saf fonksiyona ayrıldı (mutation survivor #10 — research-v2
+/// raporundaki "ServerInit cipher downgrade" kontrolü artık unit test ile
+/// kapatılıyor).
+pub(crate) fn validate_server_init(s: &Ukey2ServerInit) -> Result<()> {
+    if s.handshake_cipher != Some(Ukey2HandshakeCipher::P256Sha512 as i32) {
+        bail!(
+            "ServerInit cipher downgrade reddedildi: {:?} (beklenen P256_SHA512)",
+            s.handshake_cipher
+        );
+    }
+    if s.version != Some(1) {
+        bail!(
+            "ServerInit version={:?} — yalnız V1 destekleniyor",
+            s.version
+        );
+    }
+    Ok(())
 }
 
 pub struct ServerInitResult {
@@ -463,6 +478,65 @@ mod tests {
         assert_eq!(to_signed_bytes(&[0x80]), vec![0x00, 0x80]);
         // 0x7F en yüksek pozitif — dokunulmaz
         assert_eq!(to_signed_bytes(&[0x7F]), vec![0x7F]);
+    }
+
+    #[test]
+    fn validate_server_init_dogru_cipher_ve_versionda_gecer() {
+        use crate::securegcm::{Ukey2HandshakeCipher, Ukey2ServerInit};
+        let ok = Ukey2ServerInit {
+            version: Some(1),
+            random: Some(vec![0u8; 32]),
+            handshake_cipher: Some(Ukey2HandshakeCipher::P256Sha512 as i32),
+            public_key: Some(vec![0u8; 16]),
+        };
+        assert!(super::validate_server_init(&ok).is_ok());
+    }
+
+    #[test]
+    fn validate_server_init_cipher_downgrade_reddedilir() {
+        // SECURITY REGRESSION (research-v2 mutation survivor #10):
+        // ServerInit P256_SHA512 dışında bir cipher dönerse handshake bail
+        // etmeli. Burada `CurveCurve25519Sha512` (değer 1) kullanıyoruz —
+        // ClientInit'de teklif etmediğimiz bir cipher.
+        use crate::securegcm::{Ukey2HandshakeCipher, Ukey2ServerInit};
+        let bad = Ukey2ServerInit {
+            version: Some(1),
+            random: Some(vec![0u8; 32]),
+            handshake_cipher: Some(Ukey2HandshakeCipher::Curve25519Sha512 as i32),
+            public_key: Some(vec![0u8; 16]),
+        };
+        let err = super::validate_server_init(&bad).unwrap_err();
+        assert!(
+            err.to_string().contains("cipher downgrade"),
+            "beklenen hata mesajı 'cipher downgrade' içermeli: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_server_init_version_downgrade_reddedilir() {
+        // SECURITY: V1 dışında bir UKEY2 version dönmek hem protokol-ihlali
+        // hem de olası downgrade vektörü. `None` ve V0 gibi varyantlar da
+        // reddedilmeli.
+        use crate::securegcm::{Ukey2HandshakeCipher, Ukey2ServerInit};
+        let v0 = Ukey2ServerInit {
+            version: Some(0),
+            random: Some(vec![0u8; 32]),
+            handshake_cipher: Some(Ukey2HandshakeCipher::P256Sha512 as i32),
+            public_key: Some(vec![0u8; 16]),
+        };
+        let err = super::validate_server_init(&v0).unwrap_err();
+        assert!(
+            err.to_string().contains("yalnız V1"),
+            "version hatası beklenen: {err}"
+        );
+
+        let none_ver = Ukey2ServerInit {
+            version: None,
+            random: Some(vec![0u8; 32]),
+            handshake_cipher: Some(Ukey2HandshakeCipher::P256Sha512 as i32),
+            public_key: Some(vec![0u8; 16]),
+        };
+        assert!(super::validate_server_init(&none_ver).is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Concrete follow-ups to research-v2 infra critique (`/tmp/research-v2/infra.md` scored benchmarks 0/10 and pre-commit 0/10). This PR addresses items #1 (pre-commit), #3 (criterion bench scaffold), and #8 (mutation-survivor regression tests).

- **`.githooks/pre-commit`** — opt-in local hook: `cargo fmt --check` + `cargo clippy --all-targets -- -D warnings` + `cargo test --bin hekadrop`. Enable with `git config core.hooksPath .githooks`. `CONTRIBUTING.md` now has a *Local setup* section documenting it.
- **`benches/crypto.rs`** — criterion scaffold with 4 benchmarks: AES-256-CBC encrypt/decrypt (64 KiB), HMAC-SHA256 (64 KiB), HKDF-SHA256 (32 B out), `session_fingerprint`. `criterion 0.6` added as dev-dependency + `[[bench]] name = "crypto"` in `Cargo.toml`. Removed `bench.yml` TODO placeholder; workflow now runs real benchmarks.
- **`src/lib.rs`** — minimal `pub mod crypto;` exposure so benches can link against `hekadrop::crypto`. `src/main.rs` stays untouched (hybrid lib+bin — Cargo compiles both trees separately).
- **`src/crypto.rs` PIN KAT** — four known-answer vectors (0x01..0x20 → `1631`, `[0x42;32]` → `0755`, `[0xFF;32]` → `3464` [exercises signed-byte path], `[0x00;32]` → `0000`). Kills arithmetic / operator / modulus / signedness mutations on `pin_code_from_auth_key`.
- **`src/ukey2.rs::validate_server_init`** — extracted the inline cipher + version check from `client_handshake` into a `pub(crate)` pure function; added 3 unit tests: correct cipher OK, `Curve25519Sha512` downgrade rejected, V0 / `None` version rejected. Closes the Gemini-review mutation survivor where the downgrade check was untested.

Test count: **126 → 130** (+4).

## Test plan

- [x] `cargo bench --no-run` compiles bench binary (verified locally)
- [x] `cargo test --bin hekadrop` — 130 passed / 0 failed
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `.githooks/pre-commit` runs end-to-end on current HEAD and returns 0
- [ ] CI: Linux / macOS / Windows test matrix still green
- [ ] CI: Bench workflow (manual dispatch) runs without "no bench target" fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)