### PR TITLE
fix(security): v0.6 hotfix #2 — revert permissive legacy fallback + review aftermath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security (v0.6 hotfix #2 — PR #35 review aftermath)
+- **[HIGH] Legacy spoofing vektörü kapatıldı** (`connection.rs` —
+  PR #35 review, Copilot). PR #35'in ilk fix'i trust kararını
+  `is_trusted_by_hash(h) || is_trusted_legacy(name, id)` yapıyordu;
+  bu attacker'ın kurbanın (name, id)'sini spoof edip kendi hash'ini
+  auto-accept + opportunistic upgrade ile legacy kayda kalıcı olarak
+  bağlamasına izin veriyordu. Trust kararı artık **strict hash-first**:
+  peer hash gönderdiyse YALNIZ hash eşleşmesi trusted sayılır; legacy
+  fallback yalnız pre-v0.6 peer (hash göndermeyen) için geçerli.
+  Legacy kullanıcıların migration bedeli: ilk v0.6 bağlantısında
+  one-time dialog — Accept sonrası opportunistic upgrade hash'i bağlar,
+  sonraki bağlantılar dialog'suz.
+- **[MED] HTML attribute escape fix** (`resources/window.html` —
+  PR #35 review, Gemini). `escapeAttr()` önceden tek tırnakları `\'`
+  (JS string escape syntax'ı) ile kaçırıyordu — HTML için yanlış.
+  Ekran okuyucular ters bölüyü okuyabiliyordu. Doğru HTML entity
+  escape'ine (`&amp; &quot; &lt; &gt;`) geçildi.
+- **[MED] `tf()` placeholder dedup** (`resources/window.html` —
+  PR #35 review, Gemini). `tf()` artık `t.apply` ile `t()`'nin regex
+  tabanlı substitution'ına delege eder; iki ayrı implementasyon bakımı
+  bitti.
+- **[MED] `0o600` test umask-tolerant** (`src/settings.rs` — PR #35
+  review, Copilot). `atomic_write_mode` testi exact `0o600` yerine
+  "group/world erişim yok" (`mode & 0o077 == 0`) invariant'ını
+  kontrol eder — hardened umask ortamlarında (0o077/0o277) owner
+  bitleri daha da kısıtlansa bile security invariant'ı doğrular.
+
 ### Security (MAJOR — v0.6.0)
 - **[HIGH] Trusted device identity hardening** (Issue #17): trust
   kararı artık `PairedKeyEncryption.secret_id_hash` (6 byte,

--- a/resources/window.html
+++ b/resources/window.html
@@ -1099,6 +1099,8 @@
         .replace(/'/g, "\\'")
         .replace(/\r/g, '\\r')
         .replace(/\n/g, '\\n')
+        .replace(/\u2028/g, '\\u2028')
+        .replace(/\u2029/g, '\\u2029')
         .replace(/</g, '\\u003C');
       return escapeAttr(jsEscaped);
     }

--- a/resources/window.html
+++ b/resources/window.html
@@ -1026,7 +1026,7 @@
             ${ttlBadge}
           </div>
           <button type="button" class="small danger"
-                  onclick="act('trust_remove::${escapeAttr(rawName)}')"
+                  onclick="act('trust_remove::${escapeJsInAttr(rawName)}')"
                   aria-label="Güvenilen cihazı kaldır: ${escapeAttr(label)}">
             <span class="icon" aria-hidden="true">✕</span>${removeLabel}
           </button>
@@ -1035,20 +1035,18 @@
       }).join('');
     };
 
-    // tf() — basit formatlayıcı: window.__I18N__ sözlüğünden çeviriyi alıp
-    // `{0}` `{1}` vb. yer tutucuları args ile değiştirir (Rust tarafındaki
-    // `apply_args` ile aynı semantik — tüm eşleşmeleri değiştirir).
+    // tf() — array-argüman wrapper: çağrı sitelerinde `tf(key, [a, b])`
+    // kullanımı JS variadic `t(key, a, b)`'ye dönüştürülür. `t()` zaten
+    // regex ile tüm `{N}` eşleşmelerini değiştirir ve null/undefined'ı boş
+    // string'e çevirir; `tf` bu mantığı yeniden implemente etmez.
     //
-    // Bug (review #34 MED): önceden `String.replace(string, string)` yalnız
-    // ilk eşleşmeyi değiştiriyordu; "Dosya {0} alındı. {0} aç?" gibi aynı
-    // argümanı iki kez kullanan çeviriler ikinci `{0}`'ı literal bırakıyordu.
-    // `split/join` ile tüm eşleşmeler tek pasada değişir.
+    // Refactor (PR #35 review, Gemini MED, discussion_r3107561278):
+    // Önceki implementasyon split/join ile manuel substitution yapıyordu —
+    // `t()`'nin regex tabanlı değiştirmesinin duplicate'i. Çağrı sitelerini
+    // kırmamak için `tf(key, args)` API'si korundu ama içerik `t.apply`'a
+    // delege edildi; böylece tek bir substitution kaynağı kalır.
     function tf(key, args) {
-      let s = t(key);
-      for (let i = 0; i < args.length; i++) {
-        s = s.split('{' + i + '}').join(args[i]);
-      }
-      return s;
+      return t.apply(null, [key].concat(args || []));
     }
 
     window.applyHistory = function(items) {
@@ -1059,7 +1057,7 @@
       }
       list.innerHTML = items.map(h => `
         <button type="button" class="hitem"
-                onclick="act('reveal::${escapeAttr(h.path)}')"
+                onclick="act('reveal::${escapeJsInAttr(h.path)}')"
                 aria-label="Dosyayı göster: ${escapeAttr(h.file_name)}, ${escapeAttr(h.size_human)}, ${escapeAttr(h.device)}, ${escapeAttr(h.age)}">
           <span class="hname">${escapeHtml(h.file_name)}</span>
           <span class="hmeta">${escapeHtml(h.size_human)} • ${escapeHtml(h.device)} • ${escapeHtml(h.age)}${h.sha256 ? ` • <code style="font-size:10px">${escapeHtml(h.sha256)}</code>` : ''}</span>
@@ -1072,8 +1070,37 @@
         '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'
       }[c]));
     }
+    // escapeAttr — HTML attribute value escape (çift-tırnaklı attr'lar için).
+    //
+    // Bug (PR #35 review, Gemini MED, discussion_r3107561275):
+    // Önceki implementasyon tek tırnakları `\'` ile kaçırıyordu — bu JS
+    // string literal escape syntax'ı, HTML attribute syntax'ı değil. Sonuç
+    // DOM'a `aria-label="O\'Brian"` olarak düşüyordu; screen reader'lar
+    // ters bölü karakterini "O backslash Brian" gibi okuyabiliyordu.
+    //
+    // Doğru HTML çift-tırnaklı attribute escape'i yalnız şu karakterlere
+    // ihtiyaç duyar: `&` → &amp;, `"` → &quot;, `<` → &lt;, `>` → &gt;.
+    // Tek tırnak çift-tırnaklı attr içinde literal kalabilir (escape
+    // gerekmez).
     function escapeAttr(s) {
-      return String(s).replace(/'/g, "\\'").replace(/"/g, '&quot;');
+      return String(s).replace(/[&<>"]/g, c => ({
+        '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'
+      }[c]));
+    }
+    // escapeJsInAttr — `onclick="act('${x}')"` gibi "HTML attr içinde tek
+    // tırnaklı JS string" bağlamı için iki-katmanlı escape. Önce JS
+    // string-literal düzeyinde ters bölü + tek tırnak + newline + </script>
+    // kaçırılır; sonra HTML attribute düzeyinde `&` + `<` + `>` + `"`
+    // entity'lerine dönüşür. `escapeAttr` saf HTML için (aria-label vb.),
+    // bu helper JS-mixed bağlam için.
+    function escapeJsInAttr(s) {
+      const jsEscaped = String(s)
+        .replace(/\\/g, '\\\\')
+        .replace(/'/g, "\\'")
+        .replace(/\r/g, '\\r')
+        .replace(/\n/g, '\\n')
+        .replace(/</g, '\\u003C');
+      return escapeAttr(jsEscaped);
     }
 
     window.updateProgress = function(percent, label) {

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -529,27 +529,46 @@ async fn handle_sharing_frame(
             }
 
             // Karar mantığı (Issue #17):
-            //   1) Peer secret_id_hash gönderdiyse → (hash eşleşir VEYA legacy
-            //      kayıt eşleşir) trusted sayılır. Birinci sürüm review sonrası
-            //      fix (Gemini review #34): legacy kaydı olan cihaz ilk kez
-            //      hash gönderdiğinde dialog sormadan silent upgrade olmalı.
-            //      Önceden yalnız `is_trusted_by_hash` bakılıyordu → hash
-            //      henüz kaydedilmediği için false dönüyor, kullanıcıya
-            //      gereksiz dialog çıkıyordu.
-            //   2) Peer hash yoksa → legacy `(name, id)` eşleşmesi (fallback,
-            //      3 sürümlük uyumluluk penceresi).
+            //   1) Peer secret_id_hash gönderdiyse → YALNIZ hash eşleşmesi
+            //      trust'a yeterlidir. Legacy `(name, id)` fallback bu yolda
+            //      devreye alınmaz.
+            //   2) Peer hash göndermediyse (pre-v0.6 peer) → legacy
+            //      `(name, id)` eşleşmesi (3 sürümlük uyumluluk penceresi).
             //   3) Settings.auto_accept → dialog atla.
             //   4) Aksi halde dialog göster (3 seçenek: reddet/kabul/kabul+güven).
+            //
+            // SECURITY (PR #35 review — Copilot HIGH, discussion_r3107564927):
+            // PR #35'in ilk fix'i `Some(h) => is_trusted_by_hash(h) ||
+            // is_trusted_legacy(name, id)` kullanıyordu. Bu OR fallback
+            // legacy `(name, id)` spoofing vektörünü geri açmıştı: attacker
+            // kurbanın endpoint-id + cihaz adını öğrenir → hash gönderir →
+            // legacy kaydı OR ile eşleşir → auto-accept → "opportunistic
+            // upgrade" attacker'ın hash'ini kalıcı olarak kayda bağlar.
+            // Bundan sonra legacy fallback kaldırılsa bile attacker sessiz
+            // bypass ile trusted kalır.
+            //
+            // Legacy kullanıcı migration UX: v0.5 → v0.6 geçişinde legitimate
+            // cihazın ilk hash-gönderili bağlantısında dialog ONE-TIME çıkar
+            // (çünkü hash henüz kayıtta yok). Kullanıcı Accept / Accept+Trust
+            // dediğinde aşağıdaki opportunistic upgrade hash'i legacy kayda
+            // bağlar; sonraki bağlantılar hash-first trusted, dialog yok.
+            // Bu migration-dialog-cost spoofing engelinin doğru bedelidir.
             let trusted = {
                 let st = state::get();
                 let s = st.settings.read();
                 match peer_secret_id_hash {
-                    Some(h) => {
-                        s.is_trusted_by_hash(h) || s.is_trusted_legacy(remote_name, remote_id)
-                    }
+                    Some(h) => s.is_trusted_by_hash(h),
                     None => s.is_trusted_legacy(remote_name, remote_id),
                 }
             };
+
+            // TODO(ux): peer hash gönderdiği halde is_trusted_by_hash false ama
+            // is_trusted_legacy true ise — bu "v0.5 legacy kullanıcı ilk v0.6
+            // bağlantısı" senaryosudur. Dialog prompt'unu customize etmek
+            // kullanıcıya one-time dialog'un nedenini açıklar
+            // ("Önceki güvenilir cihazın yeni kimliği doğrulanıyor…").
+            // prompt_accept() imzası şu an custom prompt kabul etmediği için
+            // (macOS/Windows/Linux 3 ayrı blocking fn) bu polish atlandı.
 
             let auto_accept = state::get().settings.read().auto_accept;
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1136,6 +1136,21 @@ mod tests {
     ///
     /// Bu test connection.rs'teki `trusted` ifadesini Settings seviyesinde
     /// simüle eder — tam flow (prompt_accept) için test harness yok.
+    /// PR #35 review (Copilot HIGH, discussion_r3107564927) regression:
+    /// Legacy `(name, id)` kaydı olan cihaz **unknown/mismatched** bir hash
+    /// ile bağlandığında trusted sayılMAMALI — dialog ZORUNLU. Aksi halde
+    /// legacy spoofing vektörü açıktır: attacker kurbanın (name, id)'sini
+    /// öğrenir, kendi hash'i ile gelir, OR fallback nedeniyle auto-accept
+    /// olur, Accept branch'indeki opportunistic upgrade attacker'ın hash'ini
+    /// legacy kayda bağlar → kalıcı silent bypass.
+    ///
+    /// Doğru trust karar mantığı (connection.rs handle_sharing_frame):
+    ///   Some(h) => is_trusted_by_hash(h)          // YALNIZ hash
+    ///   None    => is_trusted_legacy(name, id)    // pre-v0.6 peer
+    ///
+    /// Legacy kullanıcı migration UX: ilk v0.6 bağlantısında one-time
+    /// dialog kabul edilir (bu test o davranışı doğrular). Accept sonrası
+    /// opportunistic upgrade hash'i bağlar, sonraki bağlantılar dialog'suz.
     #[test]
     fn v06_legacy_kayit_hash_ile_gelirse_dialog_yok() {
         let mut s = Settings::default();
@@ -1143,19 +1158,49 @@ mod tests {
         s.add_trusted("Pixel 7", "endpoint-abc");
         let peer_hash = [0xAB; 6];
 
-        // connection.rs'teki trusted hesabı (yeni fix):
-        //   Some(h) => is_trusted_by_hash(h) OR is_trusted_legacy(name, id)
-        let trusted =
-            s.is_trusted_by_hash(&peer_hash) || s.is_trusted_legacy("Pixel 7", "endpoint-abc");
+        // connection.rs'teki trusted hesabı (strict hash-first):
+        //   Some(h) => is_trusted_by_hash(h)  — legacy fallback YOK.
+        let trusted = s.is_trusted_by_hash(&peer_hash);
         assert!(
-            trusted,
-            "legacy kaydı olan cihaz ilk hash-gönderi ile silent kabul edilmeli"
+            !trusted,
+            "peer hash gönderdi ama kayıtta yok → trusted=false olmalı, \
+             dialog çıkmalı (legacy (name,id) match'i bypass'a çevrilMEMELİ)"
         );
 
-        // Önceki (hatalı) davranış: yalnız is_trusted_by_hash → false → dialog.
+        // Legacy kayıt hâlâ duruyor (migration için). Kullanıcı dialog'a
+        // Accept derse connection.rs'in opportunistic upgrade bloğu
+        // add_trusted_with_hash ile hash'i legacy'ye yerleştirir; sonraki
+        // bağlantıda is_trusted_by_hash true döner.
+        assert!(s.is_trusted_legacy("Pixel 7", "endpoint-abc"));
+        assert!(!s.is_trusted_by_hash(&peer_hash));
+    }
+
+    /// PR #35 review (Copilot HIGH) regression — spoofing vektörü açıkça:
+    /// Attacker kurbanın legacy (name, id)'sini öğrenir, keyfi bir hash
+    /// gönderir. Trust kararı hash-first olduğu için attacker HİÇBİR zaman
+    /// auto-trusted olmamalı; kullanıcı dialog görmeli.
+    #[test]
+    fn v06_legacy_match_hash_mismatch_spoofing_engellenir() {
+        let mut s = Settings::default();
+        s.add_trusted("Pixel 7", "endpoint-abc");
+
+        // Attacker: aynı (name, id), farklı hash.
+        let attacker_hash = [0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x01];
+
+        // Strict hash-first karar.
+        assert!(!s.is_trusted_by_hash(&attacker_hash));
+
+        // Legacy eşleşmesi var — ama trust kararı artık OR'lamıyor.
+        assert!(s.is_trusted_legacy("Pixel 7", "endpoint-abc"));
+
+        // Auto-trust olmaması gerekir → dialog zorunlu.
+        // Eski OR'lu kodda bu assertion false döner (attacker auto-accept).
+        let auto_trusted_under_strict_rule = s.is_trusted_by_hash(&attacker_hash);
         assert!(
-            !s.is_trusted_by_hash(&peer_hash),
-            "hash henüz kayıtta olmamalı (pre-upgrade durumu)"
+            !auto_trusted_under_strict_rule,
+            "legacy (name, id) match + unknown hash kombinasyonu auto-accept \
+             üretmemeli — aksi halde PR #35 review'da raporlanan spoofing \
+             vektörü geri gelir"
         );
     }
 
@@ -1225,9 +1270,21 @@ mod tests {
 
     /// Review #34 MED regression: `atomic_write_mode(path, data, Some(0o600))`
     /// tmp dosyayı baştan `O_EXCL | mode(0o600)` ile açmalı ve rename sonucu
-    /// final path da 0600 olmalı — umask ne olursa olsun. Önceki akışta tmp
-    /// default (0644) ile açılıp rename SONRASI set_permissions ile düzeltiliyordu;
-    /// bu pencerede dosya world-readable'dı.
+    /// final path da group/world-accessible OLMAMALI — umask ne olursa olsun.
+    /// Önceki akışta tmp default (0644) ile açılıp rename SONRASI
+    /// set_permissions ile düzeltiliyordu; bu pencerede dosya
+    /// world-readable'dı.
+    ///
+    /// Assertion fix (PR #35 review, Copilot MED, discussion_r3107564937):
+    /// Önceki test `mode == 0o600` exact eşitliğini kontrol ediyordu.
+    /// `OpenOptionsExt::mode(0o600)` umask ile AND'lenir — yalnız daha
+    /// **restrictive** hale gelebilir. Hardened ortamlarda (umask 0o077
+    /// veya 0o277) owner bitleri daha da kısıtlanıp dosya 0o400 olabilir;
+    /// bu durumda güvenlik invariant'ı (group/world erişim yok) hâlâ
+    /// sağlanır ama eski assertion false-negative verirdi. Invariant
+    /// olarak "group/world için hiçbir izin yok" (`mode & 0o077 == 0`)
+    /// kontrol ediyoruz; owner bitleri 0o000..=0o700 aralığında herhangi
+    /// bir değer olabilir.
     #[cfg(unix)]
     #[test]
     fn atomic_write_mode_0600_baslangictan_itibaren_uygular() {
@@ -1242,10 +1299,23 @@ mod tests {
         atomic_write_mode(&p, b"secret-bytes", Some(0o600)).expect("write");
         let meta = std::fs::metadata(&p).expect("stat");
         let mode = meta.permissions().mode() & 0o777;
+        // Security invariant: group + world için hiçbir rwx biti yok.
         assert_eq!(
-            mode, 0o600,
-            "atomic_write_mode Some(0o600) → final dosya 0600 olmalı, bulunan: 0o{:o}",
-            mode
+            mode & 0o077,
+            0,
+            "atomic_write_mode Some(0o600) → dosya group/world erişilebilir \
+             olmamalı (bulunan mode: 0o{:o}, group+world bits: 0o{:o})",
+            mode,
+            mode & 0o077
+        );
+        // Owner bitleri umask tarafından daha da kısıtlanmış olabilir
+        // (hardened setup). 0o600 tavan, 0o000 taban — arası kabul.
+        let owner_bits = mode & 0o700;
+        assert!(
+            owner_bits <= 0o600,
+            "owner bitleri 0o600'den fazla olmamalı (mode(0o600) umask'i gevşetmez): \
+             0o{:o}",
+            owner_bits
         );
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1128,31 +1128,28 @@ mod tests {
         assert!(s.is_trusted_by_hash(&[0xAA; 6]));
     }
 
-    /// Review #34 HIGH #2 regression: legacy kaydı olan cihaz ilk kez hash
-    /// gönderdiğinde connection.rs'teki `trusted` hesabı `(is_trusted_by_hash
-    /// OR is_trusted_legacy)` olmalı. Böylece dialog gösterilmeden silent
-    /// upgrade'e giden yol açılır; sadece hash'e bakan önceki kod legacy
-    /// kullanıcılara gereksiz dialog çıkarıyordu.
-    ///
-    /// Bu test connection.rs'teki `trusted` ifadesini Settings seviyesinde
-    /// simüle eder — tam flow (prompt_accept) için test harness yok.
     /// PR #35 review (Copilot HIGH, discussion_r3107564927) regression:
     /// Legacy `(name, id)` kaydı olan cihaz **unknown/mismatched** bir hash
     /// ile bağlandığında trusted sayılMAMALI — dialog ZORUNLU. Aksi halde
     /// legacy spoofing vektörü açıktır: attacker kurbanın (name, id)'sini
     /// öğrenir, kendi hash'i ile gelir, OR fallback nedeniyle auto-accept
     /// olur, Accept branch'indeki opportunistic upgrade attacker'ın hash'ini
-    /// legacy kayda bağlar → kalıcı silent bypass.
+    /// legacy kayda bağlar → kalıcı silent bypass. Bu nedenle strict
+    /// hash-first semantic seçildi; OR fallback kabul edilmez.
     ///
     /// Doğru trust karar mantığı (connection.rs handle_sharing_frame):
     ///   Some(h) => is_trusted_by_hash(h)          // YALNIZ hash
     ///   None    => is_trusted_legacy(name, id)    // pre-v0.6 peer
     ///
+    /// Bu test connection.rs'teki `trusted` ifadesini Settings seviyesinde
+    /// simüle eder — tam flow (prompt_accept) için test harness yok.
+    ///
     /// Legacy kullanıcı migration UX: ilk v0.6 bağlantısında one-time
-    /// dialog kabul edilir (bu test o davranışı doğrular). Accept sonrası
-    /// opportunistic upgrade hash'i bağlar, sonraki bağlantılar dialog'suz.
+    /// dialog kullanıcıya gösterilir; Accept sonrası connection.rs'in
+    /// opportunistic upgrade bloğu hash'i legacy kayda bağlar, sonraki
+    /// bağlantılar dialog'suz geçer.
     #[test]
-    fn v06_legacy_kayit_hash_ile_gelirse_dialog_yok() {
+    fn v06_legacy_kayit_hash_ile_gelirse_dialog_zorunlu() {
         let mut s = Settings::default();
         // Kullanıcı v0.5'te "Pixel 7"yi trusted etmiş, hash yok.
         s.add_trusted("Pixel 7", "endpoint-abc");


### PR DESCRIPTION
## Özet

PR #35 merge edildi, fakat 4 review yorumu yanıtlanmadı — ve fix'lerden biri (trust kararındaki `||` OR fallback) yeni bir HIGH güvenlik regresyonu yarattı. Bu hotfix tüm 4 yorumu **doğru** şekilde adresler.

## Adreslenen PR #35 review yorumları

### [HIGH] `connection.rs` — legacy fallback OR auto-trust bypass'ı (Copilot)
> [discussion_r3107564927](https://github.com/YatogamiRaito/HekaDrop/pull/35#discussion_r3107564927)

**Sorun:** PR #35 trust kararını şu şekilde bıraktı:

```rust
Some(h) => s.is_trusted_by_hash(h) || s.is_trusted_legacy(remote_name, remote_id),
```

Attacker kurbanın legacy `(name, id)`'sini spoof eder, kendi hash'i ile bağlanır → OR fallback match verir → **auto-accept** → Accept branch'indeki opportunistic upgrade attacker'ın hash'ini legacy kayda **kalıcı olarak** bağlar. Legacy fallback v0.7'de kaldırılsa bile attacker sessiz trust ile kalır.

**Fix (bu PR):** trust kararı strict hash-first:

```rust
Some(h) => s.is_trusted_by_hash(h),              // YALNIZ hash
None    => s.is_trusted_legacy(remote_name, remote_id),  // pre-v0.6 peer
```

**Rationale — rollback neden doğru:** legacy spoofing vektörünü kapatmak öncelik. Gerçek legacy kullanıcıların ödeyeceği bedel **one-time dialog** (ilk v0.6 bağlantısında). Kullanıcı Accept dediğinde opportunistic upgrade (PR #35'te zaten Accept branch'ine gate'lenmişti) hash'i bağlar, sonraki bağlantılar dialog'suz. Migration için one-time dialog doğru güvenlik bedeli.

**Regresyon testi eklendi:** `v06_legacy_match_hash_mismatch_spoofing_engellenir` — legacy match + unknown hash kombinasyonunun auto-trust üretmediğini doğrular. Mevcut `v06_legacy_kayit_hash_ile_gelirse_dialog_yok` hash-first invariant'ına göre invert edildi (eski OR-based assertion yerine strict hash-first).

### [MED] `window.html` — `escapeAttr` HTML attr escape'i için yanlış (Gemini)
> [discussion_r3107561275](https://github.com/YatogamiRaito/HekaDrop/pull/35#discussion_r3107561275)

**Sorun:** `escapeAttr` tek tırnakları `\'` (JS string literal escape) ile kaçırıyordu — HTML attr için yanlış. `aria-label="O\'Brian"` ekran okuyucuya ters bölü sızdırabilir.

**Fix:** `escapeAttr` artık proper HTML entity escape üretir (`&amp; &quot; &lt; &gt;`). Çift tırnaklı attr içinde tek tırnak escape gerektirmez.

**Bonus fix:** `onclick="act('...${x}')"` gibi "HTML attr içinde tek tırnaklı JS string" bağlamı için yeni `escapeJsInAttr` helper'ı eklendi ve 2 callsite'a (trust_remove + reveal) uygulandı. Eski `escapeAttr` orası için kısmen çalışıyordu; şimdi iki bağlam açıkça ayrıldı.

### [MED] `window.html` — `tf()` placeholder logic dedup (Gemini)
> [discussion_r3107561278](https://github.com/YatogamiRaito/HekaDrop/pull/35#discussion_r3107561278)

**Analiz:** `t(key, ...args)` zaten `{N}` placeholder substitution yapıyor (regex tabanlı). Yani `tf(key, args)` genuine bir duplicate — `split/join` ile yeniden yapıyordu.

**Fix:** `tf(key, args)` artık `t.apply(null, [key].concat(args))` ile delege eder. Substitution tek yerden (regex, null/undefined → empty string).

### [MED] `settings.rs` — exact `0o600` assertion umask'e duyarsız (Copilot)
> [discussion_r3107564937](https://github.com/YatogamiRaito/HekaDrop/pull/35#discussion_r3107564937)

**Sorun:** `atomic_write_mode_0600_baslangictan_itibaren_uygular` testi `assert_eq!(mode, 0o600)` kullanıyordu. `OpenOptionsExt::mode(0o600)` umask ile AND'lenir — yalnız daha kısıtlayıcı olabilir. Hardened ortamda (umask 0o077+) owner bitleri daha da kısıtlanıp test false-negative verir.

**Fix:** test artık security invariant'ı kontrol ediyor:

```rust
assert_eq!(mode & 0o077, 0, "no group/world access");
assert!(owner_bits <= 0o600, "mode(0o600) umask'i gevşetmez");
```

## Atlama notu — legacy migration dialog prompt

Task spec "isteğe bağlı" olarak legacy → hash ilk-bağlantı dialog'unda customize edilmiş bir prompt önerdi ("Önceki güvenilir cihazın yeni kimliği doğrulanıyor — güveniyor musunuz?"). `prompt_accept` imzası 3 platform (macOS osascript, Windows MessageBoxW, Linux zenity/kdialog) için ayrı blocking fn'lere sahip; custom prompt'u injection etmek 3 fn + FFI layer'a ek parametre gerektirir, invasiv bir refactor. Şimdilik `connection.rs`'te `TODO(ux):` yorumu bırakıldı, polish bir sonraki UI iterasyonuna ertelendi.

## Test plan

- [x] `cargo build` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [x] `cargo test --bin hekadrop` — **158 passing** (157 baseline + 1 new regression `v06_legacy_match_hash_mismatch_spoofing_engellenir`)
- [ ] Manual: `escapeAttr` fix için webview trusted-device list test — `O'Brian` isimli bir TrustedDevice `aria-label="Güvenilen cihazı kaldır: O'Brian"` olarak render olmalı (ters bölü yok)
- [ ] Manual: legacy `(name, id)` kaydı olan bir cihaz unknown hash ile bağlandığında dialog çıkmalı (otomatik accept yok)

🤖 Generated with [Claude Code](https://claude.com/claude-code)