### PR TITLE
ci(release): per-platform debug symbol artifacts — crash triage for v0.6.0 (H#3)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,11 +66,35 @@ jobs:
           git archive --format=tar.gz --prefix="HekaDrop-${VERSION}/" -o "$TARBALL" HEAD
           ls -la "$TARBALL"
 
+      - name: Assemble universal dSYM
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          DSYM_X86="target/x86_64-apple-darwin/release/hekadrop.dSYM"
+          DSYM_ARM="target/aarch64-apple-darwin/release/hekadrop.dSYM"
+          if [ ! -d "$DSYM_X86" ] || [ ! -d "$DSYM_ARM" ]; then
+            echo "HATA: Per-arch dSYM bundle'ları bulunamadı." >&2
+            ls -la target/x86_64-apple-darwin/release/ || true
+            ls -la target/aarch64-apple-darwin/release/ || true
+            exit 1
+          fi
+          DSYM_OUT="target/HekaDrop-${VERSION}.dSYM"
+          rm -rf "$DSYM_OUT"
+          cp -R "$DSYM_ARM" "$DSYM_OUT"
+          lipo -create \
+            "$DSYM_X86/Contents/Resources/DWARF/hekadrop" \
+            "$DSYM_ARM/Contents/Resources/DWARF/hekadrop" \
+            -output "$DSYM_OUT/Contents/Resources/DWARF/hekadrop"
+          file "$DSYM_OUT/Contents/Resources/DWARF/hekadrop"
+          (cd target && zip -r "HekaDrop-${VERSION}-macos.dSYM.zip" "HekaDrop-${VERSION}.dSYM")
+          ls -la "target/HekaDrop-${VERSION}-macos.dSYM.zip"
+
       - name: Stage macOS artifacts
         run: |
+          VERSION="${GITHUB_REF_NAME#v}"
           mkdir -p release-artifacts
           cp target/HekaDrop-*.dmg release-artifacts/
           cp target/HekaDrop-*-src.tar.gz release-artifacts/
+          cp "target/HekaDrop-${VERSION}-macos.dSYM.zip" release-artifacts/
           ls -la release-artifacts/
 
       - name: Upload macOS artifacts
@@ -117,14 +141,27 @@ jobs:
           chmod +x scripts/make-deb.sh
           ./scripts/make-deb.sh
 
+      - name: Package debug symbols (DWARF)
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          DWP="target/release/hekadrop.dwp"
+          if [ ! -f "$DWP" ]; then
+            echo "HATA: $DWP bulunamadı — split-debuginfo ayarı üretmedi." >&2
+            ls -la target/release/ | head -50
+            exit 1
+          fi
+          OUT="target/HekaDrop-${VERSION}-linux-x86_64.dwp"
+          cp "$DWP" "$OUT"
+          xz -9 -T0 -f "$OUT"
+          ls -la "${OUT}.xz"
+
       - name: Stage Linux artifacts
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
           mkdir -p release-artifacts
-          # make-deb.sh proje köküne HekaDrop-<version>.deb kopyalıyor
           cp HekaDrop-"${VERSION}".deb release-artifacts/
-          # Raw binary — .deb istemeyenler için fallback
           cp target/release/hekadrop "release-artifacts/hekadrop-${VERSION}-linux-x86_64"
+          cp "target/HekaDrop-${VERSION}-linux-x86_64.dwp.xz" release-artifacts/
           ls -la release-artifacts/
 
       - name: Upload Linux artifacts
@@ -163,6 +200,14 @@ jobs:
           New-Item -ItemType Directory -Force -Path release-artifacts | Out-Null
           # Scoop manifest HekaDrop-$version.exe bekliyor (scoop/hekadrop.json)
           Copy-Item "target/release/hekadrop.exe" "release-artifacts/HekaDrop-$Version.exe"
+          $Pdb = "target/release/hekadrop.pdb"
+          if (-not (Test-Path $Pdb)) {
+            Write-Error "HATA: $Pdb bulunamadı — profile.release.debug ayarı PDB üretmedi."
+            Get-ChildItem target/release | Select-Object -First 40
+            exit 1
+          }
+          $PdbZip = "release-artifacts/HekaDrop-$Version-windows-x86_64.pdb.zip"
+          Compress-Archive -Path $Pdb -DestinationPath $PdbZip -CompressionLevel Optimal -Force
           Get-ChildItem release-artifacts
 
       - name: Upload Windows artifact
@@ -216,6 +261,10 @@ jobs:
           echo "── release-assets/ ──"
           ls -la
 
+      - name: Compute version
+        id: ver
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
       - name: GitHub Release
         uses: softprops/action-gh-release@v2
         with:
@@ -223,3 +272,14 @@ jobs:
           generate_release_notes: true
           draft: false
           prerelease: false
+          body: |
+            ## Debug symbols (crash triage)
+
+            Platform başına ayrı "debug sidecar" artefaktları crash raporu
+            sembolizasyonu (stack trace → fonksiyon adı + satır) için ekleniyor.
+            Son kullanıcı kurulumu için gerekli değildir; sadece crash/issue
+            triage sırasında indirilir.
+
+            - `HekaDrop-${{ steps.ver.outputs.version }}-macos.dSYM.zip` — universal (x86_64 + arm64) dSYM bundle, `dsymutil`/`atos` uyumlu.
+            - `HekaDrop-${{ steps.ver.outputs.version }}-linux-x86_64.dwp.xz` — DWARF package (split-debuginfo), `gdb`/`addr2line` uyumlu.
+            - `HekaDrop-${{ steps.ver.outputs.version }}-windows-x86_64.pdb.zip` — MSVC PDB, WinDbg/Visual Studio uyumlu.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,6 +93,8 @@ harness = false
 lto = "thin"
 codegen-units = 1
 strip = true
+debug = "full"
+split-debuginfo = "packed"
 
 # cargo-deb (Linux .deb paketleme) için metadata.
 # Kullanım: `./scripts/make-deb.sh`  veya  `cargo deb`


### PR DESCRIPTION
## Problem

`Cargo.toml` altında `[profile.release] strip = true` release binary'lerden sembol tablosunu ve debug info'yu tamamen siliyor. Kullanıcıdan gelen ilk crash raporunda stack trace sadece ham adresler olacak — fonksiyon adı / satır yok, triage saatlik mesele. v0.6.0 Homebrew tap'ın açıldığı "prime time" sürüm; crash sembolizasyonu kapasitesi bu sürümden itibaren zorunlu.

## Çözüm

Rust'ın native "split debuginfo" mekanizmasını kullan: binary hâlâ strip edilsin (boyut/performans korunsun), ancak debug info platform-native sidecar dosyasına paketlensin ve GitHub Release'e ayrı asset olarak yüklensin.

### `Cargo.toml` [profile.release]

```
debug = "full"
split-debuginfo = "packed"
```

Bu kombinasyon, Cargo'nun linker çıktısı oluşturulduğu anda debug info'yu ayrı bir sidecar dosyasına çıkarmasını sağlar. `strip = true` de o arada binary'yi temizler — iki mekanizma çakışmıyor.

### `release.yml`

| Platform | Sidecar kaynağı | Release asset |
|---|---|---|
| macOS (universal2) | `target/{x86_64,aarch64}-apple-darwin/release/hekadrop.dSYM/` (Cargo dsymutil) → `lipo -create` ile birleştirilmiş evrensel dSYM | `HekaDrop-<ver>-macos.dSYM.zip` |
| Linux x86_64 | `target/release/hekadrop.dwp` (Cargo DWARF package) | `HekaDrop-<ver>-linux-x86_64.dwp.xz` |
| Windows x86_64 | `target/release/hekadrop.pdb` (MSVC linker) | `HekaDrop-<ver>-windows-x86_64.pdb.zip` |

### Release body

`softprops/action-gh-release@v2` `body:` ile "Debug symbols (crash triage)" bölümü eklendi (üç dosyanın ne işe yaradığı kısa açıklama). `generate_release_notes: true` hâlâ aktif — body'den sonra otomatik notlar devam ediyor.

## Platform detayları

**macOS:** `split-debuginfo = "packed"` + `debug = "full"` altında Cargo, her `--target` için bir `hekadrop.dSYM/` bundle'ı üretir. `build-universal.sh` iki arch için ayrı build yaptığından iki ayrı dSYM oluyor; workflow bunları `lipo -create` ile tek universal DWARF'a birleştirip `.dSYM/` yapısının içine koyuyor. `zip -r` ile paketleniyor. `atos`/`dsymutil` universal dSYM'i otomatik olarak doğru arch slice'ıyla eşler.

**Linux:** `split-debuginfo = "packed"` Rust'ta `.dwp` (DWARF Package) dosyası üretir — LTO'lu ikili için tek dosya, tüm DWARF verisi. BuildID ile binary'ye bağlı; kullanıcı `.dwp`'yi binary'nin yanına koyarsa `gdb`/`addr2line` otomatik algılar. `xz -9 -T0` sıkıştırma (46 MB → ~12 MB beklenen).

**Windows:** MSVC linker `debug = "full"` altında doğrudan `hekadrop.pdb` üretir. `strip = true` Windows'ta PDB'yi etkilemez (PDB zaten ayrı dosya). `Compress-Archive -CompressionLevel Optimal` ile zip.

## Test

- **Linux local doğrulama:** `cargo build --release` çalıştırıldı, çıktılar:
  - `target/release/hekadrop` — 6.1 MB, `file` çıktısı `stripped`, BuildID `1971f2d5…` mevcut.
  - `target/release/hekadrop.dwp` — 46 MB, ELF relocatable, DWARF dolu.
- **YAML:** `python3 yaml.safe_load` geçti.
- **Cargo.toml:** `cargo metadata` geçti.
- **CI:** Bu PR release trigger'ını tetiklemiyor (tag gerekli). CI yeşili syntactic OK kanıtlar; gerçek artifact üretimi bir sonraki tag push (örn. v0.6.0-rc1) ile doğrulanır. Manuel dry-run için tag basılıp release silinebilir.

## Risk / kaygılar

- `debug = "full"` derleme süresini biraz uzatır, hedef dizinin disk kullanımını artırır; binary'nin son boyutunu değiştirmez (strip=true).
- `.deb` paketi değişmez — cargo-deb stripped binary'yi alır.
- `rust-cache` Cargo.toml hash'ine bağlı — cache doğal invalidasyon yapar.
- Universal2 dSYM birleşimi için `lipo` iki ayrı per-arch Mach-O DWARF dosyasını üniversal yapar; `atos` slice'ı crash raporunun arch'ına göre seçer.

## Test plan

- [ ] Bu PR CI yeşil olsun (YAML/Rust derleme).
- [ ] Merge sonrası örneğin `v0.6.0-rc1` pre-tag basılıp release workflow'u çalıştırılsın.
- [ ] Release page'de üç debug asset'in de yüklendiği doğrulansın.
- [ ] macOS'te `atos -arch arm64 -o HekaDrop-<ver>.dSYM/Contents/Resources/DWARF/hekadrop 0xADDR` ile manuel sembolizasyon denensin.
- [ ] Linux'te `addr2line -e hekadrop --dwarf-package hekadrop.dwp 0xADDR` test edilsin.
- [ ] Windows'ta `.pdb` WinDbg'de yüklenebiliyor mu (stack trace decode) doğrulansın.

🤖 Generated with [Claude Code](https://claude.com/claude-code)