### PR TITLE
fix(connection): clamp/reject malformed FileMetadata.size (M#7, v0.6.0 defense-in-depth)

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -510,7 +510,43 @@ async fn handle_sharing_frame(
             let mut planned_files: Vec<(i64, std::path::PathBuf, String)> = Vec::new();
             for f in &intro.file_metadata {
                 let name = f.name.clone().unwrap_or_else(|| "dosya".into());
-                let size = f.size.unwrap_or(0);
+                let raw_size = f.size.unwrap_or(0);
+                let size = match crate::file_size_guard::classify_file_size(raw_size) {
+                    crate::file_size_guard::FileSizeGuard::Accept(s) => s,
+                    crate::file_size_guard::FileSizeGuard::Clamped => {
+                        warn!(
+                            "[{}] FileMetadata.size negatif ({}) — 0'a clamp edildi (ad: {})",
+                            peer,
+                            raw_size,
+                            crate::log_redact::path_basename(std::path::Path::new(&name))
+                        );
+                        0
+                    }
+                    crate::file_size_guard::FileSizeGuard::Reject => {
+                        warn!(
+                            "[{}] FileMetadata.size MAX_FILE_BYTES sınırını aştı ({} > {}) — Introduction reddediliyor",
+                            peer,
+                            raw_size,
+                            crate::file_size_guard::MAX_FILE_BYTES
+                        );
+                        for (_pid, path, _name) in &planned_files {
+                            if let Err(e) = std::fs::remove_file(path) {
+                                if e.kind() != std::io::ErrorKind::NotFound {
+                                    tracing::debug!(
+                                        "size-guard cleanup: placeholder silinemedi {}: {}",
+                                        crate::log_redact::path_basename(path),
+                                        e
+                                    );
+                                }
+                            }
+                        }
+                        send_sharing_frame(socket, ctx, &build_sharing_cancel()).await?;
+                        bail!(
+                            "FileMetadata.size absürt büyük: {} bayt (>1 TiB limit)",
+                            raw_size
+                        );
+                    }
+                };
                 summaries.push(ui::FileSummary {
                     name: name.clone(),
                     size,

--- a/src/file_size_guard.rs
+++ b/src/file_size_guard.rs
@@ -1,0 +1,100 @@
+//! FileMetadata.size defense-in-depth guard (M#7, v0.6.0).
+//!
+//! Protobuf `FileMetadata.size` alanı `int64`. Spec gereği **non-negative**
+//! olmalı, ancak `prost` decode tarafında bu kısıtı uygulamaz — attacker
+//! negatif ya da absürt büyük değer gönderebilir.
+//!
+//! Per-file etkileri:
+//!   * **Negatif**: UI "-5 GB" gibi kozmetik bozukluk; `i64 → u64` cast
+//!     yerine "wrap" değeri → `(written*100)/total` progress aritmetiği
+//!     çöker. Payload katmanında zaten `total_size < 0` reddi var
+//!     (`payload.rs` ~L289); Introduction aşamasında aynı belirsizliği
+//!     UI'a taşımamak için burada clamp ediyoruz.
+//!   * **Absürt büyük** (>`MAX_FILE_BYTES`): Her ne kadar `total_size` guard
+//!     tek dosya seviyesinde yine payload katmanında reddetse de, Quick
+//!     Share pratiğinde LAN üzerinden 1 TiB'tan büyük tek dosya yollamak
+//!     meşru bir kullanım değil. Introduction aşamasında reddederek
+//!     consent dialog'unda absürt boyut göstermemiş oluyoruz ve
+//!     allocation + summary render maliyetini atlıyoruz.
+//!
+//! `payload.rs` içindeki `total_size` guard'ıyla aynı pattern'e uyar;
+//! bu dosya yalnız **Introduction** aşamasında per-file karar verir.
+
+/// Introduction aşamasında kabul edilecek tek dosya için üst sınır.
+/// Quick Share spec'i formal bir limit tanımlamaz; pratik güvenli değer.
+pub const MAX_FILE_BYTES: i64 = 1 << 40; // 1 TiB
+
+/// `classify_file_size` çıktısı.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FileSizeGuard {
+    /// Spec'e uygun boyut — olduğu gibi kullanılır.
+    Accept(i64),
+    /// Negatif değerde UI/aritmetik güvenliği için 0'a clamp edildi.
+    /// Çağıran taraf warn log atıp transferi kabul edebilir; attacker
+    /// istemci bilgi olarak notlanır ama tek başına bağlantı kesme sebebi
+    /// değildir (defense-in-depth).
+    Clamped,
+    /// Absürt büyük değer — Introduction tümüyle reddedilmeli, peer'a
+    /// `Cancel` frame'i yollanıp bağlantı kapatılmalıdır.
+    Reject,
+}
+
+/// Tek bir `FileMetadata.size` değerini sınıflandırır.
+pub fn classify_file_size(size: i64) -> FileSizeGuard {
+    if size < 0 {
+        FileSizeGuard::Clamped
+    } else if size > MAX_FILE_BYTES {
+        FileSizeGuard::Reject
+    } else {
+        FileSizeGuard::Accept(size)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_100mb() {
+        assert_eq!(
+            classify_file_size(100_000_000),
+            FileSizeGuard::Accept(100_000_000)
+        );
+    }
+
+    #[test]
+    fn accepts_zero() {
+        assert_eq!(classify_file_size(0), FileSizeGuard::Accept(0));
+    }
+
+    #[test]
+    fn accepts_exactly_max() {
+        assert_eq!(
+            classify_file_size(MAX_FILE_BYTES),
+            FileSizeGuard::Accept(MAX_FILE_BYTES)
+        );
+    }
+
+    #[test]
+    fn clamps_negative_one() {
+        assert_eq!(classify_file_size(-1), FileSizeGuard::Clamped);
+    }
+
+    #[test]
+    fn clamps_i64_min() {
+        assert_eq!(classify_file_size(i64::MIN), FileSizeGuard::Clamped);
+    }
+
+    #[test]
+    fn rejects_i64_max() {
+        assert_eq!(classify_file_size(i64::MAX), FileSizeGuard::Reject);
+    }
+
+    #[test]
+    fn rejects_one_tib_plus_one() {
+        assert_eq!(
+            classify_file_size(MAX_FILE_BYTES + 1),
+            FileSizeGuard::Reject
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,3 +7,4 @@
 //! `hekadrop::crypto` yüzeyini açmaktır.
 
 pub mod crypto;
+pub mod file_size_guard;

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ mod connection;
 mod crypto;
 mod discovery;
 mod error;
+mod file_size_guard;
 mod frame;
 mod i18n;
 mod identity;

--- a/tests/file_metadata_size_guard.rs
+++ b/tests/file_metadata_size_guard.rs
@@ -1,0 +1,77 @@
+//! M#7 — FileMetadata.size defense-in-depth guard regression.
+//!
+//! Saldırgan protobuf `FileMetadata.size` alanına negatif ya da absürt
+//! büyük değer koyarsa:
+//!   * negatif → Introduction aşamasında 0'a clamp (UI cosmetic fix)
+//!   * `MAX_FILE_BYTES` (1 TiB) üstü → Introduction reddedilir, peer'a
+//!     `Cancel` frame yollanır
+//!
+//! Bu test pür sınıflandırma mantığını doğrular; TCP/UKEY2 full handshake
+//! olmadan karar fonksiyonu izole edilir (aynı pattern: `trust_hijack.rs`).
+//! `src/connection.rs` içindeki Introduction handler bu modülü çağırır —
+//! mantık değişirse bu test refactor'ı yakalar.
+
+use hekadrop::file_size_guard::{classify_file_size, FileSizeGuard, MAX_FILE_BYTES};
+
+#[test]
+fn case1_negatif_size_clamped() {
+    assert_eq!(classify_file_size(-1), FileSizeGuard::Clamped);
+    assert_eq!(classify_file_size(-1_000_000), FileSizeGuard::Clamped);
+    assert_eq!(classify_file_size(i64::MIN), FileSizeGuard::Clamped);
+}
+
+#[test]
+fn case2_i64_max_reject() {
+    assert_eq!(classify_file_size(i64::MAX), FileSizeGuard::Reject);
+}
+
+#[test]
+fn case3_one_tib_plus_reject() {
+    // Tam 1 TiB kabul (sınır dahil); üstü red.
+    assert_eq!(
+        classify_file_size(MAX_FILE_BYTES),
+        FileSizeGuard::Accept(MAX_FILE_BYTES)
+    );
+    assert_eq!(
+        classify_file_size(MAX_FILE_BYTES + 1),
+        FileSizeGuard::Reject
+    );
+    // Task spec: `size = 1 << 40` → yani **tam** 1 TiB. Sınır dahildir
+    // (pratik Quick Share transferi asla 1 TiB'e yaklaşmaz; sınırın
+    // kendisinde reject yapmak gereksiz katı). Üstü (1 << 40) + 1 reject.
+    assert_eq!(
+        classify_file_size(1i64 << 40),
+        FileSizeGuard::Accept(1i64 << 40)
+    );
+    assert_eq!(classify_file_size((1i64 << 40) + 1), FileSizeGuard::Reject);
+}
+
+#[test]
+fn case4_100mb_accept() {
+    assert_eq!(
+        classify_file_size(100_000_000),
+        FileSizeGuard::Accept(100_000_000)
+    );
+}
+
+#[test]
+fn sifir_size_accept() {
+    assert_eq!(classify_file_size(0), FileSizeGuard::Accept(0));
+}
+
+#[test]
+fn max_file_sabiti_tam_olarak_1tib() {
+    assert_eq!(MAX_FILE_BYTES, 1_099_511_627_776);
+    assert_eq!(MAX_FILE_BYTES, 1i64 << 40);
+}
+
+#[test]
+fn ui_gosterilen_deger_dogrudan_accept_s_den_gelir() {
+    // UI tarafında `FileSummary.size` negatifse "-5 GB" gösterir; guard
+    // Clamped dönerse connection.rs 0'a override ediyor → UI asla negatif
+    // görmez. Bu testin kontratı: clamp kararında boyut 0 olur.
+    match classify_file_size(-42) {
+        FileSizeGuard::Clamped => { /* UI'a 0 yazılmalı — bkz. connection.rs */ }
+        other => panic!("negatif size Clamped beklenirdi, geldi: {:?}", other),
+    }
+}


### PR DESCRIPTION
## Problem

`FileMetadata.size` protobuf `int64` alanı decode sırasında non-negative / üst sınır kısıtına sahip değil. Attacker:
- **Negatif değer** gönderirse UI "-5 GB" gösterir (cosmetic bug); `i64 → u64` cast'lerde sürpriz değerler.
- **Absürt büyük değer** (`i64::MAX`) gönderirse `(written*100)/total` progress aritmetiği taşar ve allocation maliyeti patlar.

Payload katmanında `total_size` guard zaten aynı kararı veriyor (`payload.rs:289/297/358/380`), ama o kontrol chunk'lar gelmeye başladıktan sonra devreye giriyor. Bu PR defense-in-depth olarak Introduction aşamasında per-file kararı öne çeker — consent dialog'una absürt değer hiç ulaşmaz.

## Çözüm

`src/file_size_guard.rs` (yeni):
```rust
pub const MAX_FILE_BYTES: i64 = 1 << 40; // 1 TiB

pub enum FileSizeGuard {
    Accept(i64),
    Clamped,  // size < 0
    Reject,   // size > MAX_FILE_BYTES
}

pub fn classify_file_size(size: i64) -> FileSizeGuard { ... }
```

`src/connection.rs` Introduction handler:
- `Accept(s)` → olduğu gibi summary'e yazılır.
- `Clamped` → 0'a override + `warn!` log (attacker bilgi).
- `Reject` → placeholder cleanup + `build_sharing_cancel()` + `bail!`.

**MAX_FILE sabiti**: `1 << 40` (1 TiB). Quick Share LAN üzerinden 1 TB tek dosya için meşru kullanım senaryosu yok; quick-share spec'inde de formal limit yok ama pratik güvenli değer.

## Test

`tests/file_metadata_size_guard.rs` — 7 test:
- Case 1: `size = -1 / i64::MIN / -1M` → `Clamped`
- Case 2: `size = i64::MAX` → `Reject`
- Case 3: `size = (1 << 40) + 1` → `Reject`; tam `1 << 40` → `Accept` (sınır dahil)
- Case 4: `size = 100_000_000` (100 MB) → `Accept`
- `MAX_FILE_BYTES` sabiti 1_099_511_627_776 doğrulaması
- `size = 0` → `Accept`
- UI contract: Clamped kararında 0 bekleniyor

`src/file_size_guard.rs` içinde ayrıca 7 unit test (aynı case'ler).

## Test plan

- [x] `cargo fmt` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test` — 7 yeni test + 7 unit test dahil tüm suite passes

## Notlar

- `payload.rs`'deki mevcut guard kaldırılmadı — savunma derinliği prensibi (iki katman, aynı sabit).
- Gelecekte (v0.7+) `file_size_guard::MAX_FILE_BYTES` sabiti `payload.rs` local `MAX_FILE_BYTES` yerine kullanılabilir; bu PR kapsamını genişletmemek için dokunulmadı.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>