### PR TITLE
chore(release): v0.6.0 — Homebrew tap public milestone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,60 @@ All notable changes to HekaDrop will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.6.0] - 2026-04-20
+
+**"Prime time" release — Homebrew tap public yayın sürümü.**
+
+HekaDrop v0.6.0, 6 ay süren geliştirme döngüsünün kilometre taşı: Issue #17
+kripto kimlik sertleştirmesi, WCAG 2.1 AA webview, per-platform release
+workflow ve pre-release research programının (6 paralel ajan, 58 bulgu)
+akan 5 High + 1 Medium düzeltmesinin hepsi bu sürümde. CVE/GHSA advisory'si
+release notes'a ek olarak yayınlanır.
+
+### Security (research v2 — 5 High + 1 Medium)
+- **[HIGH] Per-transfer CancellationToken** (PR #37). Global
+  `STATE.cancel_flag: AtomicBool` kaldırıldı; `tokio_util::sync::CancellationToken`
+  hiyerarşisi: `cancel_root` + `active_transfers` HashMap + `TransferGuard`
+  RAII. İki paralel receiver/sender semantiği artık doğru: birinin cancel'ı
+  diğerine sızmaz; `cleanup_transfer_state` root'u sıfırlamıyor.
+  `tokio::select!` ile cancel sinyali `read_frame_timeout` await'ini
+  kesiyor (60 sn steady timeout'a kadar bekleme yok). `TransferGuard::new`
+  içinde otomatik `clear_cancel` — footgun kapandı.
+- **[HIGH] `save()` snapshot pattern** (PR #39). `Settings` ve `Stats`
+  `save()` çağrıları artık write-lock dışında çalışıyor: `snap = {let g =
+  write(); ...mutate...; g.clone()}; drop(g); snap.save()`. Yavaş FS
+  (encrypted home, FUSE) altında UI tick donmaz.
+- **[HIGH] Release debug symbols** (PR #38). Per-platform `dSYM`/`PDB`/
+  `dwp` artifact'leri GH Release'e ayrı dosya olarak yükleniyor —
+  `HekaDrop-<ver>-macos.dSYM.zip`, `-linux-x86_64.dwp.xz`,
+  `-windows-x86_64.pdb.zip`. `Cargo.toml` `[profile.release]`
+  `debug = "full"` + `split-debuginfo = "packed"` + `strip = true`.
+  Crash symbolication triage'ı mümkün.
+- **[HIGH] Privacy controls UI** (PR #42). 4 yeni Settings alanı:
+  - `advertise: bool` (default true) — mDNS LAN visibility.
+    `false` → receive-only mod (Android tarafı cihazı listede göstermez).
+  - `log_level: LogLevel` (error/warn/info/debug, default info) — tracing
+    filter. `RUST_LOG` env var override.
+  - `keep_stats: bool` (default true) — `Stats::save()` guard.
+    `false` iken yeni yazım + snapshot clone atlanır; mevcut `stats.json`
+    silinmez.
+  - `disable_update_check: bool` (default false) — GitHub release poll
+    kapat. `HEKADROP_NO_UPDATE_CHECK` env var OR setting.
+  Tüm yeni alanlar `#[serde(default)]` → eski config.json otomatik
+  migrate.
+- **[HIGH] Known-vector crypto + UKEY2 downgrade regression tests**
+  (PR #41). `pin_code_from_auth_key` için donmuş golden vektör —
+  HKDF/label değişikliğinde test kırılır. `tests/ukey2_downgrade.rs`:
+  gerçek wire-bytes encode → decode → `validate_server_init` pipeline'ı
+  üzerinden 9 senaryo (happy path + cipher downgrade + version downgrade
+  + malformed message_type). `src/lib.rs` `validate_server_init` ve
+  `securegcm::*` tipleri integration testten erişilebilir şekilde
+  expose edildi.
+- **[MED] `FileMetadata.size` guard** (PR #40, defense-in-depth).
+  Negatif `size` → 0'a clamp + warn log; `MAX_FILE_BYTES` (1 TiB) üstü
+  → `Cancel` + `bail!`. `src/file_size_guard.rs` yeni modül +
+  `classify_file_size` pure helper + 7 unit + 4 integration test.
+  UI "-5 GB" cosmetic bug + absürt allocation overflow savunması.
 
 ### Security (v0.6 hotfix #2 — PR #35 review aftermath)
 - **[HIGH] Legacy spoofing vektörü kapatıldı** (`connection.rs` —

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1510,7 +1510,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hekadrop"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "aes",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hekadrop"
-version = "0.5.2"
+version = "0.6.0"
 edition = "2021"
 description = "Google Quick Share (Nearby Share) protokolünün Rust implementasyonu — cross-platform alıcı/gönderici"
 authors = ["destek@sourvice.com"]

--- a/Casks/hekadrop.rb
+++ b/Casks/hekadrop.rb
@@ -1,6 +1,6 @@
 cask "hekadrop" do
-  version "0.5.2"
-  sha256 "a3e9612143a6811c05609369984c9eb0b49f27ef39632864b7444575392a083f"
+  version "0.6.0"
+  sha256 :no_check
 
   url "https://github.com/YatogamiRaito/HekaDrop/releases/download/v#{version}/HekaDrop-#{version}.dmg"
   name "HekaDrop"

--- a/resources/Info.plist
+++ b/resources/Info.plist
@@ -11,9 +11,9 @@
     <key>CFBundleDisplayName</key>
     <string>HekaDrop</string>
     <key>CFBundleVersion</key>
-    <string>0.5.2</string>
+    <string>0.6.0</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.5.2</string>
+    <string>0.6.0</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleInfoDictionaryVersion</key>

--- a/resources/window.html
+++ b/resources/window.html
@@ -1221,7 +1221,7 @@
     }
     // escapeJsInAttr — `onclick="act('${x}')"` gibi "HTML attr içinde tek
     // tırnaklı JS string" bağlamı için iki-katmanlı escape. Önce JS
-    // string-literal düzeyinde ters bölü + tek tırnak + newline + </script>
+    // string-literal düzeyinde ters bölü + tek tırnak + newline + <\/script>
     // kaçırılır; sonra HTML attribute düzeyinde `&` + `<` + `>` + `"`
     // entity'lerine dönüşür. `escapeAttr` saf HTML için (aria-label vb.),
     // bu helper JS-mixed bağlam için.

--- a/scoop/hekadrop.json
+++ b/scoop/hekadrop.json
@@ -1,10 +1,10 @@
 {
-  "version": "0.5.2",
+  "version": "0.6.0",
   "description": "Google Quick Share (Nearby Share) client — Rust, cross-platform",
   "homepage": "https://github.com/YatogamiRaito/HekaDrop",
   "license": "MIT",
   "url": "https://github.com/YatogamiRaito/HekaDrop/releases/download/v$version/HekaDrop-$version.exe",
-  "hash": "2ab318e54b7dce9d4b046a8fece5fa1cc2d69e7b1995a3b631f2c63eabfda0be",
+  "hash": "0000000000000000000000000000000000000000000000000000000000000000",
   "bin": [
     [
       "HekaDrop-$version.exe",

--- a/src/main.rs
+++ b/src/main.rs
@@ -680,6 +680,8 @@ fn push_i18n_to_ui() {
         "webview.privacy.update_check.label",
         "webview.privacy.update_check.desc",
         "webview.privacy.restart_notice",
+        "webview.badge.on",
+        "webview.badge.off",
         "webview.diag.section.app",
         "webview.diag.version",
         "webview.diag.device",


### PR DESCRIPTION
## v0.6.0 release PR

### Version bumps
- `Cargo.toml` + `Cargo.lock` → 0.6.0
- `resources/Info.plist` CFBundleVersion + CFBundleShortVersionString → 0.6.0
- `Casks/hekadrop.rb` version → 0.6.0, `sha256 :no_check` (release sonrası gerçek SHA ile değiştirilecek)
- `scoop/hekadrop.json` version → 0.6.0, hash placeholder (release sonrası .exe SHA-256 ile değiştirilecek)

### CHANGELOG
`[Unreleased]` bölümü `[0.6.0] - 2026-04-20` başlığına çevrildi; research v2 5 High + 1 Medium (#37, #38, #39, #40, #41, #42) detaylı özet eklendi.

### Release post-merge adımları
1. `git tag -a v0.6.0 -m "v0.6.0" && git push origin v0.6.0`
2. `release.yml` tetiklenir → macOS DMG + Linux .deb + Windows .exe + per-platform debug symbols + CHECKSUMS.txt
3. GH Release body = CHANGELOG [0.6.0] bloğu + CVE/GHSA advisory (design 017 §6)
4. `Casks/hekadrop.rb` sha256 → DMG'den al, commit + push (main)
5. `scoop/hekadrop.json` hash → .exe SHA-256, commit + push (main)
6. `YatogamiRaito/homebrew-tap` repo'suna `Casks/hekadrop.rb` push (tap public yayını)
7. README.md "Homebrew (macOS — yakında)" → "Homebrew (macOS)" + install komutu aktif

### Test plan
- [x] `cargo build --release` local
- [x] `cargo check` + `Cargo.lock` sync
- [ ] CI 3 platform pass
- [ ] Manual: post-tag release workflow artifact'leri beklenenler

🤖 Generated with [Claude Code](https://claude.com/claude-code)