### PR TITLE
hotfix(release): v0.6.0 release workflow — defer debug symbols + fix .deb glob

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,35 +66,14 @@ jobs:
           git archive --format=tar.gz --prefix="HekaDrop-${VERSION}/" -o "$TARBALL" HEAD
           ls -la "$TARBALL"
 
-      - name: Assemble universal dSYM
-        run: |
-          VERSION="${GITHUB_REF_NAME#v}"
-          DSYM_X86="target/x86_64-apple-darwin/release/hekadrop.dSYM"
-          DSYM_ARM="target/aarch64-apple-darwin/release/hekadrop.dSYM"
-          if [ ! -d "$DSYM_X86" ] || [ ! -d "$DSYM_ARM" ]; then
-            echo "HATA: Per-arch dSYM bundle'ları bulunamadı." >&2
-            ls -la target/x86_64-apple-darwin/release/ || true
-            ls -la target/aarch64-apple-darwin/release/ || true
-            exit 1
-          fi
-          DSYM_OUT="target/HekaDrop-${VERSION}.dSYM"
-          rm -rf "$DSYM_OUT"
-          cp -R "$DSYM_ARM" "$DSYM_OUT"
-          lipo -create \
-            "$DSYM_X86/Contents/Resources/DWARF/hekadrop" \
-            "$DSYM_ARM/Contents/Resources/DWARF/hekadrop" \
-            -output "$DSYM_OUT/Contents/Resources/DWARF/hekadrop"
-          file "$DSYM_OUT/Contents/Resources/DWARF/hekadrop"
-          (cd target && zip -r "HekaDrop-${VERSION}-macos.dSYM.zip" "HekaDrop-${VERSION}.dSYM")
-          ls -la "target/HekaDrop-${VERSION}-macos.dSYM.zip"
+      # macOS dSYM üniversal assemble şu an v0.6.0 için devre dışı — H#3 workflow
+      # config'i split-debuginfo ile uyumsuz; düzgün implementasyon v0.6.1.
 
       - name: Stage macOS artifacts
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
           mkdir -p release-artifacts
           cp target/HekaDrop-*.dmg release-artifacts/
           cp target/HekaDrop-*-src.tar.gz release-artifacts/
-          cp "target/HekaDrop-${VERSION}-macos.dSYM.zip" release-artifacts/
           ls -la release-artifacts/
 
       - name: Upload macOS artifacts
@@ -141,19 +120,9 @@ jobs:
           chmod +x scripts/make-deb.sh
           ./scripts/make-deb.sh
 
-      - name: Package debug symbols (DWARF)
-        run: |
-          VERSION="${GITHUB_REF_NAME#v}"
-          DWP="target/release/hekadrop.dwp"
-          if [ ! -f "$DWP" ]; then
-            echo "HATA: $DWP bulunamadı — split-debuginfo ayarı üretmedi." >&2
-            ls -la target/release/ | head -50
-            exit 1
-          fi
-          OUT="target/HekaDrop-${VERSION}-linux-x86_64.dwp"
-          cp "$DWP" "$OUT"
-          xz -9 -T0 -f "$OUT"
-          ls -la "${OUT}.xz"
+      # Debug symbols (DWARF/dwp) şu an v0.6.0 için devre dışı — H#3 workflow
+      # config'i split-debuginfo ile uyumsuz; düzgün implementasyon v0.6.1.
+      # Atlama yerine adım tamamen kaldırıldı (sessiz fail yerine net davranış).
 
       - name: Stage Linux artifacts
         run: |
@@ -161,7 +130,6 @@ jobs:
           mkdir -p release-artifacts
           cp HekaDrop-"${VERSION}".deb release-artifacts/
           cp target/release/hekadrop "release-artifacts/hekadrop-${VERSION}-linux-x86_64"
-          cp "target/HekaDrop-${VERSION}-linux-x86_64.dwp.xz" release-artifacts/
           ls -la release-artifacts/
 
       - name: Upload Linux artifacts
@@ -273,13 +241,8 @@ jobs:
           draft: false
           prerelease: false
           body: |
-            ## Debug symbols (crash triage)
+            Ayrıntılar için [CHANGELOG](https://github.com/YatogamiRaito/HekaDrop/blob/v${{ steps.ver.outputs.version }}/CHANGELOG.md).
 
-            Platform başına ayrı "debug sidecar" artefaktları crash raporu
-            sembolizasyonu (stack trace → fonksiyon adı + satır) için ekleniyor.
-            Son kullanıcı kurulumu için gerekli değildir; sadece crash/issue
-            triage sırasında indirilir.
-
-            - `HekaDrop-${{ steps.ver.outputs.version }}-macos.dSYM.zip` — universal (x86_64 + arm64) dSYM bundle, `dsymutil`/`atos` uyumlu.
-            - `HekaDrop-${{ steps.ver.outputs.version }}-linux-x86_64.dwp.xz` — DWARF package (split-debuginfo), `gdb`/`addr2line` uyumlu.
-            - `HekaDrop-${{ steps.ver.outputs.version }}-windows-x86_64.pdb.zip` — MSVC PDB, WinDbg/Visual Studio uyumlu.
+            Windows PDB sidecar'ı (crash triage) bu yayında mevcut; macOS dSYM
+            ve Linux dwp debug sembolleri v0.6.1'e ertelendi (split-debuginfo
+            workflow uyumsuzluğu).

--- a/scripts/make-deb.sh
+++ b/scripts/make-deb.sh
@@ -26,11 +26,13 @@ fi
 echo "==> cargo deb (HekaDrop v${VERSION})"
 cargo deb
 
-# cargo-deb çıktı dosyası: target/debian/hekadrop_<version>_amd64.deb
-# Mimari host'a göre değişebilir (aarch64, arm64, vb.) — o yüzden glob ile bul.
-DEB_SRC="$(ls -t target/debian/hekadrop_"${VERSION}"_*.deb 2>/dev/null | head -n1 || true)"
+# cargo-deb iki isim şeması üretebilir:
+#   1) hekadrop_<version>_<arch>.deb              (eski davranış)
+#   2) hekadrop_<version>-<revision>_<arch>.deb   (cargo-deb v3+ default — revision 1)
+# Glob her ikisini yakalar; mimari host'a göre değişebilir (amd64, arm64, …).
+DEB_SRC="$(ls -t target/debian/hekadrop_"${VERSION}"*_*.deb 2>/dev/null | head -n1 || true)"
 if [[ -z "$DEB_SRC" || ! -f "$DEB_SRC" ]]; then
-  echo "HATA: cargo-deb çıktısı bulunamadı (target/debian/hekadrop_${VERSION}_*.deb)." >&2
+  echo "HATA: cargo-deb çıktısı bulunamadı (target/debian/hekadrop_${VERSION}*_*.deb)." >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Problem

v0.6.0 tag push sonrası release workflow 2 platformda fail:

1. **Linux**: `scripts/make-deb.sh` glob `hekadrop_0.6.0_*.deb` arıyor, cargo-deb v3 default `hekadrop_0.6.0-1_amd64.deb` üretiyor (revision). Glob revision'ı yakalamıyor.
2. **macOS**: H#3'te (PR #38) eklenen "Assemble universal dSYM" step'i `split-debuginfo = "packed"` + manuel `lipo` zinciri üzerinden dSYM bundle bekliyor; Cargo bu şekilde macOS'ta dSYM üretmiyor → `lipo` fail → job fail.

Windows PDB build'i **başarılı** (hâlâ mevcut). Publish-release job skip'lendi çünkü 2 build fail'di.

## Çözüm

- `scripts/make-deb.sh`: glob `hekadrop_\${VERSION}*_*.deb` — hem eski (`_version_arch.deb`) hem yeni (`_version-revision_arch.deb`) şemayı yakalar.
- `.github/workflows/release.yml`: `Assemble universal dSYM` (macOS) + `Package debug symbols (DWARF)` (Linux) step'leri + bunlara bağlı cp'ler kaldırıldı. Windows PDB korundu.
- Release body güncellendi — macOS/Linux debug symbols v0.6.1'e ertelendi, Windows PDB mevcut.

## Sonraki

1. Merge bu hotfix main'e.
2. `v0.6.0` tag'i **sil + yeniden at** (destructive, user explicit onayı ile — kullanıcı "hotfix at" dedi).
3. Release workflow re-run → GH Release yaratılır (DMG + .deb + .exe + PDB + src tarball + CHECKSUMS).
4. Cask sha256 + Scoop hash güncelle post-release.
5. Homebrew-tap repo public push.

## v0.6.1 scope

`[profile.release]` platform-conditional debug config + workflow'da per-arch `dsymutil` + `objcopy`-based symbol split. Düzgün dSYM.zip + dwp.xz sidecar artifact'leri.

🤖 Generated with [Claude Code](https://claude.com/claude-code)