### PR TITLE
chore(release): v0.6.0 post-release — Cask sha256 + Scoop hash + README tap live

### DIFF
--- a/Casks/hekadrop.rb
+++ b/Casks/hekadrop.rb
@@ -1,6 +1,6 @@
 cask "hekadrop" do
   version "0.6.0"
-  sha256 :no_check
+  sha256 "8c46061f595cc5541fcb2062292c54f1671b588d1b60467c5f95f560a2534941"
 
   url "https://github.com/YatogamiRaito/HekaDrop/releases/download/v#{version}/HekaDrop-#{version}.dmg"
   name "HekaDrop"

--- a/README.md
+++ b/README.md
@@ -58,14 +58,13 @@ doğrudan — bulut yok, hesap yok, tracker yok.
 
 ## Kurulum
 
-### Homebrew (macOS — yakında)
+### Homebrew (macOS)
 
 ```bash
 brew install --cask yatogamiraito/tap/hekadrop
 ```
 
-> Tap (`yatogamiraito/homebrew-tap`) henüz yayında değil — **coming soon**.
-> `Casks/hekadrop.rb` dosyası repoda hazır (v0.4.0 zip + SHA ile); tap repo'ya kopyalandığında doğrudan çalışır.
+Tap (`yatogamiraito/homebrew-tap`) v0.6.0 ile public yayına girdi. Cask her yeni release'te güncellenir.
 
 ### Releases (zip / deb / exe)
 

--- a/scoop/hekadrop.json
+++ b/scoop/hekadrop.json
@@ -4,7 +4,7 @@
   "homepage": "https://github.com/YatogamiRaito/HekaDrop",
   "license": "MIT",
   "url": "https://github.com/YatogamiRaito/HekaDrop/releases/download/v$version/HekaDrop-$version.exe",
-  "hash": "0000000000000000000000000000000000000000000000000000000000000000",
+  "hash": "d33c26c049d5d31d5eb4f129265299a14afff1161a24ffa2048eb3975c8712a5",
   "bin": [
     [
       "HekaDrop-$version.exe",


### PR DESCRIPTION
## Post-release — v0.6.0 artifact SHA'larını yansıt

GH Release v0.6.0 yayında (7 artifact + CHECKSUMS.txt). CHECKSUMS.txt'ten alınan değerler:

- `Casks/hekadrop.rb` → `sha256 "8c46061f595cc5541fcb2062292c54f1671b588d1b60467c5f95f560a2534941"` (`HekaDrop-0.6.0.dmg`)
- `scoop/hekadrop.json` → `"hash": "d33c26c049d5d31d5eb4f129265299a14afff1161a24ffa2048eb3975c8712a5"` (`HekaDrop-0.6.0.exe`)

README'de `Homebrew (macOS — yakında)` → `Homebrew (macOS)`; tap (`YatogamiRaito/homebrew-tap`) v0.6.0 ile public.

## Bundan sonra

`Casks/hekadrop.rb` dosyası `YatogamiRaito/homebrew-tap` public repo'sunun `Casks/` dizinine bu PR merge olduktan sonra kopyalanacak (ayrı işlem — tap repo'suna push user onayı ile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)