### PR TITLE
fix(android): Quick Share keşif, payload_id, peer disconnect bekleme

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1129,7 +1129,7 @@ pub(crate) async fn send_sharing_frame(
     sharing: &SharingFrame,
 ) -> Result<()> {
     let body = sharing.encode_to_vec();
-    let payload_id: i64 = rand::thread_rng().next_u64() as i64;
+    let payload_id: i64 = (rand::thread_rng().next_u64() >> 1) as i64;
     let total = body.len() as i64;
 
     // İlk chunk: tam gövde, offset=0, flags=0

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -88,16 +88,28 @@ fn parse(info: &mdns_sd::ServiceInfo) -> Option<DiscoveredDevice> {
     let n_b64 = txt.get("n").and_then(|p| p.val_str().into())?;
     let endpoint_info = URL_SAFE_NO_PAD.decode(n_b64).ok()?;
 
-    if endpoint_info.len() < 18 {
+    if endpoint_info.len() < 17 {
         return None;
     }
     let bitmap = endpoint_info[0];
     let device_type = (bitmap >> 1) & 0x07;
-    let name_len = endpoint_info[17] as usize;
-    if endpoint_info.len() < 18 + name_len {
-        return None;
+
+    let name = if endpoint_info.len() >= 18 {
+        let name_len = endpoint_info[17] as usize;
+        if endpoint_info.len() >= 18 + name_len && name_len > 0 {
+            String::from_utf8(endpoint_info[18..18 + name_len].to_vec()).ok()
+        } else {
+            None
+        }
+    } else {
+        None
     }
-    let name = String::from_utf8(endpoint_info[18..18 + name_len].to_vec()).ok()?;
+    .unwrap_or_else(|| {
+        info.get_hostname()
+            .trim_end_matches('.')
+            .trim_end_matches(".local")
+            .to_string()
+    });
 
     Some(DiscoveredDevice {
         name,

--- a/src/sender.rs
+++ b/src/sender.rs
@@ -91,7 +91,7 @@ pub async fn send(req: SendRequest) -> Result<()> {
             path: path.clone(),
             name,
             size: raw_size as i64,
-            payload_id: rand::thread_rng().next_u64() as i64,
+            payload_id: (rand::thread_rng().next_u64() >> 1) as i64,
         });
     }
     // Multi-file toplamda i64 overflow olmaması için checked_add kullan.
@@ -279,6 +279,15 @@ pub async fn send(req: SendRequest) -> Result<()> {
                             .await?;
                             bytes_sent += plan.size;
                         }
+                        // Peer'in son chunk'ı işleyip Disconnection göndermesini
+                        // bekle. Aksi halde Android "Dosya alınamadı" der çünkü
+                        // alıcı son chunk'ı işlerken bizim tarafımız TCP'yi
+                        // kapatmış oluyor.
+                        let _ = tokio::time::timeout(
+                            std::time::Duration::from_secs(10),
+                            wait_peer_disconnect(&mut socket, &mut ctx),
+                        )
+                        .await;
                         connection::send_disconnection(&mut socket, &mut ctx)
                             .await
                             .ok();
@@ -412,6 +421,46 @@ async fn send_file_chunks(
         }
     }
     Ok(())
+}
+
+/// Son chunk'tan sonra peer'in Disconnection veya herhangi bir kapanış sinyalini
+/// göndermesini bekler. Böylece Android dosyayı diske yazıp doğrularken bizim
+/// tarafımız TCP'yi kapatmış olmaz. Hata/EOF durumlarında sessizce döner —
+/// caller tarafında `timeout` sarmalayıcısı zaten üst sınırı koyuyor.
+async fn wait_peer_disconnect(socket: &mut TcpStream, ctx: &mut SecureCtx) -> Result<()> {
+    loop {
+        let raw = match frame::read_frame(socket).await {
+            Ok(r) => r,
+            Err(_) => return Ok(()),
+        };
+        let inner = match ctx.decrypt(&raw) {
+            Ok(b) => b,
+            Err(_) => continue,
+        };
+        let Ok(offline) = OfflineFrame::decode(inner.as_ref()) else {
+            continue;
+        };
+        let Some(v1) = offline.v1 else { continue };
+        let ftype = v1
+            .r#type
+            .and_then(|t| v1_frame::FrameType::try_from(t).ok());
+        match ftype {
+            Some(v1_frame::FrameType::Disconnection) => return Ok(()),
+            Some(v1_frame::FrameType::KeepAlive) => {
+                let reply = OfflineFrame {
+                    version: Some(1),
+                    v1: Some(V1Frame {
+                        r#type: Some(v1_frame::FrameType::KeepAlive as i32),
+                        keep_alive: Some(Default::default()),
+                        ..Default::default()
+                    }),
+                };
+                let enc = ctx.encrypt(&reply.encode_to_vec())?;
+                frame::write_frame(socket, &enc).await?;
+            }
+            _ => {}
+        }
+    }
 }
 
 fn wrap_payload_transfer(

--- a/src/sender.rs
+++ b/src/sender.rs
@@ -48,6 +48,12 @@ use tracing::{info, warn};
 /// Quick Share yönergeleri 512 KB civarını öneriyor; 1 MB sınırı zorlar.
 const CHUNK_SIZE: usize = 512 * 1024;
 
+/// Son chunk gönderildikten sonra peer'in Disconnection frame'ini (veya
+/// EOF'u) beklemek için üst sınır. Android dosyayı diske yazıp doğrulamayı
+/// bitirmeden bizim TCP'yi kapatmamamız için gerekli. 10 sn, 1 GB'lık bir
+/// dosyanın Android tarafında fsync + doğrulama süresinden rahat geniştir.
+const PEER_DISCONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
 pub struct SendRequest {
     pub device: DiscoveredDevice,
     pub files: Vec<std::path::PathBuf>,
@@ -284,7 +290,7 @@ pub async fn send(req: SendRequest) -> Result<()> {
                         // alıcı son chunk'ı işlerken bizim tarafımız TCP'yi
                         // kapatmış oluyor.
                         let _ = tokio::time::timeout(
-                            std::time::Duration::from_secs(10),
+                            PEER_DISCONNECT_TIMEOUT,
                             wait_peer_disconnect(&mut socket, &mut ctx),
                         )
                         .await;
@@ -423,10 +429,12 @@ async fn send_file_chunks(
     Ok(())
 }
 
-/// Son chunk'tan sonra peer'in Disconnection veya herhangi bir kapanış sinyalini
-/// göndermesini bekler. Böylece Android dosyayı diske yazıp doğrularken bizim
-/// tarafımız TCP'yi kapatmış olmaz. Hata/EOF durumlarında sessizce döner —
-/// caller tarafında `timeout` sarmalayıcısı zaten üst sınırı koyuyor.
+/// Son chunk'tan sonra peer'in `Disconnection` frame'ini göndermesini veya
+/// bağlantının EOF/okuma hatasıyla kapanmasını bekler. Arada gelen
+/// `KeepAlive` çağrılarına yanıt verir; diğer frame tipleri yok sayılır.
+/// Böylece Android dosyayı diske yazıp doğrularken bizim tarafımız TCP'yi
+/// kapatmış olmaz. Üst sınır caller'daki [`PEER_DISCONNECT_TIMEOUT`]
+/// sarmalayıcısıyla uygulanır.
 async fn wait_peer_disconnect(socket: &mut TcpStream, ctx: &mut SecureCtx) -> Result<()> {
     loop {
         let raw = match frame::read_frame(socket).await {


### PR DESCRIPTION
## Özet

Mac → Android yönünde Quick Share gönderiminin uçtan uca çalışması için üç ayrı bug düzeltildi. Hepsi canlı cihazda gözlemlendi.

- **Keşif (`discovery.rs`):** Android endpoint_info'yu **17 bayt** gönderiyor (bitmap + 16 rastgele; isim bayt zinciri hiç yok). Eski parser `< 18` kontrolüyle bunları sessizce eliyordu → mDNS'te görünmesine rağmen cihaz listede hiç çıkmıyordu. Minimum 17 bayta indirildi, isim yoksa mDNS hostname'ine fallback (`Android_KG89ALUP` gibi).
- **payload_id (`sender.rs`, `connection.rs`):** `rand::thread_rng().next_u64() as i64` → u64'ün yüksek biti varsa i64 negatif çıkıyordu. Google referans implementasyonu `Math.abs(Random.nextLong())` kullanıyor. Biz de `>> 1` ile pozitif i64 üretiyoruz.
- **Peer disconnect bekleme (`sender.rs`):** Son file chunk'tan hemen sonra Disconnection + TCP close → Android dosyayı diske yazıp doğrulamayı bitirmeden bağlantı düşünce "Dosya alınamadı" hatası. Artık son chunk sonrası peer'in Disconnection frame'i 10 sn boyunca bekleniyor (arada gelen KeepAlive'lara yanıt veriyoruz), ardından kendi Disconnection'ımız gidiyor.

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` temiz
- [x] `cargo fmt --check` temiz
- [x] `cargo test --bins` — 171 test yeşil
- [x] Manuel: Mac (Ebubekir Mac Mini) → Android Quick Share — keşif, UKEY2, introduction/accept, file transfer tamamlandı
- [ ] Android tarafında "Dosya alındı" bildirimi (kullanıcı doğrulaması bekleniyor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)