### PR TITLE
feat(ux+net): tray sol tık → pencere aç + if-addrs is_p2p filtresi

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -358,6 +358,8 @@ fn run_app() -> ! {
     push_i18n_to_ui();
 
     let menu_channel = MenuEvent::receiver();
+    #[cfg(not(target_os = "linux"))]
+    let tray_channel = TrayIconEvent::receiver();
     let open_downloads_id = open_downloads.id().clone();
     let open_config_id = open_config.id().clone();
     let about_item_id = about_item.id().clone();
@@ -427,15 +429,19 @@ fn run_app() -> ! {
 
         // Tray ikonunun kendisine tıklama (macOS/Windows): sol tık → pencere aç.
         // Sağ tık menüyü tray-icon tarafından otomatik açılır.
+        // Doğrudan `window.set_visible/set_focus` kullanıyoruz; state flag
+        // üzerinden gitseydik `consume_show_window()` bu tick'te geçildiği için
+        // pencere bir sonraki tick'e (≤250ms) kalırdı.
         #[cfg(not(target_os = "linux"))]
-        while let Ok(ev) = TrayIconEvent::receiver().try_recv() {
+        while let Ok(ev) = tray_channel.try_recv() {
             if let TrayIconEvent::Click {
                 button: MouseButton::Left,
                 button_state: MouseButtonState::Up,
                 ..
             } = ev
             {
-                state::request_show_window();
+                window.set_visible(true);
+                window.set_focus();
             }
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,8 @@ use tokio::runtime::Handle;
 use tracing::info;
 use tray_icon::menu::{CheckMenuItem, Menu, MenuEvent, MenuItem, PredefinedMenuItem};
 use tray_icon::TrayIconBuilder;
+#[cfg(not(target_os = "linux"))]
+use tray_icon::{MouseButton, MouseButtonState, TrayIconEvent};
 use wry::{DragDropEvent, WebViewBuilder};
 
 mod config;
@@ -288,12 +290,16 @@ fn run_app() -> ! {
     tray_menu.append(&PredefinedMenuItem::separator()).ok();
     tray_menu.append(&quit_item).ok();
 
-    let tray = TrayIconBuilder::new()
+    // macOS/Windows'ta sol tık = pencere aç (Quick Share UX pattern), sağ tık =
+    // menü. Linux AppIndicator click event yaymadığı için default'ta kalır
+    // (sol tık da menüyü açar, tek yol).
+    let tray_builder = TrayIconBuilder::new()
         .with_menu(Box::new(tray_menu))
         .with_title("⇄")
-        .with_tooltip("HekaDrop")
-        .build()
-        .expect("tray icon oluşturulamadı");
+        .with_tooltip("HekaDrop");
+    #[cfg(not(target_os = "linux"))]
+    let tray_builder = tray_builder.with_menu_on_left_click(false);
+    let tray = tray_builder.build().expect("tray icon oluşturulamadı");
 
     // Ana pencere + WebView
     let window = WindowBuilder::new()
@@ -417,6 +423,20 @@ fn run_app() -> ! {
             );
             let _ = webview.evaluate_script(&js_status);
             last_ui_progress_signature = sig;
+        }
+
+        // Tray ikonunun kendisine tıklama (macOS/Windows): sol tık → pencere aç.
+        // Sağ tık menüyü tray-icon tarafından otomatik açılır.
+        #[cfg(not(target_os = "linux"))]
+        while let Ok(ev) = TrayIconEvent::receiver().try_recv() {
+            if let TrayIconEvent::Click {
+                button: MouseButton::Left,
+                button_state: MouseButtonState::Up,
+                ..
+            } = ev
+            {
+                state::request_show_window();
+            }
         }
 
         // Tray menü olayları

--- a/src/mdns.rs
+++ b/src/mdns.rs
@@ -32,8 +32,9 @@ pub fn advertise(device_name: &str, port: u16) -> Result<Option<MdnsHandle>> {
     // deneyip başarısız olursa transfer düşer.
     //
     // İki filtre katmanı: (1) OS-seviyeli point-to-point flag (if-addrs 0.15+
-    // `is_p2p`; Windows/macOS/Linux'ta tutarlı olmayan tunel bayrağı), (2) isim
-    // prefix whitelisti — p2p flag yakalamadığı VPN / köprü arayüzleri için.
+    // `is_p2p()`; Windows/macOS/Linux'ta tutarlı olmayan tunel bayrağı),
+    // (2) aşağıdaki `skip_prefix` — p2p flag yakalamadığı VPN / köprü / container
+    // arayüzleri için isim-prefix denylist'i.
     // Defensive: ikisi belt-and-suspenders; biri kaçırırsa diğeri yakalar.
     let skip_prefix = [
         "docker",

--- a/src/mdns.rs
+++ b/src/mdns.rs
@@ -30,6 +30,11 @@ pub fn advertise(device_name: &str, port: u16) -> Result<Option<MdnsHandle>> {
     // Sadece fiziksel/kablosuz arayüzleri yayınla. Docker, libvirt, Tailscale ve
     // benzerleri LAN üzerinden erişilebilir değil; Android phone yanlış IP'yi
     // deneyip başarısız olursa transfer düşer.
+    //
+    // İki filtre katmanı: (1) OS-seviyeli point-to-point flag (if-addrs 0.15+
+    // `is_p2p`; Windows/macOS/Linux'ta tutarlı olmayan tunel bayrağı), (2) isim
+    // prefix whitelisti — p2p flag yakalamadığı VPN / köprü arayüzleri için.
+    // Defensive: ikisi belt-and-suspenders; biri kaçırırsa diğeri yakalar.
     let skip_prefix = [
         "docker",
         "br-",
@@ -45,6 +50,7 @@ pub fn advertise(device_name: &str, port: u16) -> Result<Option<MdnsHandle>> {
     let addrs: Vec<IpAddr> = if_addrs::get_if_addrs()?
         .into_iter()
         .filter(|i| !i.is_loopback())
+        .filter(|i| !i.is_p2p())
         .filter(|i| !skip_prefix.iter().any(|p| i.name.starts_with(p)))
         .map(|i| i.ip())
         .filter(|ip| ip.is_ipv4())


### PR DESCRIPTION
## Özet

Plan'daki follow-up maddelerinden ikisi — tek PR. Her ikisi de yeni paket sürümlerinden (tray-icon 0.22, if-addrs 0.15) yararlanıyor.

### 1. Tray sol tık → pencere aç (Quick Share UX)

macOS menu bar ve Windows tray'de artık:
- **Sol tık** → HekaDrop penceresi açılır
- **Sağ tık** → menü açılır

Bu Quick Share / Google Drive benzeri native pattern. Eskiden her tıklama menüyü açıyor, kullanıcı pencere için ayrıca menüden \"Pencereyi göster\"i seçmek zorundaydı.

**Linux değişmedi:** AppIndicator click event yayınlamıyor (libappindicator sınırı), o yüzden sol tık hâlâ menüyü açar — Linux'ta pencereyi açmak için menü tek yol.

### 2. mDNS arayüz filtresi — OS-seviyeli p2p flag

\`if_addrs 0.15\`'in yeni \`is_p2p()\` metodu point-to-point interface'leri (tun/tap/ppp/VPN) OS flagi ile tespit ediyor:
- Linux: POSIX \`IFF_POINTOPOINT\`
- macOS: SystemConfiguration SCNetworkInterface
- Windows: NET_LUID tunnel/ppp type

Mevcut \`skip_prefix\` whitelist'i defensive fallback olarak duruyor — iki katman, biri kaçırırsa diğeri yakalar.

## Dosyalar

- \`src/main.rs\`: TrayIconEvent import + cfg-gated builder/event handling
- \`src/mdns.rs\`: \`.filter(|i| !i.is_p2p())\` satırı

## Test plan

- [x] \`cargo clippy --all-targets -- -D warnings\` temiz
- [x] \`cargo fmt --check\` temiz
- [x] \`cargo test --bins\` — 171/171 yeşil
- [x] \`cargo build --release\` başarılı
- [x] Manuel: macOS menu bar → sol tık pencere açıldı, sağ tık menü geldi
- [ ] Linux regression: sol tık hâlâ menü açmalı (cfg guard'lı)
- [ ] Windows regression: sol tık pencere / sağ tık menü

🤖 Generated with [Claude Code](https://claude.com/claude-code)