### PR TITLE
fix: PR #75-#77 review yorumları + #78 orphan i18n key'leri canlandır

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ homepage = "https://github.com/YatogamiRaito/HekaDrop"
 readme = "README.md"
 keywords = ["quick-share", "nearby-share", "p2p", "file-transfer", "macos"]
 categories = ["network-programming", "command-line-utilities"]
+rust-version = "1.90"
 
 [dependencies]
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "io-util", "sync", "signal", "time", "fs"] }
@@ -95,7 +96,11 @@ opt-level = "z"
 lto = true
 codegen-units = 1
 strip = true
-debug = false
+# debug = 1 → line tables only (minimal debuginfo). Windows release build'inin
+# .pdb üretmesi için gerekli; `strip = true` ile symbol table'dan arındırılsa da
+# `split-debuginfo = "packed"` dbg info'yu ayrı pack'e alır ve crash/stack trace
+# kalitesini yükseltir. Binary boyut maliyeti ~200 KB.
+debug = 1
 split-debuginfo = "packed"
 
 # cargo-deb (Linux .deb paketleme) için metadata.

--- a/resources/window.html
+++ b/resources/window.html
@@ -1158,6 +1158,19 @@
       if (confirm(t('webview.diag.reset_confirm'))) act('stats_reset');
     }
 
+    // Modal focus trap helper: Tab/Shift+Tab liste elemanları arasında döner.
+    // length < 2 veya aktif öğe liste dışında → no-op (preventDefault da atlanır).
+    function trapFocus(e, focusableElements) {
+      if (e.key !== 'Tab' || focusableElements.length < 2) return;
+      const i = focusableElements.indexOf(document.activeElement);
+      if (i === -1) return;
+      e.preventDefault();
+      const nextIndex = e.shiftKey
+        ? (i - 1 + focusableElements.length) % focusableElements.length
+        : (i + 1) % focusableElements.length;
+      focusableElements[nextIndex].focus();
+    }
+
     // ---- Tab bar (WAI-ARIA Authoring Practices pattern) ----
     const TABS = ['home', 'history', 'settings', 'diag'];
 
@@ -1380,14 +1393,7 @@
           return;
         }
         if (e.key === 'Tab') {
-          const focusables = [clearCancel, clearConfirm];
-          const i = focusables.indexOf(document.activeElement);
-          if (i === -1) return;
-          e.preventDefault();
-          const next = e.shiftKey
-            ? focusables[(i - 1 + focusables.length) % focusables.length]
-            : focusables[(i + 1) % focusables.length];
-          next.focus();
+          trapFocus(e, [clearCancel, clearConfirm]);
         }
       });
       // Backdrop click closes (clicks on dialog bubble don't match).
@@ -1462,15 +1468,7 @@
           return;
         }
         if (e.key === 'Tab') {
-          const focusables = [onboardingSettings, onboardingDismiss].filter(Boolean);
-          if (focusables.length < 2) return;
-          const i = focusables.indexOf(document.activeElement);
-          if (i === -1) return;
-          e.preventDefault();
-          const next = e.shiftKey
-            ? focusables[(i - 1 + focusables.length) % focusables.length]
-            : focusables[(i + 1) % focusables.length];
-          next.focus();
+          trapFocus(e, [onboardingSettings, onboardingDismiss].filter(Boolean));
         }
       });
       onboardingModal.addEventListener('click', (e) => {

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -9,6 +9,7 @@
 //!   6) Plain ConnectionResponse (Accept)             (us   → peer)
 //!   7) Şifreli loop — tüm sonraki frame'ler SecureMessage katmanından geçer.
 
+use crate::error::HekaError;
 use crate::frame;
 use crate::location::nearby::connections::{
     os_info::OsType,
@@ -28,7 +29,7 @@ use crate::sharing::nearby::{
 use crate::state::{self, HistoryItem, ProgressState};
 use crate::ui;
 use crate::ukey2;
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{anyhow, Context, Result};
 use prost::Message;
 use rand::RngCore;
 use std::collections::HashMap;
@@ -96,30 +97,42 @@ pub async fn handle(mut socket: TcpStream, peer: SocketAddr) -> Result<()> {
                 "[{}] rate limit aşıldı (60 sn pencerede >10 bağlantı), reddediliyor",
                 peer
             );
-            return Err(anyhow!(
-                "rate limit: aynı IP'den çok fazla bağlantı denemesi"
-            ));
+            return Err(HekaError::RateLimited(peer.to_string()).into());
         }
     } else {
         info!("[{}] trusted cihaz — rate limit uygulanmadı", peer);
     }
 
-    // 2) UKEY2 ClientInit
-    let ci = frame::read_frame_timeout(&mut socket, frame::HANDSHAKE_READ_TIMEOUT)
-        .await
-        .context("Ukey2ClientInit okunamadı")?;
-    let state = ukey2::process_client_init(&ci).context("ClientInit")?;
-
-    // 3) UKEY2 ServerInit
-    frame::write_frame(&mut socket, &state.server_init_bytes)
-        .await
-        .context("ServerInit yazılamadı")?;
-
-    // 4) UKEY2 ClientFinished
-    let cf = frame::read_frame_timeout(&mut socket, frame::HANDSHAKE_READ_TIMEOUT)
-        .await
-        .context("Ukey2ClientFinished okunamadı")?;
-    let keys = ukey2::process_client_finish(&cf, &state).context("ClientFinish")?;
+    // 2-4) UKEY2 handshake. Bir async bloğa sarıp `?`'lerin tüm adımları
+    // kapsamasını garantiliyoruz; hata durumunda downcast zinciriyle
+    // kullanıcıya uygun i18n key (PIN / timeout / disconnect / insecure)
+    // tek noktadan gösterilir (Dalga 2 UX: "sessiz sonlandırma" yerine
+    // anlaşılır bildirim).
+    let handshake: Result<(ukey2::ServerInitResult, ukey2::DerivedKeys)> = async {
+        let ci = frame::read_frame_timeout(&mut socket, frame::HANDSHAKE_READ_TIMEOUT)
+            .await
+            .context("Ukey2ClientInit okunamadı")?;
+        let st = ukey2::process_client_init(&ci).context("ClientInit")?;
+        frame::write_frame(&mut socket, &st.server_init_bytes)
+            .await
+            .context("ServerInit yazılamadı")?;
+        let cf = frame::read_frame_timeout(&mut socket, frame::HANDSHAKE_READ_TIMEOUT)
+            .await
+            .context("Ukey2ClientFinished okunamadı")?;
+        let k = ukey2::process_client_finish(&cf, &st).context("ClientFinish")?;
+        Ok((st, k))
+    }
+    .await;
+    let (_state, keys) = match handshake {
+        Ok(v) => v,
+        Err(e) => {
+            let key = classify_handshake_error(&e);
+            warn!("[{}] UKEY2 handshake başarısız: {:#}", peer, e);
+            ui::notify(crate::i18n::t("notify.app_name"), crate::i18n::t(key));
+            state::set_progress(ProgressState::Idle);
+            return Err(e);
+        }
+    };
     // SECURITY: PIN clear-text log'a yazılmaz. 4-basamaklı PIN'in hash'i
     // brute-force olur; onun yerine 256-bit auth_key fingerprint'i
     // kullanıyoruz (bkz. `session_fingerprint`).
@@ -520,11 +533,11 @@ async fn handle_sharing_frame(
             // maliyeti yaratabilir. Quick Share pratikte tek aktarımda
             // yüzlerce dosya yeterli — 1000 cömert üst sınır.
             if file_count > 1000 || text_count > 64 {
-                bail!(
-                    "Introduction cardinality flood: {} dosya, {} metin (limit 1000/64)",
-                    file_count,
-                    text_count
-                );
+                return Err(HekaError::IntroductionFlood {
+                    files: file_count,
+                    texts: text_count,
+                }
+                .into());
             }
 
             info!(
@@ -567,10 +580,7 @@ async fn handle_sharing_frame(
                             }
                         }
                         send_sharing_frame(socket, ctx, &build_sharing_cancel()).await?;
-                        bail!(
-                            "FileMetadata.size absürt büyük: {} bayt (>1 TiB limit)",
-                            raw_size
-                        );
+                        return Err(HekaError::PayloadSizeAbsurd(raw_size).into());
                     }
                 };
                 summaries.push(ui::FileSummary {
@@ -634,6 +644,17 @@ async fn handle_sharing_frame(
 
             let auto_accept = state::get().settings.read().auto_accept;
 
+            // Dalga 3 UX: Peer hash göndermiş olduğu halde hash kayıtta yoksa,
+            // `(name, id)` legacy kaydı varsa — bu "v0.5 → v0.6 migration"
+            // senaryosudur. Dialog açılmadan önce kullanıcıya nedenini
+            // açıklayan bir bildirim gönder; aksi halde tanıdık cihaz için
+            // birden dialog görünce "güveni zedelenmiş mi?" tereddüdü doğar.
+            let migration_hint = peer_secret_id_hash.is_some() && !trusted && {
+                let st = state::get();
+                let s = st.settings.read();
+                s.is_trusted_legacy(remote_name, remote_id)
+            };
+
             let decision = if trusted {
                 info!("[{}] trusted cihaz → otomatik kabul", peer);
                 // Sliding-window TTL: aktif kullanım varsa timestamp'i yenile.
@@ -651,6 +672,16 @@ async fn handle_sharing_frame(
                 info!("[{}] settings.auto_accept=true → otomatik kabul", peer);
                 ui::AcceptResult::Accept
             } else {
+                if migration_hint {
+                    info!(
+                        "[{}] legacy → hash migration dialog'u gösteriliyor: {}",
+                        peer, remote_name
+                    );
+                    ui::notify(
+                        crate::i18n::t("trust.migration.title"),
+                        &crate::i18n::tf("trust.migration.body", &[remote_name, pin_code]),
+                    );
+                }
                 ui::prompt_accept(remote_name, pin_code, &summaries, text_count)
                     .await
                     .unwrap_or(ui::AcceptResult::Reject)
@@ -932,7 +963,7 @@ fn unique_downloads_path(name: &str) -> Result<PathBuf> {
         }
         n += 1;
         if n > 10_000 {
-            bail!("uygun dosya adı bulunamadı (10k deneme)");
+            return Err(HekaError::FileNameExhausted.into());
         }
     }
 }
@@ -1132,8 +1163,10 @@ pub(crate) async fn send_sharing_frame(
     let payload_id: i64 = (rand::thread_rng().next_u64() >> 1) as i64;
     let total = body.len() as i64;
 
-    // İlk chunk: tam gövde, offset=0, flags=0
-    let first = wrap_payload_transfer(payload_id, total, 0, 0, body.clone());
+    // İlk chunk: tam gövde, offset=0, flags=0.
+    // `body` bu satırdan sonra kullanılmıyor → clone yerine move (alokasyon
+    // yarıya iner; küçük frame'lerde önemli değil ama hot path hijyeni).
+    let first = wrap_payload_transfer(payload_id, total, 0, 0, body);
     let enc1 = ctx.encrypt(&first.encode_to_vec())?;
     frame::write_frame(socket, &enc1).await?;
 
@@ -1192,6 +1225,49 @@ pub(crate) fn build_connection_response_accept() -> OfflineFrame {
             ..Default::default()
         }),
     }
+}
+
+/// UKEY2 handshake sırasında oluşan hatayı kullanıcıya gösterilecek
+/// i18n key'ine sınıflandırır. Downcast önceliği: önce
+/// [`crate::error::HekaError`] variant'ları (tip-safe ayrım), sonra
+/// `std::io::Error` (generic I/O). String-match son çare değil — düşmüyoruz,
+/// fallback kasıtlı olarak `err.pin_mismatch`: UKEY2 handshake spec'inde
+/// handshake tamamlansa ama ClientFinished commitment reddedilse bu noktada
+/// `Ukey2CommitmentMismatch` downcast yakalar; bilinmeyen generic hata
+/// kullanıcı için de pratikte "PIN eşleşmedi" olarak yorumlanır (en sık neden).
+fn classify_handshake_error(e: &anyhow::Error) -> &'static str {
+    fn map_io_error(io: &std::io::Error) -> &'static str {
+        use std::io::ErrorKind::*;
+        match io.kind() {
+            TimedOut => "err.peer_timeout",
+            ConnectionReset | ConnectionAborted | BrokenPipe | UnexpectedEof | NotConnected => {
+                "err.peer_disconnected"
+            }
+            _ => "err.peer_disconnected",
+        }
+    }
+    for cause in e.chain() {
+        if let Some(he) = cause.downcast_ref::<HekaError>() {
+            match he {
+                HekaError::ReadTimeout(_) => return "err.peer_timeout",
+                HekaError::UnexpectedEof | HekaError::PeerDisconnected => {
+                    return "err.peer_disconnected"
+                }
+                HekaError::Io(io) => return map_io_error(io),
+                HekaError::Ukey2CommitmentMismatch => return "err.pin_mismatch",
+                HekaError::Ukey2CipherDowngrade(_)
+                | HekaError::Ukey2VersionDowngrade(_)
+                | HekaError::Ukey2(_)
+                | HekaError::CipherCommitmentFlood(_)
+                | HekaError::ProtocolState(_) => return "err.handshake_insecure",
+                _ => {}
+            }
+        }
+        if let Some(io) = cause.downcast_ref::<std::io::Error>() {
+            return map_io_error(io);
+        }
+    }
+    "err.pin_mismatch"
 }
 
 fn parse_remote_name(endpoint_info: &[u8]) -> Option<String> {
@@ -1311,12 +1387,20 @@ mod tests {
         assert_eq!(cleaned, 2, "iki yarım dosya temizlenmeliydi");
         assert!(names.is_empty(), "pending_names sıfırlanmalı");
         assert!(texts.is_empty(), "pending_texts sıfırlanmalı");
-        // NOT: `register_file_destination` çağrılmış ama hiç chunk gelmemiş dosyalar
-        // için `assembler.cancel(id)` yalnızca haritadan kaldırır — diskte
-        // file yoktur (çünkü biz elle oluşturduk). Burada test dosyalarını
-        // temizlemek test hijyeni için:
-        std::fs::remove_file(&p1).ok();
-        std::fs::remove_file(&p2).ok();
+        // Regresyon (Copilot review): `drain_pending` yalnız haritaları
+        // boşaltmakla yetinmemeli — `assembler.cancel(id)` üzerinden kayıtlı
+        // hedef dosyayı diskten de silmeli. Aksi halde reject / cancel
+        // yolunda indirme klasöründe 0-bayt placeholder'lar birikir.
+        assert!(
+            !p1.exists(),
+            "drain_pending dosyayı silmemiş: {}",
+            p1.display()
+        );
+        assert!(
+            !p2.exists(),
+            "drain_pending dosyayı silmemiş: {}",
+            p2.display()
+        );
     }
 
     #[tokio::test]

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1246,6 +1246,9 @@ fn classify_handshake_error(e: &anyhow::Error) -> &'static str {
             _ => "err.peer_disconnected",
         }
     }
+    // HekaError::Io(#[from] std::io::Error) thiserror `source()` zinciri
+    // ürettiği için iç `io::Error` aşağıdaki generic io downcast dalında
+    // yakalanır — HekaError::Io özel bir kolu gereksiz (PR #79 gemini review).
     for cause in e.chain() {
         if let Some(he) = cause.downcast_ref::<HekaError>() {
             match he {
@@ -1253,7 +1256,6 @@ fn classify_handshake_error(e: &anyhow::Error) -> &'static str {
                 HekaError::UnexpectedEof | HekaError::PeerDisconnected => {
                     return "err.peer_disconnected"
                 }
-                HekaError::Io(io) => return map_io_error(io),
                 HekaError::Ukey2CommitmentMismatch => return "err.pin_mismatch",
                 HekaError::Ukey2CipherDowngrade(_)
                 | HekaError::Ukey2VersionDowngrade(_)

--- a/src/error.rs
+++ b/src/error.rs
@@ -42,6 +42,9 @@ pub enum HekaError {
     /// Rate limiter aynı IP'den pencere aşımı tespit etti (trusted muaf).
     #[error("rate limit: aynı IP'den çok fazla bağlantı denemesi ({0})")]
     RateLimited(String),
+    /// TcpStream::connect üst sınırı aşıldı (erişilemez host / router drop).
+    #[error("bağlantı zaman aşımına uğradı ({secs} sn): {addr}")]
+    ConnectTimeout { secs: u64, addr: String },
 
     // ---- Crypto / secure channel ----
     /// HMAC tag alanı 32 bayt değil — truncation oracle / length-confusion
@@ -126,6 +129,10 @@ pub enum HekaError {
     /// Gönderici boş dosya(lar) (toplam 0 bayt).
     #[error("boş dosya gönderilemez (toplam 0 bayt)")]
     EmptyPayload,
+    /// Gönderici hiç dosya seçmedi (0 dosya). `EmptyPayload`'dan farklı —
+    /// "0 bayt dosya" değil, "hiç dosya yok".
+    #[error("hiç dosya seçilmedi")]
+    NoFilesSelected,
     /// Tek dosya boyutu i64::MAX üstü (saçma büyük).
     #[error("dosya çok büyük (>= {max} bayt, desteklenmiyor): {path}")]
     FileTooLarge { max: i64, path: String },

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -74,6 +74,18 @@ impl DeviceIdentity {
             }
             let mut key = [0u8; 32];
             key.copy_from_slice(&buf);
+
+            // SECURITY (PR #76 review — gemini): v0.6 öncesi install'lar
+            // hardening'den geçmemiş olabilir. Mevcut identity.key dosyalarını
+            // da her açılışta ACL sertleştirmeden geçiriyoruz ki eski kurulumlar
+            // da güvenli hale gelsin. Hata fatal değil — warn log + devam.
+            // (Windows dışı target'larda no-op, ucuz.)
+            if let Err(e) = harden_identity_file_acl(path) {
+                tracing::warn!(
+                    "identity.key mevcut ACL sertleştirme başarısız: {e} (devam ediliyor)"
+                );
+            }
+
             return Ok(Self { long_term_key: key });
         }
 
@@ -167,21 +179,32 @@ pub(crate) fn identity_path() -> PathBuf {
 /// username/SID hard-code etmekten kaçınırız, user profilinde dosya zaten
 /// current user'a ait oluyor.
 ///
+/// **PATH hijack koruması (PR #76 review):** `icacls.exe` PATH'ten değil,
+/// `%SystemRoot%\System32\icacls.exe` mutlak yolundan çağrılır.
+///
 /// **Test:** Windows CI yok; manuel doğrulama `icacls <path>` çıktısının
 /// yalnız `OWNER RIGHTS:(F)` ACE'si içerdiğini göstermeli.
 #[cfg(target_os = "windows")]
 fn harden_identity_file_acl(path: &std::path::Path) -> Result<()> {
     use std::process::Command;
 
-    // `icacls` PATH'te olmalı (System32 varsayılan olarak PATH'te) — sistem
-    // PATH'i sabotaj edilmişse fallback absolute path. Absolute path tercihen
-    // %SystemRoot%\System32\icacls.exe; %SystemRoot% tipik olarak C:\Windows.
-    let output = Command::new("icacls")
+    // SECURITY (PR #76 review — Copilot + gemini): PATH araması yapmayız.
+    // `Command::new("icacls")` cwd/PATH'te sahte `icacls.exe` varsa onu
+    // çağırabilirdi (PATH hijack). `icacls` Windows built-in aracıdır —
+    // doğrudan `%SystemRoot%\System32\icacls.exe` mutlak yolundan çağırırız.
+    // `%SystemRoot%` env yoksa tipik varsayılan `C:\Windows` fallback.
+    let icacls_path = std::env::var_os("SystemRoot")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from(r"C:\Windows"))
+        .join("System32")
+        .join("icacls.exe");
+
+    let output = Command::new(&icacls_path)
         .arg(path)
         .arg("/inheritance:r")
         .args(["/grant:r", "*S-1-3-4:(F)"])
         .output()
-        .context("icacls.exe çalıştırılamadı")?;
+        .with_context(|| format!("{} çalıştırılamadı", icacls_path.display()))?;
 
     if !output.status.success() {
         bail!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -839,7 +839,18 @@ fn handle_settings_save(json: &str) {
                 return;
             }
         }
-        snap.save_debounced();
+        // RUNTIME handle tokio async thread init'inde set edilir (main.rs:170).
+        // `handle_settings_save` UI event-loop thread'inden çağrılıyor → burada
+        // `Handle::try_current()` çalışmaz. OnceLock henüz set edilmemişse
+        // (teorik: async init daha başlamadıysa) sync fallback ile yaz.
+        match RUNTIME.get() {
+            Some(h) => snap.save_debounced(h),
+            None => {
+                if let Err(e) = snap.save() {
+                    tracing::warn!("settings save fallback (no runtime): {}", e);
+                }
+            }
+        }
     }
     info!("[ui] ayarlar güncellendi");
     state::enqueue_js("window.showSaved && window.showSaved()".into());
@@ -887,8 +898,13 @@ fn push_i18n_to_ui() {
         "webview.settings.saved",
         "webview.settings.trust_remove",
         "webview.settings.trust_ttl_days",
+        "webview.settings.trust_clear_title",
+        "webview.settings.trust_clear_body",
+        "webview.settings.trust_clear_cancel",
+        "webview.settings.trust_clear_confirm",
         "webview.trusted.ttl_label",
         "webview.trusted.ttl_expired",
+        "webview.trusted.expired_tooltip",
         // H#4 privacy section
         "webview.privacy.title",
         "webview.privacy.advertise.label",
@@ -904,6 +920,8 @@ fn push_i18n_to_ui() {
         "webview.privacy.update_check.label",
         "webview.privacy.update_check.desc",
         "webview.privacy.restart_notice",
+        "webview.privacy.restart_badge",
+        "webview.privacy.hotswap_badge",
         "webview.badge.on",
         "webview.badge.off",
         "webview.diag.section.app",
@@ -1433,7 +1451,20 @@ async fn check_update_async() {
             None => (body_full.as_ref(), ""),
         };
         match code {
-            "403" => return UpdateCheckOutcome::RateLimited,
+            "403" => {
+                // GitHub 403 yalnız rate-limit değildir: abuse detection,
+                // eksik/yanlış User-Agent veya kurumsal proxy blokları da aynı
+                // kodu döndürür. Body'de "rate limit" ifadesi varsa gerçekten
+                // rate-limit'tir; aksi halde kullanıcıya genel API hatası
+                // gösterip detayı kısaltılmış body ile veriyoruz (debug için).
+                let body_lower = body.to_lowercase();
+                if body_lower.contains("rate limit") || body_lower.contains("api rate limit") {
+                    return UpdateCheckOutcome::RateLimited;
+                }
+                // Body'yi 200 char ile sınırla (char-safe, UTF-8 boundary sağlam).
+                let snippet: String = body.chars().take(200).collect();
+                return UpdateCheckOutcome::ApiError(format!("403: {}", snippet));
+            }
             "200" => {}
             other if !other.is_empty() => {
                 return UpdateCheckOutcome::ApiError(format!("HTTP {}", other));
@@ -1485,30 +1516,35 @@ async fn check_update_async() {
 }
 
 fn render_update_outcome(outcome: UpdateCheckOutcome) {
+    // Hard-coded TR string'ler → i18n key'leri. Mesaj içerikleri src/i18n.rs'te
+    // `update.error.*` / `update.status.*` altında tanımlı; burada yalnızca
+    // key referansı tutuyoruz → TR/EN otomatik çözülür.
     match outcome {
         UpdateCheckOutcome::Disabled => {
-            push_update_status(i18n::t("dialog.update.disabled"), "info");
+            push_update_status(i18n::t("update.error.disabled"), "info");
         }
         UpdateCheckOutcome::Current => {
-            push_update_status("Güncel sürümdesiniz", "info");
+            push_update_status(i18n::t("update.status.up_to_date"), "info");
         }
         UpdateCheckOutcome::Available { tag, url } => {
-            push_update_status(&format!("{} mevcut → {}", tag, url), "success");
+            let msg = i18n::tf("update.status.new_version", &[&tag]);
+            // URL'yi mesaja iliştiriyoruz — i18n string'i sürüm taglına odaklı,
+            // link satır içi bilgi olarak kalıyor.
+            push_update_status(&format!("{} — {}", msg, url), "success");
         }
         UpdateCheckOutcome::NetworkError => {
-            push_update_status(
-                "Ağ hatası — GitHub API'ye ulaşılamadı, bağlantıyı kontrol edin",
-                "error",
-            );
+            push_update_status(i18n::t("update.error.network"), "error");
         }
         UpdateCheckOutcome::RateLimited => {
-            push_update_status(
-                "GitHub API rate-limit — lütfen birkaç dakika sonra tekrar deneyin",
-                "error",
-            );
+            push_update_status(i18n::t("update.error.rate_limit"), "error");
         }
         UpdateCheckOutcome::ApiError(detail) => {
-            push_update_status(&format!("API hatası: {}", detail), "error");
+            // Generic error + detay: detay debug/bug report için değerli, ana
+            // mesaj i18n'den gelir.
+            push_update_status(
+                &format!("{} ({})", i18n::t("update.error.generic"), detail),
+                "error",
+            );
         }
     }
 }

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -31,6 +31,28 @@ use tracing::warn;
 /// syscall + wakeup overhead rapor etti; sync std::io + BufWriter bunu eler.
 const FILE_WRITE_BUF_CAPACITY: usize = 128 * 1024;
 
+/// Sync bir closure'ı runtime flavor'una göre çalıştırır:
+/// - **MultiThread runtime** (prod, `#[tokio::test(flavor = "multi_thread")]`):
+///   [`tokio::task::block_in_place`] sinyaliyle sar — tokio bu worker'ı
+///   "blocking" olarak işaretler, park halindeki async task'ları başka
+///   worker'a taşır. Böylece yavaş disk (iCloud Drive, SMB/NFS mount,
+///   yavaş USB) syscall'ları network read / UI task'ları geciktirmez.
+/// - **CurrentThread runtime** (default `#[tokio::test]`): `block_in_place`
+///   çağrısı panik atar; closure'ı direkt çağırırız. Tek worker'ı zaten
+///   tutuyoruz, kaybedecek diğer worker yok.
+/// - **Runtime yok** (senkron çağrı path'i): direkt çağır.
+#[inline]
+fn block_in_place_if_multi<F, R>(f: F) -> R
+where
+    F: FnOnce() -> R,
+{
+    use tokio::runtime::{Handle, RuntimeFlavor};
+    match Handle::try_current() {
+        Ok(h) if h.runtime_flavor() == RuntimeFlavor::MultiThread => tokio::task::block_in_place(f),
+        _ => f(),
+    }
+}
+
 /// Bir chunk üzerinden geçmişken `last_chunk_at`'in ne kadar eskiyebileceği.
 ///
 /// 120 saniye = Quick Share protokolünün makul en yavaş transfer hızı bile
@@ -66,9 +88,11 @@ struct BytesBuf {
 /// (`tokio::fs`) sürümü chunk başına ~5-10 µs tokio task-pool + syscall
 /// overhead getiriyordu; 512 KiB chunk'lar zaten kısa süreli blocking I/O'ya
 /// izin verir ve 128 KiB BufWriter tamponu syscall sayısını azaltır.
-/// Dikkat: `ingest_file` hâlâ `async fn` — sync write runtime worker'ını
-/// kısa bir süre blocke eder. Ölçülen yük düşük ama çok daha yavaş diskte
-/// (ör. ağ diski) gerekirse [`tokio::task::spawn_blocking`] sarmalamaya geç.
+/// Sync I/O çağrıları `ingest_file` içinde [`block_in_place_if_multi`] ile
+/// sarılır — multi-thread runtime'da tokio'ya "blocking" sinyali verilir ki
+/// yavaş disk (iCloud Drive, SMB/NFS, yavaş USB) runtime worker'ını tutmasın;
+/// current_thread runtime'da (unit test) `block_in_place` panik edeceği için
+/// sync çağrı direkt yapılır.
 struct FileSink {
     writer: BufWriter<File>,
     path: PathBuf,
@@ -376,7 +400,12 @@ impl PayloadAssembler {
                 }
                 .into());
             }
-            sink.writer.write_all(body).context("disk yazma")?;
+            // Sync I/O'yu multi-thread runtime'da tokio'ya "blocking" olarak
+            // işaretle — iCloud Drive / SMB / yavaş USB'de write_all 10-100 ms
+            // bloklayabilir; bu sırada diğer async task'lar başka worker'a
+            // taşınsın. Current-thread runtime'da (unit test) fallback: direkt
+            // çağrı — block_in_place current_thread'de panik eder.
+            block_in_place_if_multi(|| sink.writer.write_all(body)).context("disk yazma")?;
             sink.hasher.update(body);
             sink.written = new_written;
             sink.last_chunk_at = Instant::now();
@@ -404,16 +433,18 @@ impl PayloadAssembler {
             // gönderebiliriz ama disk'te veri henüz yok → crash durumunda
             // dosya boş/yarım kalır. Hatayı propagate et ki user retry'la
             // anlamlı bir sonuç alabilsin.
-            sink.writer.flush().with_context(|| {
+            //
+            // flush + sync_all tek blokta: ikisi de blocking syscall
+            // (fsync özellikle yavaş disklerde 100+ ms olabilir) — iki ayrı
+            // block_in_place yerine tek sinyalle tokio'ya yük bildir.
+            let flush_sync_res: std::io::Result<()> = block_in_place_if_multi(|| {
+                sink.writer.flush()?;
+                sink.writer.get_ref().sync_all()?;
+                Ok(())
+            });
+            flush_sync_res.with_context(|| {
                 format!(
-                    "BufWriter flush başarısız: id={} path={}",
-                    id,
-                    sink.path.display()
-                )
-            })?;
-            sink.writer.get_ref().sync_all().with_context(|| {
-                format!(
-                    "dosya senkronize edilemedi: id={} path={}",
+                    "dosya finalize edilemedi (flush/fsync): id={} path={}",
                     id,
                     sink.path.display()
                 )

--- a/src/sender.rs
+++ b/src/sender.rs
@@ -429,7 +429,7 @@ pub async fn send_text(req: SendTextRequest) -> Result<()> {
                 Ok(r) => r?,
                 Err(_) => return Err(HekaError::ConnectTimeout {
                     secs: CONNECT_TIMEOUT.as_secs(),
-                    addr: addr.clone(),
+                    addr,
                 }.into()),
             }
         }

--- a/src/sender.rs
+++ b/src/sender.rs
@@ -70,7 +70,10 @@ struct PlannedFile {
 
 pub async fn send(req: SendRequest) -> Result<()> {
     if req.files.is_empty() {
-        return Err(HekaError::EmptyPayload.into());
+        // Not: "hiç dosya yok" ile "toplam 0 bayt dosya var" semantik olarak
+        // farklı — `EmptyPayload` ikincisini anlatır, UI mesajı yanıltıcı
+        // olur. Ayrı variant ile doğru i18n/log eşlemesi (Copilot review).
+        return Err(HekaError::NoFilesSelected.into());
     }
 
     let mut plans: Vec<PlannedFile> = Vec::with_capacity(req.files.len());
@@ -390,7 +393,7 @@ const CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 pub async fn send_text(req: SendTextRequest) -> Result<()> {
     let text = req.text;
     if text.is_empty() {
-        bail!("boş metin gönderilemez");
+        return Err(HekaError::EmptyPayload.into());
     }
     // `as i64` cast i64::MAX üstü uzunlukta wrap/negatif üretir; protokol
     // field'ları (`size`, `total_size`) bozulur. Pratikte bir String bu boyuta
@@ -420,11 +423,14 @@ pub async fn send_text(req: SendTextRequest) -> Result<()> {
     // SYN retry bekletmesin, iptal anında çıkabilsin.
     let mut socket = tokio::select! {
         biased;
-        _ = cancel_token.cancelled() => bail!("kullanıcı aktarımı iptal etti"),
+        _ = cancel_token.cancelled() => return Err(HekaError::UserCancelled.into()),
         res = tokio::time::timeout(CONNECT_TIMEOUT, TcpStream::connect(&addr)) => {
             match res {
                 Ok(r) => r?,
-                Err(_) => bail!("bağlantı zaman aşımına uğradı ({} sn): {}", CONNECT_TIMEOUT.as_secs(), addr),
+                Err(_) => return Err(HekaError::ConnectTimeout {
+                    secs: CONNECT_TIMEOUT.as_secs(),
+                    addr: addr.clone(),
+                }.into()),
             }
         }
     };
@@ -471,7 +477,7 @@ pub async fn send_text(req: SendTextRequest) -> Result<()> {
                 connection::send_sharing_frame(&mut socket, &mut ctx, &cancel).await.ok();
                 connection::send_disconnection(&mut socket, &mut ctx).await.ok();
                 state::set_progress(ProgressState::Idle);
-                bail!("kullanıcı aktarımı iptal etti");
+                return Err(HekaError::UserCancelled.into());
             }
             res = frame::read_frame_timeout(&mut socket, frame::STEADY_READ_TIMEOUT) => res?,
         };
@@ -531,11 +537,11 @@ pub async fn send_text(req: SendTextRequest) -> Result<()> {
                             connection::send_disconnection(&mut socket, &mut ctx)
                                 .await
                                 .ok();
-                            bail!(
-                                "Peer metin gönderimini reddetti (status={}). Session fingerprint: {}",
+                            return Err(HekaError::PeerRejected {
                                 status,
-                                crate::crypto::session_fingerprint(&keys.auth_key)
-                            );
+                                fingerprint: crate::crypto::session_fingerprint(&keys.auth_key),
+                            }
+                            .into());
                         }
                         send_text_bytes(
                             &mut socket,
@@ -578,7 +584,7 @@ pub async fn send_text(req: SendTextRequest) -> Result<()> {
                         return Ok(());
                     }
                     Some(sh_v1::FrameType::Cancel) => {
-                        bail!("Peer aktarımı iptal etti");
+                        return Err(HekaError::PeerCancelled.into());
                     }
                     _ => {}
                 }
@@ -597,7 +603,7 @@ pub async fn send_text(req: SendTextRequest) -> Result<()> {
             }
             Some(v1_frame::FrameType::Disconnection) => {
                 warn!("[sender] peer disconnect (metin)");
-                bail!("peer beklenmedik biçimde bağlantıyı kesti");
+                return Err(HekaError::PeerDisconnected.into());
             }
             _ => {}
         }
@@ -623,7 +629,7 @@ async fn send_text_bytes(
     let mut offset: usize = 0;
     while offset < data.len() {
         if cancel.is_cancelled() {
-            bail!("metin chunk gönderim sırasında iptal");
+            return Err(HekaError::CancelledDuringChunk.into());
         }
         let end = (offset + CHUNK_SIZE).min(data.len());
         let body = data[offset..end].to_vec();
@@ -674,7 +680,7 @@ fn wrap_bytes_payload_transfer(
                 payload_chunk: Some(PayloadChunk {
                     offset: Some(offset),
                     flags: Some(flags),
-                    body: Some(body),
+                    body: Some(body.into()),
                     ..Default::default()
                 }),
                 ..Default::default()

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -537,21 +537,15 @@ impl Settings {
     /// **en son** snapshot diske yazılır. Sessiz (rapid toggle yok) bir süreçte
     /// tek `save_debounced()` çağrısı tek atomik write üretir.
     ///
-    /// `tokio::Handle::try_current()` çalışmıyorsa (test/no-runtime bağlamı)
-    /// senkron `save()`'e düşer — davranış semantik olarak aynı, sadece coalesce
-    /// yok.
-    pub fn save_debounced(&self) {
+    /// Debounce task'ı her zaman çağıran tarafından sağlanan Tokio runtime
+    /// handle'ı üzerinde spawn edilir; UI/event-loop thread'i runtime dışında
+    /// olsa bile coalesce davranışı korunur. Önceden `Handle::try_current()`
+    /// kullanılıyordu — fakat tao event-loop thread'i tokio runtime'a bağlı
+    /// olmadığından her çağrı `Err(_)` dalına düşüp sync `save()`'e iniyordu
+    /// ve debounce fiilen devre dışı kalıyordu.
+    pub fn save_debounced(&self, handle: &tokio::runtime::Handle) {
         let snap = self.clone();
-        let handle = match tokio::runtime::Handle::try_current() {
-            Ok(h) => h,
-            Err(_) => {
-                // Runtime yoksa coalesce mümkün değil — doğrudan yaz, hata log.
-                if let Err(e) = snap.save() {
-                    tracing::warn!("settings save_debounced fallback: {}", e);
-                }
-                return;
-            }
-        };
+        let handle = handle.clone();
         let mut slot = DEBOUNCE_TASK.lock();
         // Aynı window içindeki önceki pending task'ı iptal et — son çağrı kazanır.
         if let Some(prev) = slot.take() {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -125,16 +125,16 @@ fn prompt_accept_blocking(
             let s = String::from_utf8_lossy(&o.stdout);
             // osascript çıktısı: "button returned:<LABEL>, gave up:false"
             // formatındadır. Önce "button returned:" prefix'li satırı tam
-            // olarak ayıklayıp, label'ı virgülün soluna kadar al; sonra
-            // `==` ile karşılaştır. Böylece "Kabul" ⊂ "Kabul + güven"
-            // gibi substring çakışmaları elimine edilir.
+            // olarak ayıklayıp, sonra standart ", gave up:false" suffix'ini
+            // `trim_end_matches` ile temizle. Label içinde virgül olabilir
+            // (lokalize "Kabul, ve Devam Et" gibi) — `split(',')` kullansak
+            // bozulurdu. `==` ile karşılaştırma substring çakışmalarını
+            // ("Kabul" ⊂ "Kabul + güven") elimine eder.
             let result_line = s
                 .lines()
                 .find_map(|l| l.strip_prefix("button returned:"))
                 .unwrap_or("");
-            // osascript bazen tek satırda "button returned:X, gave up:false"
-            // verir; virgülün solu gerçek label'dır.
-            let label = result_line.split(',').next().unwrap_or("").trim();
+            let label = result_line.trim_end_matches(", gave up:false").trim();
             if label == btn_trust {
                 AcceptResult::AcceptAndTrust
             } else if label == btn_accept {
@@ -1027,7 +1027,14 @@ pub fn send_progress_notify(device: &str, file: &str) {
 
 #[cfg(target_os = "macos")]
 fn escape_applescript(s: &str) -> String {
-    s.replace('\\', "\\\\").replace('"', "\\\"")
+    // AppleScript string literal'ında raw newline (`\n`) syntax error verir
+    // ve `display dialog` penceresi açılmaz. `sanitize_display_text` mesaj
+    // gövdesinde `\n`'leri koruduğu için burada `\r` (AppleScript'in
+    // satır sonu karakteri) ile değiştiriyoruz — dialog içinde çok satırlı
+    // metin böylece doğru render olur.
+    s.replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('\n', "\\r")
 }
 
 /// zenity `--extra-button` flag'ini destekliyor mu? Versiyon 3.0+'da var.


### PR DESCRIPTION
## Özet

PR #75-#77 merge edildi, #78 atlandı. Bu PR iki kategoriyi birlikte çözüyor:

1. **14 doğru review yorumu** (gemini + Copilot) — PR #75/#76/#77'ye gelen, kritik 5 bug + 9 correctness/improvement.
2. **#78'in non-split kısmı** — `connection.rs`'de `classify_handshake_error` + UKEY2 handshake notify + legacy trust migration dialog açıklaması. Orphan i18n key'leri (`err.pin_mismatch`, `trust.migration.*` vb.) canlandırıldı.

## Düzeltmeler

### Build (Cargo.toml)
- `rust-version = "1.90"` eklendi — canonical MSRV deklarasyonu.
- `debug = false` → `debug = 1` — Windows release workflow'un aradığı `.pdb` üretilmiyordu → release fail. Line tables-only ile PDB garantili, binary +200 KB.

### Güvenlik — macOS/Linux (ui.rs)
- `escape_applescript` `\n` → `\r` dönüşümü eklendi (multi-line mesajda dialog açılmıyordu).
- Button parse `split(',')` → `trim_end_matches(", gave up:false")` + tam eşitlik.

### Güvenlik — Windows (identity.rs)
- `icacls` PATH hijack: explicit `%SystemRoot%\System32\icacls.exe` (fallback `C:\Windows`).
- Mevcut identity.key dosyaları için de hardening çağrısı (`load_or_create_at`).

### Performans (payload.rs)
- `ingest_file` sync I/O → `block_in_place_if_multi()` helper ile sarıldı. Prod multi-thread → `tokio::task::block_in_place`; test current_thread → direkt çağrı (panic önlendi).

### Settings debounce (settings.rs + main.rs)
- `save_debounced(&self)` → `save_debounced(&self, handle: &Handle)`. UI thread tokio runtime dışında olduğu için `Handle::try_current()` fail ediyor ve debounce hiç çalışmıyordu. main.rs'deki `RUNTIME: OnceLock<Handle>` üzerinden iletiliyor.

### i18n push (main.rs)
- `push_i18n_to_ui` listesine 7 eksik key eklendi (`webview.privacy.*`, `webview.settings.trust_clear_*`, `webview.trusted.expired_tooltip`). HTML'de `?key?` placeholder'lar kayboldu.

### Update check (main.rs)
- GitHub 403 ayrımı: body lowercase'de "rate limit" → `RateLimited`, aksi halde `ApiError("403: ...")`. Abuse/UA/kurumsal blok artık yanlış teşhis edilmiyor.
- `render_update_outcome` 6 branch i18n key'lerine geçti.

### Connection UX (connection.rs + sender.rs + error.rs)
- **`classify_handshake_error`** helper (downcast-öncelikli, I/O kind sınıflandırma).
- **UKEY2 handshake hata notify**: async block + match pattern; Err dalında `ui::notify(app_name, i18n(key))` + `set_progress(Idle)`.
- **Legacy→hash trust migration**: dialog öncesi `ui::notify(trust.migration.title, tf(body, [peer, pin]))`.
- **`bail!` → HekaError migration**: connection.rs 4 site + sender.rs 8 site. `use anyhow::bail` kaldırıldı.
- **Yeni variant'lar**: `NoFilesSelected` (EmptyPayload'dan ayrı), `ConnectTimeout{secs,addr}`.

### UI DRY (window.html)
- `trapFocus(e, focusableElements)` helper. İki modal Tab handler'ı 18 satır inline → 2 satır helper çağrısı.

### Test hardening
- `drain_pending_yarim_kalan_dosyalari_diskten_siler`: manuel `remove_file` kaldırıldı, `!p.exists()` negatif assert'ler eklendi.

## Build hot-fix

Main squash-merge'de `sender.rs` Dalga 2-3 Bytes adaptasyonları eksik geldi (#78 merge olmadı) → `cargo check` 10 hata. `use anyhow::bail` restore + 1× `body.into()` ile build kurtarıldı. Bu commit'te `bail!` tamamen migrate, hot-fix kalıntısı yok.

## Kapsam dışı (bilinçli)

- **#78 connection modular split** — user tercihi; connection.rs monolit kalıyor, UX içeriği bu PR'da.
- **cleanup_transfer_state RAII guard** (gemini HIGH kısmen) — borrow-checker refactor; ayrı PR adayı.
- **opt-level="z" throughput bench** (gemini informational) — HekaDrop I/O-bound.

## Test planı

- [x] `cargo fmt --check` ✓
- [x] `cargo clippy --all-targets -D warnings` ✓
- [x] `cargo test` → **397 test, 0 fail**
- [ ] Manuel: Windows release build → `.pdb` üretimi doğrula
- [ ] Manuel: macOS — multi-line dialog mesajı (`\n` içeren body) açılıyor
- [ ] Manuel: PIN mismatch → "PIN uyuşmadı" notify gelmeli
- [ ] Manuel: legacy cihazdan bağlantı → "Cihaz kimliği güncelleniyor" notify

## Yorumlanan ama uygulanmayan

| Yorum | Neden atlandı |
|---|---|
| gemini `opt-level="z"` benchmark | Informational; I/O-bound proje, gerçek bug değil |
| gemini focus trap DRY | ✓ Uygulandı |
| gemini `handle()` cleanup on error (RAII) | Kısmen — mevcut erken return'ler pratik risk yaratmıyor, tam RAII guard ayrı refactor |
| gemini I/O classification helper | ✓ `map_io_error` inline helper olarak uygulandı |
| gemini placeholder cleanup duplication | Not yet — connection.rs içinde 2 site'ta manuel loop var, ayrı helper gerektiriyor |

🤖 Generated with [Claude Code](https://claude.com/claude-code)