### PR TITLE
v0.8 RFCs — chunk-HMAC, transfer resume, folder payload

### DIFF
--- a/docs/protocol/README.md
+++ b/docs/protocol/README.md
@@ -14,7 +14,7 @@ Aşağıdakiler Google / LocalSend topluluklarının spec'leri. Biz konuşuyoruz
   Kullandığımız protobuf tanımları `proto/` dizininde (device_to_device_messages, offline_wire_formats,
   securegcm, sharing, ukey, wire_format).
 - **LocalSend v2** — [localsend/protocol](https://github.com/localsend/protocol). v0.15.0'da
-  (2027 Q5) implement ediliyor.
+  (ROADMAP §Q5 çeyreği, 2027-05 → 2027-07) implement ediliyor.
 
 ## HekaDrop-spesifik uzantılar
 

--- a/docs/protocol/README.md
+++ b/docs/protocol/README.md
@@ -1,0 +1,62 @@
+# HekaDrop Protokol Dokümantasyonu
+
+Bu dizin, HekaDrop'un konuştuğu protokollerin **wire-level** spesifikasyonlarını içerir.
+Farklı bir implementasyon yazacak kişinin (başka dilde reimplementation, fuzzer geliştirici,
+güvenlik denetçisi) ek araştırma yapmadan okuyup uygulayabileceği detay seviyesi hedeflenir.
+
+## Taban protokoller (upstream)
+
+Aşağıdakiler Google / LocalSend topluluklarının spec'leri. Biz konuşuyoruz ama biz yazmadık:
+
+- **Quick Share / Nearby Connections** — upstream Google, resmi spec yok; reverse-engineered
+  referans: [grishka/NearDrop/PROTOCOL.md](https://github.com/grishka/NearDrop/blob/master/PROTOCOL.md),
+  [Martichou/rquickshare/core_lib](https://github.com/Martichou/rquickshare/tree/master/core_lib).
+  Kullandığımız protobuf tanımları `proto/` dizininde (device_to_device_messages, offline_wire_formats,
+  securegcm, sharing, ukey, wire_format).
+- **LocalSend v2** — [localsend/protocol](https://github.com/localsend/protocol). v0.15.0'da
+  (2027 Q5) implement ediliyor.
+
+## HekaDrop-spesifik uzantılar
+
+Aşağıdakiler HekaDrop'un Quick Share'in üstüne eklediği, capabilities negotiation arkasında
+opsiyonel özellikler. Eski Quick Share peer'ları (Google/Samsung Android, NearDrop) bu
+özellikleri görmezden gelir; fallback davranışı her spec'te tanımlıdır.
+
+| # | Doküman | Durum | Eklendi |
+|---|---|---|---|
+| 001 | capabilities.md | 📝 TBD (RFC-0003 draft, implementation'da yazılacak) | v0.8.0 |
+| 002 | chunk-hmac.md | 📝 TBD (RFC-0003 draft, implementation'da yazılacak) | v0.8.0 |
+| 003 | [resume.md](resume.md) | 📝 Draft (RFC-0004 ile beraber) | v0.8.0 |
+| 004 | folder-payload.md | 📝 TBD (RFC-0005 draft, implementation'da yazılacak) | v0.8.0 |
+
+Her spec:
+- Byte-level wire layout (alan uzunlukları, encoding)
+- State machine (sender/receiver arrow diagram)
+- Capabilities gate (hangi bit, fallback davranışı)
+- Error handling (mismatch, timeout, abort)
+- Example traffic capture (opsiyonel ama önerilir)
+
+## Versiyonlama
+
+Wire format değişiklikleri **semver-benzeri** izlenir ancak protokol için:
+- **MAJOR**: geriye uyumsuz, capabilities negotiation ile gate edilmeden yollanamaz
+- **MINOR**: geriye uyumlu, yeni opsiyonel alan veya davranış
+- **PATCH**: spec netleştirmesi (wire değişmiyor)
+
+Her spec dosyasının başında `Protokol sürümü:` alanı bulunur.
+
+## Test capture'ları
+
+`docs/protocol/captures/` altına (git-tracked) örnek trafik capture'ları:
+- Android → HekaDrop file transfer (hex dump)
+- HekaDrop → Android URL send
+- Resume handshake
+- Folder payload roundtrip
+
+Format: `{senaryo}.pcap` ve insan-okunaklı `{senaryo}.md` açıklama.
+Fuzz corpus'u buradan türetilebilir.
+
+## Related
+- [../rfcs/](../rfcs/) — protocol-shaping tasarım kararları
+- [../security/threat-model.md](../security/threat-model.md) — STRIDE per component
+- [../../proto/](../../proto/) — Quick Share protobuf şemaları (upstream)

--- a/docs/protocol/resume.md
+++ b/docs/protocol/resume.md
@@ -32,7 +32,7 @@ sender                                 receiver
   |        partial/ for matching          |
   |        session_id + payload_id)       |
   |                                       |
-  |  V1Frame{type=ResumeHint, ...}        |
+  |  HekaDropFrame{resume_hint=...}       |
   |<--------------------------------------|   (optional; only if partial exists
   |                                       |    AND capabilities.RESUME_V1 set)
   |                                       |
@@ -47,8 +47,8 @@ sender                                 receiver
   |  ... resume from offset ...           |
   |                                       |
   |  -- mismatch --                       |
-  |  V1Frame{type=ResumeReject,           |
-  |          reason=HASH_MISMATCH}        |
+  |  HekaDropFrame{resume_reject=...,     |
+  |               reason=HASH_MISMATCH}   |
   |-------------------------------------->|
   |                                       |   (receiver deletes .part + .meta,
   |                                       |    resets state, expects offset=0)
@@ -64,51 +64,67 @@ sender                                 receiver
   matching Introduction frame, or sender falls back to `offset = 0`.
 - Sender MUST respond within **30 s** of receiving `ResumeHint` for a
   10 GiB file (SHA-256 verification budget). Larger files scale linearly
-  (~3 s/GiB, without SHA-NI). If receiver does not see a PayloadTransfer
-  or ResumeReject within `(30 s + file_size_gib * 3 s)`, it MUST close
-  the connection and purge `.part`/`.meta`.
+  (~5 s/GiB, defansive upper bound for non-SHA-NI CPUs with HDD I/O).
+  If receiver does not see a PayloadTransfer or ResumeReject within
+  `(30 s + file_size_gib * 5 s)`, it MUST close the connection and
+  purge `.part`/`.meta`. (See §11 open-question on adaptive timeout.)
 
-## 2. `V1Frame` type extension
+## 2. Frame routing — HekaDropFrame wrapper, **not** `V1Frame.FrameType`
 
-Existing `V1Frame.FrameType` enum (in `proto/v1/location/nearby/connections/wire_format.proto`):
+**Kritik:** `ResumeHint` and `ResumeReject` are **not** slots in upstream
+`V1Frame.FrameType`. That enum belongs to Google's Quick Share / Nearby
+Connections spec (`proto/offline_wire_formats.proto:47`); its defined
+values are immutable for third-party implementations. Notably **slot 7
+is already `PAIRED_KEY_ENCRYPTION`** upstream, so any "ResumeHint = 7"
+claim in earlier drafts was incorrect.
 
-| Value | Name              |
-|------:|-------------------|
-| 0     | UNKNOWN_FRAME_TYPE|
-| 1     | ConnectionRequest |
-| 2     | ConnectionResponse|
-| 3     | PayloadTransfer   |
-| 4     | KeepAlive         |
-| 5     | Disconnection    |
-| 6     | Introduction     |
+HekaDrop extensions live inside a magic-prefixed `HekaDropFrame` wrapper
+(defined in RFC-0003 §3.2) which is carried as the plaintext of an
+otherwise-normal `SecureCtx::encrypt` payload:
 
-**New values (proto/v2):**
+```
+frame_header (length-prefix) ─▶ SecureCtx ciphertext ─▶ plaintext =
+    0xA5DEB201 (4 B magic) ∥ protobuf(HekaDropFrame)
+```
 
-| Value | Name          | Direction              |
-|------:|---------------|------------------------|
-| 7     | ResumeHint    | receiver → sender      |
-| 8     | ResumeReject  | sender → receiver      |
+Oneof slot assignments inside `HekaDropFrame.payload` (canonical table
+mirrored from RFC-0003):
 
-Values are chosen to be forward-compatible: receivers MUST ignore
-unknown frame types with `frame_type >= 100` (logging warn) to allow
-future extensions (`100..` reserved for experimental).
+| Slot | Field           | Defining RFC |
+|-----:|-----------------|--------------|
+| 10   | `capabilities`  | RFC-0003     |
+| 11   | `chunk_tag`     | RFC-0003     |
+| 12   | `resume_hint`   | RFC-0004 (this spec) |
+| 13   | `resume_reject` | RFC-0004 (this spec) |
+| 14   | `folder_mft`    | RFC-0005     |
+| 15..63 | reserved      | future v0.x minor additions |
+
+A non-HekaDrop peer receiving this plaintext sees the magic prefix
+as an invalid varint tag for `OfflineFrame` and drops the frame. The
+capabilities gate (§7) ensures the frame is never transmitted to such
+peers in the first place; the magic prefix is a defence-in-depth
+fail-loud marker.
 
 ## 3. `ResumeHint` message
 
-```protobuf
-syntax = "proto3";
-package hekadrop.protocol.resume.v1;
+Defined inside the shared `proto/hekadrop_extensions.proto` file
+(package `hekadrop.ext`, same file that hosts `HekaDropFrame` and
+`Capabilities`):
 
+```protobuf
 message ResumeHint {
   int64  session_id           = 1;  // required, non-zero
   int64  payload_id           = 2;  // required, matches Introduction
   int64  offset               = 3;  // required, 0 < offset < file_size
   bytes  partial_hash         = 4;  // required, exactly 32 bytes (SHA-256)
-  int32  capabilities_version = 5;  // required, matches capabilities frame
+  uint32 capabilities_version = 5;  // required, equals Capabilities.version
   bytes  last_chunk_tag       = 6;  // optional; 32 bytes if CHUNK_HMAC_V1 set,
                                      // zero-length otherwise
 }
 ```
+
+Wire carriage: `HekaDropFrame{resume_hint = ResumeHint{...}}` (oneof
+slot 12), then magic-prefixed and passed to `SecureCtx::encrypt`.
 
 ### 3.1 Field semantics
 
@@ -147,11 +163,14 @@ capabilities_version = 1                       -> 1 byte
 last_chunk_tag       = <32 bytes HMAC>         -> 34 bytes
 ```
 
-Total ≈ 89 bytes. Wrapped in `V1Frame{type=7, resume_hint=...}`, then
-encrypted-then-MAC'd per `src/secure.rs` standard 16 MiB frame cap — well
-under limit.
+Total ≈ 89 bytes. Wrapped in `HekaDropFrame{resume_hint=...}` (oneof
+slot 12, magic-prefixed), then encrypted-then-MAC'd per `src/secure.rs`
+standard 16 MiB frame cap — well under limit.
 
 ## 4. `ResumeReject` message
+
+Defined in the same `proto/hekadrop_extensions.proto` file. Wire carriage:
+`HekaDropFrame{resume_reject = ResumeReject{...}}` (oneof slot 13).
 
 ```protobuf
 message ResumeReject {
@@ -240,9 +259,11 @@ negotiated at handshake.
 - Neither peer advertises bit → no resume. Normal byte-0 transfer.
 - Only sender advertises → receiver cannot send hint; sender receives
   no hint; falls through 2 s timeout.
-- Only receiver advertises → receiver sends hint; sender does not
-  recognize frame type 7 → logs warn, drops frame, proceeds with
-  byte-0 transfer. Receiver `.part` is kept and retried on next session.
+- Only receiver advertises → receiver transmits `HekaDropFrame{resume_hint}`;
+  sender does not recognize the `HekaDropFrame` magic prefix (non-HekaDrop
+  peer) or does not advertise `RESUME_V1` (HekaDrop peer with the bit off)
+  → logs warn, drops frame, proceeds with byte-0 transfer. Receiver
+  `.part` is kept and retried on next session.
 
 ## 8. `.meta` JSON schema (receiver-local, **not on wire**)
 
@@ -316,3 +337,11 @@ implementation lands (PR accompanying RFC 0004 merge).
 3. Chunk-HMAC's exact tag size / algorithm (HMAC-SHA256 vs Poly1305)
    is owned by RFC 0003. This document assumes SHA-256 (32 B tag); if
    RFC 0003 chooses differently, update §3.1 `last_chunk_tag` size.
+4. **Adaptive verify-timeout.** §1 specifies a static `30 s + 5 s/GiB`
+   budget — defensive for non-SHA-NI CPUs paired with HDDs. A future
+   iteration could measure the first chunk's hash throughput and scale
+   the budget dynamically (e.g. `30 s + max(3, 10_000 / measured_MiB_s) * file_size_gib`),
+   tightening the window for modern hardware while keeping the slow-path
+   budget. Tradeoff: more state on sender, more surface for a malicious
+   receiver to stall the protocol by triggering a slow first chunk.
+   Deferred to v0.9.

--- a/docs/protocol/resume.md
+++ b/docs/protocol/resume.md
@@ -1,0 +1,318 @@
+# HekaDrop Protocol — Transfer Resume (wire-level spec)
+
+- **Protocol family:** HekaDrop extensions to Google Quick Share wire format
+- **Version:** `resume_v1` (capabilities bit `0x0002`)
+- **Status:** Draft, hedef implementation v0.8.0
+- **Normative RFC:** `docs/rfcs/0004-transfer-resume.md`
+- **Dependencies:** RFC 0003 (chunk-HMAC) for `last_chunk_tag` field
+- **Audience:** protocol implementers (Android router authors, 3rd party
+  Quick Share clients, fuzz harness writers)
+
+This document is the **byte-exact reference**. The prose, motivation and
+design trade-offs live in RFC 0004. If the two documents disagree, the RFC
+is authoritative for design intent and this document is authoritative for
+bytes on the wire.
+
+---
+
+## 1. Frame placement in the session state machine
+
+```
+sender                                 receiver
+------                                 --------
+  |                                       |
+  |  (UKEY2 + AES-CBC+HMAC secure ch.)    |
+  |======================================>|
+  |                                       |
+  |  V1Frame{type=Introduction,           |
+  |          payload_ids=[p1, p2, ...]}   |
+  |-------------------------------------->|
+  |                                       |
+  |       (receiver scans ~/.hekadrop/    |
+  |        partial/ for matching          |
+  |        session_id + payload_id)       |
+  |                                       |
+  |  V1Frame{type=ResumeHint, ...}        |
+  |<--------------------------------------|   (optional; only if partial exists
+  |                                       |    AND capabilities.RESUME_V1 set)
+  |                                       |
+  |  (sender opens local file, seeks to   |
+  |   offset, streams SHA-256 [0..offset],|
+  |   constant-time compares to hint.hash)|
+  |                                       |
+  |  -- match --                          |
+  |  V1Frame{type=PayloadTransfer,        |
+  |          chunk.offset=N, body=...}    |
+  |-------------------------------------->|
+  |  ... resume from offset ...           |
+  |                                       |
+  |  -- mismatch --                       |
+  |  V1Frame{type=ResumeReject,           |
+  |          reason=HASH_MISMATCH}        |
+  |-------------------------------------->|
+  |                                       |   (receiver deletes .part + .meta,
+  |                                       |    resets state, expects offset=0)
+  |  V1Frame{type=PayloadTransfer,        |
+  |          chunk.offset=0, body=...}    |
+  |-------------------------------------->|
+  |  ... normal restart ...               |
+```
+
+**Timing constraints:**
+
+- Receiver MUST send `ResumeHint` within **2000 ms** of receiving the
+  matching Introduction frame, or sender falls back to `offset = 0`.
+- Sender MUST respond within **30 s** of receiving `ResumeHint` for a
+  10 GiB file (SHA-256 verification budget). Larger files scale linearly
+  (~3 s/GiB, without SHA-NI). If receiver does not see a PayloadTransfer
+  or ResumeReject within `(30 s + file_size_gib * 3 s)`, it MUST close
+  the connection and purge `.part`/`.meta`.
+
+## 2. `V1Frame` type extension
+
+Existing `V1Frame.FrameType` enum (in `proto/v1/location/nearby/connections/wire_format.proto`):
+
+| Value | Name              |
+|------:|-------------------|
+| 0     | UNKNOWN_FRAME_TYPE|
+| 1     | ConnectionRequest |
+| 2     | ConnectionResponse|
+| 3     | PayloadTransfer   |
+| 4     | KeepAlive         |
+| 5     | Disconnection    |
+| 6     | Introduction     |
+
+**New values (proto/v2):**
+
+| Value | Name          | Direction              |
+|------:|---------------|------------------------|
+| 7     | ResumeHint    | receiver → sender      |
+| 8     | ResumeReject  | sender → receiver      |
+
+Values are chosen to be forward-compatible: receivers MUST ignore
+unknown frame types with `frame_type >= 100` (logging warn) to allow
+future extensions (`100..` reserved for experimental).
+
+## 3. `ResumeHint` message
+
+```protobuf
+syntax = "proto3";
+package hekadrop.protocol.resume.v1;
+
+message ResumeHint {
+  int64  session_id           = 1;  // required, non-zero
+  int64  payload_id           = 2;  // required, matches Introduction
+  int64  offset               = 3;  // required, 0 < offset < file_size
+  bytes  partial_hash         = 4;  // required, exactly 32 bytes (SHA-256)
+  int32  capabilities_version = 5;  // required, matches capabilities frame
+  bytes  last_chunk_tag       = 6;  // optional; 32 bytes if CHUNK_HMAC_V1 set,
+                                     // zero-length otherwise
+}
+```
+
+### 3.1 Field semantics
+
+| Field | Type | Size | Notes |
+|-------|------|------|-------|
+| `session_id` | `int64` | varint (1-10 B) | First 8 bytes of `SHA-256(UKEY2.auth_key)` interpreted as **big-endian i64**. Sender MUST recompute and drop frame on mismatch. |
+| `payload_id` | `int64` | varint (1-10 B) | Identical to `Introduction.FileMetadata[*].payload_id`. Sender drops frame if id not announced in this session's Introduction. |
+| `offset` | `int64` | varint (1-10 B) | Number of bytes the receiver has on disk. **Invariant:** `0 < offset < file_size`. Exactly 0 is a protocol violation (sender rejects with `ResumeReject{INVALID_OFFSET}`); `offset == file_size` means "already complete, no transfer needed" — sender sends zero PayloadTransfer frames plus final Disconnection. |
+| `partial_hash` | `bytes` | fixed 32 B | SHA-256 over receiver's `.part[0..offset]`. Sender verifies in constant time against its own local file hash. |
+| `capabilities_version` | `int32` | varint (1-5 B) | Monotonically-increasing version number of the capabilities frame exchanged earlier. Sender rejects with `ResumeReject{VERSION_MISMATCH}` if peer negotiated a different version than this hint claims. |
+| `last_chunk_tag` | `bytes` | 0 or 32 B | If `CHUNK_HMAC_V1` capability bit is set, this is the HMAC-SHA256 tag of the **last fully-received chunk** (chunk ending at `offset`). Lets sender skip the O(offset) full SHA-256 and verify only the last-chunk tag — O(1). If bit not set, field is zero-length and sender falls back to full-hash verification. |
+
+### 3.2 Encoding examples
+
+**Example 1: 1 GiB file, 512 MiB received, no chunk-HMAC.**
+
+```
+session_id           = 0x4A8F2E31C7D90B54      -> 10-byte varint
+payload_id           = 8 442 310 559           -> 5-byte varint
+offset               = 536 870 912             -> 5-byte varint
+partial_hash         = <32 bytes SHA-256>      -> 2-byte tag + 32 bytes
+capabilities_version = 1                       -> 1 byte
+last_chunk_tag       = <empty>                 -> tag only (2 bytes) or omitted
+```
+
+Resulting protobuf-encoded frame body ≈ 56 bytes.
+
+**Example 2: 10 GiB file, 9.2 GiB received, chunk-HMAC active.**
+
+```
+session_id           = 0xA3F1B82E6CD07419      -> 10-byte varint
+payload_id           = 5 138 472 819           -> 5-byte varint
+offset               = 9 878 030 336           -> 5-byte varint
+partial_hash         = <32 bytes>              -> 34 bytes
+capabilities_version = 1                       -> 1 byte
+last_chunk_tag       = <32 bytes HMAC>         -> 34 bytes
+```
+
+Total ≈ 89 bytes. Wrapped in `V1Frame{type=7, resume_hint=...}`, then
+encrypted-then-MAC'd per `src/secure.rs` standard 16 MiB frame cap — well
+under limit.
+
+## 4. `ResumeReject` message
+
+```protobuf
+message ResumeReject {
+  int64 payload_id = 1;  // echo of the rejected hint
+  Reason reason    = 2;
+
+  enum Reason {
+    REASON_UNSPECIFIED  = 0;
+    HASH_MISMATCH       = 1;  // partial_hash does not match local [0..offset]
+    INVALID_OFFSET      = 2;  // offset <= 0 or >= file_size
+    VERSION_MISMATCH    = 3;  // capabilities_version disagrees
+    PAYLOAD_UNKNOWN     = 4;  // payload_id not in Introduction
+    SESSION_MISMATCH    = 5;  // session_id does not match sender-computed value
+    INTERNAL_ERROR      = 6;  // sender-side I/O or hash failure
+  }
+}
+```
+
+**Receiver handling on `ResumeReject`:**
+
+| Reason | Receiver action |
+|--------|-----------------|
+| HASH_MISMATCH | Delete `.part` + `.meta`, restart from `offset=0` |
+| INVALID_OFFSET | Delete `.part` + `.meta`, restart (likely local disk corruption) |
+| VERSION_MISMATCH | Log warn, retry without `ResumeHint` (downgrade to v0.7 behavior) |
+| PAYLOAD_UNKNOWN | Delete stale `.meta` (sender no longer plans to send this file) |
+| SESSION_MISMATCH | Delete `.meta` (stale session); log warn — possible key rotation |
+| INTERNAL_ERROR | Retain `.meta`, retry on next connection |
+
+## 5. Invariants and validation rules
+
+**Sender MUST** (when it receives `ResumeHint`):
+
+1. Reject if `session_id != session_id_i64(self.ukey2.auth_key)` →
+   `ResumeReject{SESSION_MISMATCH}`.
+2. Reject if `payload_id` not in `self.current_introduction.payload_ids`
+   → `ResumeReject{PAYLOAD_UNKNOWN}`.
+3. Reject if `offset <= 0 || offset >= file_size`
+   → `ResumeReject{INVALID_OFFSET}`.
+4. Reject if `partial_hash.len() != 32`
+   → drop frame (malformed; do not echo fields).
+5. Compute local `[0..offset]` SHA-256; constant-time compare.
+6. If `last_chunk_tag` non-empty, verify HMAC of last chunk (RFC-0003)
+   before full SHA-256 (O(1) fast path).
+7. On success, seek to `offset`, set `PayloadChunk.offset = offset` on first
+   transfer frame.
+
+**Receiver MUST** (before sending `ResumeHint`):
+
+1. Verify `.meta.session_id == session_id_i64(self.ukey2.auth_key)`;
+   if not, delete and fall through to normal path.
+2. Verify `.meta.payload_id` matches one of the Introduction payload_ids;
+   else delete and fall through.
+3. Verify `.meta.total_size == Introduction.FileMetadata[payload_id].size`;
+   else delete and fall through (sender has different file, same id).
+4. Verify `.meta.updated_at` within TTL (default 7 days); else delete.
+5. Re-hash `.part[0..offset]` (fresh, not from cache) to detect disk
+   corruption between sessions — sender will catch mismatches, but a
+   local re-hash saves a round trip.
+
+**Receiver MUST NOT** send more than one `ResumeHint` per payload per session.
+
+## 6. Error handling matrix
+
+| Event | Sender state | Action |
+|-------|-------------|--------|
+| `ResumeHint` timeout (2 s) | Waiting | Proceed with `offset=0`, normal flow |
+| Malformed `ResumeHint` (parse fail) | Waiting | Ignore, proceed with `offset=0` |
+| Invalid field per §5 checks | Waiting | Send `ResumeReject`, proceed with `offset=0` |
+| Hash verify success | Waiting | Seek + send PayloadTransfer frames |
+| Local file missing (sender path changed) | Waiting | Send `ResumeReject{PAYLOAD_UNKNOWN}` |
+| Mid-resume disconnect | Resuming | Same as v0.7: abort; receiver retains `.part`+`.meta` if CHUNK_HMAC valid |
+| TTL expiry mid-resume | N/A | Cleanup sweep skips in-use files |
+| Budget eviction mid-resume | N/A | Cleanup sweep skips in-use sessions |
+
+## 7. Capabilities negotiation
+
+The capabilities frame is defined by RFC 0003. Resume adds the
+`RESUME_V1 = 0x0002` bit. Both peers MUST advertise this bit in the
+capabilities exchange for `ResumeHint` to be transmitted. The
+`capabilities_version` field in `ResumeHint` MUST equal the version
+negotiated at handshake.
+
+**Downgrade behavior:**
+
+- Neither peer advertises bit → no resume. Normal byte-0 transfer.
+- Only sender advertises → receiver cannot send hint; sender receives
+  no hint; falls through 2 s timeout.
+- Only receiver advertises → receiver sends hint; sender does not
+  recognize frame type 7 → logs warn, drops frame, proceeds with
+  byte-0 transfer. Receiver `.part` is kept and retried on next session.
+
+## 8. `.meta` JSON schema (receiver-local, **not on wire**)
+
+```json
+{
+  "version": 1,
+  "session_id": "<16-char lowercase hex>",
+  "payload_id": <int64>,
+  "file_name": "<sanitized name from Introduction>",
+  "total_size": <int64>,
+  "received_bytes": <int64>,
+  "chunk_hmac_chain": "<base64(concat of last 4 chunk HMAC tags)>",
+  "peer_endpoint_id": "<string from Introduction>",
+  "created_at": "<RFC3339 UTC>",
+  "updated_at": "<RFC3339 UTC>"
+}
+```
+
+`version` monotonically increasing; incompatible changes bump this. v0.8
+parser rejects `version > 1`.
+
+`session_id` is the hex representation (not the i64 form) for
+human-readable filenames. Conversion: `format!("{:016x}", id as u64)`.
+
+## 9. Security considerations (wire-level only)
+
+- `ResumeHint` and `ResumeReject` are carried **inside the UKEY2-derived
+  secure channel**. No plaintext exposure on the LAN.
+- Replay within a session: receiver must not send duplicate hints; sender
+  logs and drops subsequent hints for the same `payload_id`.
+- Cross-session replay: impossible because `session_id` is derived from
+  this session's `auth_key`, which is ephemeral ECDH material.
+- Hash oracle: sender reveals no information on mismatch beyond "hash
+  differs"; `partial_hash` is not a pre-image for any long-lived key.
+
+## 10. Interop test vectors
+
+Implementers SHOULD validate against these vectors
+(all hex, no separators):
+
+**Vector 1: small file, tiny offset**
+
+- Input file: `000102...FF` (256 bytes repeating), total 1 024 bytes
+- Offset: `128`
+- SHA-256 of `[0..128]`: `7ca6d9a3e8b2f6...` *(to be finalized in test
+  harness — computed at implementation time)*
+- Expected `ResumeHint` wire (protobuf):
+  `08<session_varint> 10<payload_varint> 1880 01 2220<32 hash bytes> 2801`
+
+**Vector 2: large file, chunk-HMAC tag**
+
+- Input file: 10 GiB of `0x42`
+- Offset: `9 878 030 336` (after 18,840 chunks of 512 KiB)
+- `last_chunk_tag`: HMAC-SHA256 of chunk #18839 under chunk-HMAC key
+
+Full vectors will be shipped as `tests/resume/vectors.bin` once the
+implementation lands (PR accompanying RFC 0004 merge).
+
+---
+
+## 11. Open questions (wire-level)
+
+1. Should `ResumeHint` support **multi-file** resume in a single frame
+   (repeated `Hint` sub-message) when Introduction announces multiple
+   files? Current design: one hint per payload; simpler, allows per-file
+   reject. Alternative adds complexity with unclear upside — deferred.
+2. Should `ResumeReject.reason` expose `INTERNAL_ERROR` at all (vs.
+   silent drop + timeout on receiver)? Silent drop leaks less info but
+   makes debugging harder. Current: explicit reason code, logged on
+   receiver with rate-limiting.
+3. Chunk-HMAC's exact tag size / algorithm (HMAC-SHA256 vs Poly1305)
+   is owned by RFC 0003. This document assumes SHA-256 (32 B tag); if
+   RFC 0003 chooses differently, update §3.1 `last_chunk_tag` size.

--- a/docs/rfcs/0003-chunk-hmac.md
+++ b/docs/rfcs/0003-chunk-hmac.md
@@ -5,28 +5,35 @@
 - **Oluşturulma tarihi:** 2026-04-24
 - **Hedef sürüm:** v0.8.0 ("Protokol Sağlamlaştırma", ROADMAP §Q1 v0.8.0)
 - **İlgili issue:** #— (henüz açılmadı); deferred risk tablosu `threat-model.md` §8 D-2.
-- **İlişkili RFC'ler:** 0004 (resume protokolü) ve 0005 (folder streaming) bu RFC'nin tanımlayacağı `CapabilitiesFrame` ve chunk-integrity primitive'ini yeniden kullanacak. Her üç RFC paralel yazılıyor; `CapabilitiesFrame` tasarımının burada "first mover" olarak konumlanması gerek.
+- **İlişkili RFC'ler:** 0004 (resume protokolü) ve 0005 (folder streaming) bu RFC'nin tanımlayacağı `Capabilities` mesajını ve chunk-integrity primitive'ini yeniden kullanacak. Her üç RFC paralel yazılıyor; `Capabilities` tasarımının burada "first mover" olarak konumlanması gerek.
 
 ## 1. Özet
 
-HekaDrop'a **chunk başına** HMAC-SHA256 bütünlük etiketi eklenir. Mevcut durumda `SecureCtx` (bkz. `src/secure.rs:42-84`) UKEY2 türevi `send_hmac_key` ile her **frame**'in tamamını Encrypt-then-MAC sargısı altında korur; ancak bir `PayloadTransferFrame.payload_chunk.body` bu sargıdan geçtikten sonra düz metindir ve ilgili dosya/bytes payload'ı için bütünlük yalnızca son chunk'tan sonra `sink.hasher.finalize()` ile doğrulanır (`src/payload.rs:409`). Bu RFC, her `PayloadChunk`'ın **düz metin gövdesine** — frame-level HMAC'in dışında, ek bir katman olarak — HKDF ile ayrılmış, yeni bir `chunk_hmac_key` altında üretilen 32 bayt HMAC-SHA256 etiketi ekler. Etiket, `PayloadChunk` gönderildikten **hemen sonra** ayrı bir `ChunkIntegrity` shared-frame ile iletilir; alıcı her chunk'ı diske yazmadan önce tag'i doğrular, mismatch'te transfer derhal iptal edilir ve placeholder dosya silinir. Wire-level capabilities negotiation peer her iki taraf da bu özelliği duyurmuşsa aktifleşir; aksi hâlde mevcut "end-of-file SHA-256" davranışı korunur. Upstream Quick Share proto şemasına breaking değişiklik getirilmez.
+HekaDrop'a **chunk başına** HMAC-SHA256 bütünlük etiketi eklenir. Mevcut `SecureCtx` (bkz. `src/secure.rs:78,113`) UKEY2 türevi `send_hmac_key` ile her **frame**'in tamamını zaten Encrypt-then-MAC disiplini altında koruyor — yani **wire transit seviyesinde** tampering hâlihazırda yakalanır ve bu RFC **oraya ek bir savunma katmanı iddia etmez**. Chunk-HMAC'in gerçek gerekçesi farklı bir katmanda yatar:
+
+1. **Resume protokolünün O(1) önkoşulu:** Receiver'ın elindeki partial dosyada hangi byte aralığının "intact" olduğu, sender tarafından full-file SHA-256 yeniden hesaplanmadan doğrulanabilsin (RFC-0004 fast-path bu önkoşula bağlıdır).
+2. **Early abort / storage corruption:** Frame-level MAC doğrulandıktan *sonra* plaintext diske yazılıncaya kadar geçen sürede (receiver-side disk bitflip, memory corruption, receiver-internal tampering) oluşabilecek bozulma, bugün ancak transfer sonundaki SHA-256 karşılaştırmasıyla yakalanır; chunk-HMAC bunu her chunk'ta **erken** yakalar.
+3. **Partial file integrity as a first-class protocol primitive:** "Elimde chunk 0..k-1 doğrulandı" ifadesi protokolde taşınabilir, görünür, kriptografik olarak pin'lenmiş bir olgudur — ne receiver-local bir best-effort hash, ne de sender'a opak bir claim.
+
+Bu RFC her `PayloadChunk`'ın **düz metin gövdesine** HKDF ile ayrılmış, yeni bir `chunk_hmac_key` altında üretilen 32 bayt HMAC-SHA256 etiketi ekler. Etiket, `PayloadChunk` gönderildikten **hemen sonra** ayrı bir `ChunkIntegrity` shared-frame ile iletilir; alıcı her chunk'ı diske yazmadan önce tag'i doğrular, mismatch'te transfer derhal iptal edilir ve placeholder dosya silinir. Wire-level capabilities negotiation peer her iki taraf da bu özelliği duyurmuşsa aktifleşir; aksi hâlde mevcut "end-of-file SHA-256" davranışı korunur. Upstream Quick Share proto şemasına breaking değişiklik getirilmez.
 
 ## 2. Motivasyon
 
-### 2.1 Problem 1 — Geç Tespit
+### 2.1 Problem 1 — Resume fast-path için O(1) önkoşul
 
-Mevcut akış, bir `FileSink` için SHA-256 hasher'ı chunk geldikçe besler (`src/payload.rs:409`) ve yalnız `last_chunk=true` geldiğinde `hasher.finalize()`'i `FileMetadata.payload_hash` ile karşılaştırır; yani **ilk chunk tampered ise bile 10 GiB'lik bir dosya için 10 GiB trafik harcanır ve sonunda reddedilir.** Pratikte bu iki senaryoda ciddi sorundur:
-
-- **Aktif LAN saldırganı (A2)** Encrypt-then-MAC sarmalayıcısının bir bug'ı üzerinden tek bir ciphertext bit'ini flip etse bile bugün mimari onu frame-level HMAC ile yakalar; ancak ileride AES-GCM'e geçiş düşünüldüğünde (ayrı RFC) veya yanlış proto decode'da güvenlik-hot-path dışı bit bozulması olduğunda, payload-level bağımsız bir integrity katmanı derinliği artırır.
-- **Ağ (non-adversarial) bit bozulması / disk path'inde sessiz corruption:** TCP checksum 16-bit'tir ve ≈2^16 mesajda bir false-negative bekleniyor; gigabaytlık dosyalarda bu deneyimlenmiştir (Stone & Partridge, SIGCOMM 2000). AES-CBC + HMAC frame-level tag bunu yakalar, ama yine **frame bazında**; büyük bir chunk içinde gömülü, frame sınırlarına saygılı bir gürültü geç ortaya çıkabilir.
-
-Somut ölçüm: 10 GiB dosya, 100 MiB/s gerçek Wi-Fi throughput → **100 s**. Chunk-HMAC ile ilk bozulan chunk (`CHUNK_SIZE = 512 KiB`) **ilk 0.005 s** içinde tespit edilir (chunk 1). Mevcut tasarımda 100 s kaybedilir.
-
-### 2.2 Problem 2 — Resume Protokolünün Önkoşulu
-
-RFC 0004 transfer resume'i tanımlıyor: alıcı yarım dosyayı `~/.hekadrop/partial/` altında tutacak ve sender'a "ofset X'e kadar sende hangi byte range intact?" önergesi sunacak. Bunun için **sender'ın alıcının intact byte range iddiasına güvenebilmesi** gerekir. Mevcut end-of-file SHA-256 bu iddiayı doğrulamayacak granülariteye sahiptir — tüm dosya tamamlanmadan hash çıkmaz. Chunk-HMAC ile alıcı "chunk 0..k-1 tag'leri benim nezdimde doğrulandı; lütfen chunk k'dan itibaren gönder" diyebilir; sender aynı `chunk_hmac_key`'i yeniden türettiği için (deterministic HKDF) iddianın doğru olup olmadığını tag'leri karşılaştırarak cross-check edebilir.
+RFC 0004 transfer resume'i tanımlıyor: alıcı yarım dosyayı `~/.hekadrop/partial/` altında tutacak ve sender'a "ofset X'e kadar sende hangi byte range intact?" önergesi sunacak. Bugünkü tek kriptografik karşılaştırma `FileMetadata.payload_hash` (end-of-file SHA-256) — yani tüm dosya tamamlanmadan hash çıkmaz; partial için doğrulanabilir bir primitif yok. Fallback olarak sender `[0..offset]` aralığını yeniden hash'leyebilir, ama 10 GiB için SHA-NI'siz ~30 saniye CPU işi. Chunk-HMAC ile alıcı "chunk 0..k-1 tag'leri benim nezdimde doğrulandı; lütfen chunk k'dan itibaren gönder" diyebilir; sender aynı `chunk_hmac_key`'i yeniden türettiği için (deterministic HKDF) iddiayı **sadece son chunk tag'ini karşılaştırarak** O(1) doğrular.
 
 Dolayısıyla chunk-HMAC **resume'den önce merge edilmelidir**. Bu RFC, 0004'ün zeminidir.
+
+### 2.2 Problem 2 — Erken tespit ve storage corruption
+
+`SecureCtx` (`src/secure.rs:78,113`) frame-level Encrypt-then-MAC ile **wire transit'teki** tampering'i zaten yakalar; bu RFC oraya bir savunma katmanı iddia etmez. Ancak frame MAC doğrulandıktan sonra plaintext chunk `FileSink::write_chunk` buffer'ından diske flush'lanıncaya kadar geçen sürede bozulma kaynakları vardır:
+
+- **Receiver-side storage path corruption:** RAM bitflip, disk controller bug, ECC olmayan donanım, kötü kablo. Bugünkü tespit yalnızca `last_chunk` sonrası end-of-file SHA-256 ile olur; yani 10 GiB dosyada bozulma **ilk chunk'ta bile olsa** 10 GiB trafik harcanır.
+- **Defence in depth — frame MAC regresyonu:** Tarihte constant-time karşılaştırma regresyonları, sequence counter wrap bug'ları, padding oracle'lar görüldü. Chunk-level bağımsız tag, frame-level MAC'in sessiz regresyonunu görünür kılar (fail-loud).
+- **Ağ bozulması / sessiz corruption:** TCP checksum 16-bit; Stone & Partridge (SIGCOMM 2000) büyük dosyalarda false-negative'i belgeledi. Frame MAC bunu yakalar; bir bug varsa chunk-HMAC yakalar.
+
+Somut ölçüm: 10 GiB dosya, 100 MiB/s gerçek Wi-Fi throughput → **100 s**. Chunk-HMAC ile ilk bozulan chunk (`CHUNK_SIZE = 512 KiB`) **ilk 0.005 s** içinde tespit edilir (chunk 1). Mevcut tasarımda 100 s kaybedilir ve kullanıcı "SHA-256 mismatch, yeniden dene" mesajı alır.
 
 ## 3. Ayrıntılı Tasarım
 
@@ -36,7 +43,11 @@ Quick Share `PayloadTransferFrame.PayloadChunk` proto'suna (bkz. `proto/offline_
 
 **Seçenek (a): Chunk body'sinin son 32 baytı tag.** `effective_body = body[..body.len()-32]`. Geri uyumsuz: eski HekaDrop sürümleri bu 32 baytı payload'ın parçası olarak disk'e yazar → dosya bozulur, SHA-256 mismatch. Feature flag gerektirir ve yine de kullanıcı başka bir Quick Share peer'i ile (Android, rquickshare) konuşurken bu kip kapatılmalı. Protokol katmanlamasını kirletir: `PayloadChunk.body` anlambilimsel olarak "dosya içeriği"dir; integrity metadata'sı orada yaşamamalı.
 
-**Seçenek (b): Ayrı `ChunkIntegrity` shared-frame.** `PayloadChunk` normalde nasılsa öyle gönderilir. Hemen ardından (aynı `SecureCtx::encrypt` zinciri altında, yani mevcut sequence counter disiplinine uyarak) ayrı bir shared-frame tipi — HekaDrop-özel — iletilir. Bu frame Quick Share peer'i tarafından alındığında parse hatası verir mi? **Hayır**: alıcı peer'ın capabilities'i yok ise sender zaten bu frame'i göndermez (bkz. §4). Peer eşit seviyedeki HekaDrop ise frame tanınır. Shared-frame tipini mevcut `OfflineFrame` değil, `NearbyFrame` (paired-key shared) hattında kullanırız — zira `OfflineFrame.V1Frame.FrameType` Google-tanımlıdır; biz orada yeni enum varyantı ekleyemeyiz. Çözüm: `PAIRED_KEY_ENCRYPTION` yolunu kullanmak yerine kendi `HekaDropFrame` proto'muzu (ayrı proto file) `SecureCtx::encrypt` payload'ı olarak gömüp karşı tarafa yolluyoruz — iç düzeyde bizim parser'ımız bu seri-numarasını `OfflineFrame` mı yoksa `HekaDropFrame` mi olduğunu **magic prefix** (ilk 4 bayt sabit `0xA5 0xDE 0xB2 0x01`) ile ayırt eder. HekaDrop olmayan peer prefix'i tanımaz → `OfflineFrame::decode` hatası → frame drop; ama bu duruma zaten capabilities-gate sayesinde girilmez.
+**Seçenek (b): Ayrı `ChunkIntegrity` shared-frame.** `PayloadChunk` normalde nasılsa öyle gönderilir. Hemen ardından (aynı `SecureCtx::encrypt` zinciri altında, yani mevcut sequence counter disiplinine uyarak) ayrı bir shared-frame tipi — HekaDrop-özel — iletilir. Bu frame Quick Share peer'i tarafından alındığında parse hatası verir mi? **Hayır**: alıcı peer'ın capabilities'i yok ise sender zaten bu frame'i göndermez (bkz. §4). Peer eşit seviyedeki HekaDrop ise frame tanınır.
+
+**Kritik:** Upstream `OfflineFrame.V1Frame.FrameType` enum Google-tanımlıdır ve biz orada **yeni enum varyantı eklemeyiz**. Upstream'deki tanımlı değerler (`proto/offline_wire_formats.proto:47` civarı; 1=ConnectionRequest, 2=ConnectionResponse, 3=PayloadTransfer, 4=KeepAlive, 5=Disconnection, 6=Introduction, 7=`PAIRED_KEY_ENCRYPTION`, 8=`PAIRED_KEY_RESULT`) HekaDrop için dokunulmazdır. Önceki RFC taslaklarında "FrameType = 7" gibi slot iddiaları **yanlıştı**; 7 zaten `PAIRED_KEY_ENCRYPTION` tarafından kullanılıyor.
+
+Çözüm: HekaDrop uzantılarını **hiçbir durumda** upstream `V1Frame.FrameType` enum'una ekleme; bunun yerine kendi `HekaDropFrame` proto wrapper'ımızı `SecureCtx::encrypt` payload'ı olarak gömüp karşı tarafa yolluyoruz. Parser `OfflineFrame` mı yoksa `HekaDropFrame` mı olduğunu **magic prefix** (ilk 4 bayt sabit `0xA5 0xDE 0xB2 0x01`) ile ayırt eder. HekaDrop olmayan peer prefix'i tanımaz → `OfflineFrame::decode` hatası → frame drop; ama bu duruma zaten capabilities-gate sayesinde girilmez.
 
 **Öneri: (b).** Karar gerekçeleri:
 
@@ -45,7 +56,9 @@ Quick Share `PayloadTransferFrame.PayloadChunk` proto'suna (bkz. `proto/offline_
 3. Capabilities-gate üzerinde çalışır → 3rd-party Quick Share peer'leri etkilenmez.
 4. 0004 (resume) ve 0005 (folder) aynı shared-frame mekanizmasını kullanabilir.
 
-### 3.2 `CapabilitiesFrame` (first mover — 0004/0005 ortak)
+### 3.2 `HekaDropFrame` wrapper ve `Capabilities` mesajı (first mover — 0004/0005 ortak)
+
+Kanonik şema (üç RFC'nin tümü bu tanımlara referans verir; çelişki olursa bu bölüm normatiftir):
 
 ```proto
 // proto/hekadrop_extensions.proto (yeni dosya, HekaDrop-özel)
@@ -55,39 +68,40 @@ package hekadrop.ext;
 message HekaDropFrame {
   // Magic: 0xA5DEB201 (big-endian) — HekaDropFrame discriminator.
   // Quick Share uyumsuz peer'lar parse edemez; bu kasıtlı.
-  fixed32 magic = 1;
-  uint32 version = 2;  // sürüm 1 = v0.8.0 bootstrap
+  fixed32 magic   = 1;
+  uint32  version = 2;  // v0.8 = 1; monoton artar
   oneof payload {
-    CapabilitiesFrame capabilities = 3;
-    ChunkIntegrity chunk_integrity = 4;
-    // Reserved 5..15 — 0004 ResumeHint, 0005 FolderManifest vb.
-    // (oneof slot reservation; kritik: yeni field eklerken numarayı
-    // koru — 0004/0005 RFC'leri 5 ve 6'yı alacak.)
+    Capabilities    capabilities  = 10;  // bu RFC
+    ChunkIntegrity  chunk_tag     = 11;  // bu RFC
+    ResumeHint      resume_hint   = 12;  // RFC-0004
+    ResumeReject    resume_reject = 13;  // RFC-0004
+    FolderManifest  folder_mft    = 14;  // RFC-0005
+    // 15..63 — reserved for future v0.x minor additions
   }
-  reserved 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15;
-  reserved "resume_hint", "folder_manifest";
 }
 
-message CapabilitiesFrame {
-  // Bitmask. Gelecekte genişleyebilir; bilinmeyen bit sessiz yok sayılır.
-  // Bit 0 = CHUNK_HMAC_SHA256 (bu RFC)
-  // Bit 1 = RESUME_V1 (RFC 0004)
-  // Bit 2 = FOLDER_STREAM_V1 (RFC 0005)
-  // Bit 3..63 reserved
-  uint64 capability_bits = 1;
-
-  // Peer'ın HekaDrop sürümü (diagnostics; trust kararı için kullanılmaz).
-  string version = 2;
+message Capabilities {
+  uint32 version  = 1;  // monoton artan; v0.8.0 için = 1
+  uint64 features = 2;  // bitfield (aşağıdaki sabitler)
 }
+
+// Feature bitleri — üç RFC de bu sabit numaralara referans verir.
+// (Proto sabit değil; dokümantasyon. Rust tarafı `pub const` olarak tutar.)
+//   CHUNK_HMAC_V1_V1     = 0x0001   // bit 0, bu RFC
+//   RESUME_V1         = 0x0002   // bit 1, RFC-0004
+//   FOLDER_STREAM_V1  = 0x0004   // bit 2, RFC-0005
+//   0x0008..0x8000    — reserved for v0.8–v1.0
 
 message ChunkIntegrity {
-  int64 payload_id = 1;   // PayloadHeader.id ile eşleşir
-  int64 chunk_index = 2;  // 0'dan başlayan monotonik sayaç
-  int64 offset = 3;       // PayloadChunk.offset aynası (redundant integrity)
-  uint32 body_len = 4;    // Ayrı doğrulama: len(body) bu değere eşit olmalı
-  bytes tag = 5;          // HMAC-SHA256 (32 bayt), ayrıntı §3.4
+  int64  payload_id  = 1;   // PayloadHeader.id ile eşleşir
+  int64  chunk_index = 2;   // 0'dan başlayan monotonik sayaç
+  int64  offset      = 3;   // PayloadChunk.offset aynası (redundant integrity)
+  uint32 body_len    = 4;   // Ayrı doğrulama: len(body) bu değere eşit olmalı
+  bytes  tag         = 5;   // HMAC-SHA256 (32 bayt), ayrıntı §3.4
 }
 ```
+
+**Oneof slot stratejisi:** Slot numaraları **10'dan başlar** — 1..9 arası ileriki sürümlerde (v0.9+) temel (non-payload) alanlar için bilinçli olarak açık bırakılır. 10–14 bu RFC paketinde sabitlenmiş beş slot'tur; 15..63 minor eklemeler için rezerve. Önemli: proto3'te `oneof` içinde `reserved` numara aralığı **yasaklama anlamına gelir ve oneof'un ileride genişlemesini engeller**, dolayısıyla burada `reserved` bloğu **kullanılmaz**; bunun yerine kullanılmayan slot numaraları sadece terkedilmiş olarak bırakılır ve yukarıdaki policy tablosu ile dokümante edilir.
 
 **Not:** `HekaDropFrame` magic prefix yaklaşımı, proto3'ün "unknown field silently preserved" davranışından bilinçli ayrılır; karşı taraf HekaDrop değilse frame parse hatası verip drop eder, bu zaten peer capabilities'i yok demek → ekosistemimizde bu frame oraya hiç gönderilmeyecektir (capabilities-gate §4 altında). Magic prefix defansiftir: capabilities-gate bug'ı durumunda sessiz interop hatası yerine sert parse hatası ile erken tanı.
 
@@ -96,15 +110,15 @@ message ChunkIntegrity {
 ```
 ConnectionRequest → UKEY2 handshake → ConnectionResponse(ACCEPT)
     → PairedKeyEncryption (mevcut)
-    → CapabilitiesFrame (YENI — SecureCtx altında, her iki taraf gönderir)
+    → Capabilities (YENI — SecureCtx altında, her iki taraf gönderir)
     → payload akışı
 ```
 
-Ekleme noktası: `connection.rs` Introduction öncesi. PairedKeyEncryption phase'i tamamlanır tamamlanmaz her iki uç kendi `CapabilitiesFrame`'ini yollar (sender → receiver ve receiver → sender). Karşı taraftan 2 sn içinde `CapabilitiesFrame` almazsa: **legacy mode** (peer HekaDrop değil veya <v0.8.0). Legacy mode'da `chunk_hmac_key` asla türetilmez, `ChunkIntegrity` frame'i gönderilmez, alıcı da beklenmez.
+Ekleme noktası: `connection.rs` Introduction öncesi. PairedKeyEncryption phase'i tamamlanır tamamlanmaz her iki uç kendi `Capabilities`'ini yollar (sender → receiver ve receiver → sender). Karşı taraftan 2 sn içinde `Capabilities` almazsa: **legacy mode** (peer HekaDrop değil veya <v0.8.0). Legacy mode'da `chunk_hmac_key` asla türetilmez, `ChunkIntegrity` frame'i gönderilmez, alıcı da beklenmez.
 
-Timeout neden 2 sn? PairedKeyEncryption ile Introduction arası mevcut akışta genellikle <100 ms; 2 sn cömert bir margin, handshake `HANDSHAKE_READ_TIMEOUT = 30 s` limitinin çok altında. `CapabilitiesFrame` zorunlu değil — legacy Quick Share peer'ı asla göndermez; o akışta receiver `CapabilitiesFrame` beklemek yerine Introduction frame'ini ilk gördüğünde "peer capabilities bildirmemiş = 0" varsayar.
+Timeout neden 2 sn? PairedKeyEncryption ile Introduction arası mevcut akışta genellikle <100 ms; 2 sn cömert bir margin, handshake `HANDSHAKE_READ_TIMEOUT = 30 s` limitinin çok altında. `Capabilities` zorunlu değil — legacy Quick Share peer'ı asla göndermez; o akışta receiver `Capabilities` beklemek yerine Introduction frame'ini ilk gördüğünde "peer capabilities bildirmemiş = 0" varsayar.
 
-Negotiated `active_caps = my_caps & peer_caps`. Bit-AND seçimi: bir taraf bir özelliği kapatmışsa (örn. CLI flag `HEKADROP_DISABLE_CHUNK_HMAC=1`) ikili AND ile sessizce devre-dışı.
+Negotiated `active_caps = my_caps & peer_caps`. Bit-AND seçimi: bir taraf bir özelliği kapatmışsa (örn. CLI flag `HEKADROP_DISABLE_CHUNK_HMAC_V1=1`) ikili AND ile sessizce devre-dışı.
 
 ### 3.4 HMAC Anahtar Türetmesi
 
@@ -139,16 +153,17 @@ tag = HMAC-SHA256(chunk_hmac_key, message)
 
 `PayloadAssembler::ingest` (`src/payload.rs:233-264`) şu adımlarla genişler:
 
-1. `PayloadChunk` alınır. Eğer `active_caps & CHUNK_HMAC == 0` → mevcut akış (değişiklik yok).
-2. Eğer `CHUNK_HMAC` aktif: `PayloadChunk` işleme **almadan** aynı `SecureCtx` stream'inde bir sonraki frame'i oku, `HekaDropFrame.ChunkIntegrity` ile eşleşmesi beklenir.
+1. `PayloadChunk` alınır. Eğer `active_caps & CHUNK_HMAC_V1 == 0` → mevcut akış (değişiklik yok).
+2. Eğer `CHUNK_HMAC_V1` aktif: `PayloadChunk` işleme **almadan** aynı `SecureCtx` stream'inde bir sonraki frame'i oku, `HekaDropFrame.ChunkIntegrity` ile eşleşmesi beklenir.
 3. Sıra uyumu kontrolleri:
    - `ChunkIntegrity.payload_id == PayloadHeader.id`
    - `ChunkIntegrity.chunk_index == expected_next_index[payload_id]` (monotonik artan, `expected_next_index` `PayloadAssembler` state'ine eklenir)
    - `ChunkIntegrity.offset == PayloadChunk.offset`
    - `ChunkIntegrity.body_len == body.len()`
-4. `expected_tag = HMAC-SHA256(chunk_hmac_key, message)` hesapla (§3.5 formatı).
-5. `subtle::ConstantTimeEq::ct_eq(&expected_tag, &ChunkIntegrity.tag)` — **constant-time** karşılaştırma (mevcut kullanım `src/crypto.rs:82`). Mismatch → `HekaError::ChunkHmacMismatch { payload_id, chunk_index }`, transfer abort, placeholder dosya silinir (`remove_partial_file` helper — `src/payload.rs:480+` civarındaki mevcut cleanup yolu üzerinden).
-6. `expected_next_index[payload_id] += 1`, chunk body `sink.writer.write_all`'a devam eder.
+4. **Tag uzunluk kontrolü (`ChunkIntegrity.tag.len() == 32`)** — constant-time karşılaştırmadan **önce** yapılır. Yanlış uzunlukta tag ya da eksik alan → `HekaError::ChunkHmacMismatch`, transfer abort. Non-constant length check burada timing yüzeyi açmaz çünkü `tag` attacker-controlled bir payload'dır ve uzunluğu zaten attacker tarafından biliniyor; gizli değildir.
+5. `expected_tag = HMAC-SHA256(chunk_hmac_key, message)` hesapla (§3.5 formatı).
+6. `subtle::ConstantTimeEq::ct_eq(&expected_tag, &ChunkIntegrity.tag)` — **constant-time** karşılaştırma (mevcut kullanım `src/crypto.rs:82`). Mismatch → `HekaError::ChunkHmacMismatch { payload_id, chunk_index }`, transfer abort, placeholder dosya silinir (`remove_partial_file` helper — `src/payload.rs:480+` civarındaki mevcut cleanup yolu üzerinden).
+7. `expected_next_index[payload_id] += 1`, chunk body `sink.writer.write_all`'a devam eder.
 
 Hata yolu kritik: tag mismatch'te **partial_file disk'ten mutlaka silinmelidir**, çünkü resume protokolü (RFC 0004) bozuk chunk içeren partial'i geçerli sayarsa attacker-controlled corruption kalıcı olur. Silme başarısızsa log'a `error!` seviyesinde uyarı + dosya `.corrupt` uzantısıyla rename.
 
@@ -165,7 +180,7 @@ for chunk in file.chunks(CHUNK_SIZE):
     write_frame(socket, enc2)
 ```
 
-İki ayrı `SecureCtx::encrypt` çağrısı → iki ayrı sequence number. Bu sender'ı `client_seq` tarafında 2× hızlı tüketir; mevcut overflow guard `checked_add` 2^31 mesajla yeterli (2^30 chunk = 512 GiB × 512 KiB = 512 PiB, nasıl olsa erişilmez).
+İki ayrı `SecureCtx::encrypt` çağrısı → iki ayrı sequence number. Bu sender'ı `client_seq` tarafında 2× hızlı tüketir; mevcut overflow guard `checked_add` 2^31 mesajla yeterli (2^30 chunk × 512 KiB ≈ **512 TiB**, nasıl olsa erişilmez).
 
 **Alternatif:** Tek frame içinde `HekaDropFrame` ile `PayloadTransferFrame`'i concatenate et. Reddedildi: wire format'ta frame = 4-byte length prefix + protobuf; her seferinde bir mesaj. Composite frame için yeni parser gerekir.
 
@@ -174,7 +189,7 @@ for chunk in file.chunks(CHUNK_SIZE):
 | İş | Saat | 0004 ile Kesişim |
 |---|---|---|
 | `proto/hekadrop_extensions.proto` + build.rs integration | 2 | ✓ (ortak dosya; 0004 reserved slot açar) |
-| `CapabilitiesFrame` negotiation (`src/capabilities.rs` yeni modül) | 4 | ✓ (0004/0005 aynı modülü genişletir) |
+| `Capabilities` negotiation (`src/capabilities.rs` yeni modül) | 4 | ✓ (0004/0005 aynı modülü genişletir) |
 | `HekaDropFrame` magic-prefix dispatcher (`src/frame.rs` ext) | 3 | ✓ |
 | `chunk_hmac_key` HKDF türetme + `DerivedKeys` genişletme | 2 | — |
 | Sender yolunda `ChunkIntegrity` üretimi (`src/sender.rs`) | 3 | — |
@@ -212,8 +227,8 @@ Paralel çalışılırsa 0004 ile ortak primitifler (`proto/hekadrop_extensions.
 ## 5. Geriye Uyumluluk / Migration
 
 - **Wire format:** Quick Share proto'larına değişiklik yok. Yeni proto: `proto/hekadrop_extensions.proto` (bizim yönetimimizde).
-- **Peer interop:** `CapabilitiesFrame` yoksa legacy mode; tam geri uyumlu. Android / rquickshare / NearDrop peer'ları etkilenmez.
-- **Config:** `HEKADROP_DISABLE_CHUNK_HMAC=1` env var ile sender-side opt-out (debug / A/B için). Receiver zaten peer capabilities'i bildirmemişse legacy.
+- **Peer interop:** `Capabilities` yoksa legacy mode; tam geri uyumlu. Android / rquickshare / NearDrop peer'ları etkilenmez.
+- **Config:** `HEKADROP_DISABLE_CHUNK_HMAC_V1=1` env var ile sender-side opt-out (debug / A/B için). Receiver zaten peer capabilities'i bildirmemişse legacy.
 - **Feature flag gerekir mi?** Hayır — capabilities-gate zaten flag görevi görür. Ama release sonrası ilk iki hafta telemetry (diag panel) için `stats.json` içine `chunk_hmac_used: bool` field'ı eklenir.
 
 ## 6. Güvenlik Değerlendirmesi
@@ -222,7 +237,7 @@ Paralel çalışılırsa 0004 ile ortak primitifler (`proto/hekadrop_extensions.
 
 Mevcut `threat-model.md` §5.3 "Transfer" STRIDE tablosunda etkilenen hücreler:
 
-- **T (Tampering) — `A2: Ciphertext bit-flip (CBC malleability)`:** Mevcut mitigation "HMAC-SHA256 tag header_and_body üzerine" — frame-level. Chunk-HMAC bu korumayı payload içeriği seviyesinde **tekrarlar**; defense-in-depth. Frame-level HMAC'in bir bug'ı (örn. `subtle::ConstantTimeEq` mis-invocation, sequence counter wrap) chunk-HMAC ile hâlâ yakalanır.
+- **T (Tampering) — wire transit (A2: ciphertext bit-flip):** Frame-level HMAC bunu **zaten yakalar** (`SecureCtx::decrypt_verify`); chunk-HMAC buraya yeni bir kilit eklemez. Chunk-HMAC'in katkısı **defence-in-depth** perspektifinden: frame-level MAC'in bir regresyonu (örn. `subtle::ConstantTimeEq` mis-invocation, sequence counter wrap bug'ları, padding oracle) durumunda chunk-level bağımsız tag bu regresyonu fail-loud hale getirir. Yani chunk-HMAC "wire transit koruması" iddia etmez ama frame-MAC sessiz bir şekilde devre dışı kalırsa yüzeye çıkarır.
 - **T — Mid-stream silent corruption:** Bugün "end-of-file SHA-256" ile yakalanır ama geç; chunk-HMAC ile her chunk'ta yakalanır. Threat model'e yeni satır eklenecek: "Chunk-level tag (§3.5); mismatch → immediate abort + partial cleanup."
 - **I (Information disclosure):** Tag plaintext gönderilir ama HMAC one-way → IKM (`chunk_hmac_key`) sızdırmaz. Timing oracle: constant-time verify (§3.6/5). Payload hacmi anlamına gelebilecek length-leak zaten `PayloadChunk.body` boyutundan var; `ChunkIntegrity.body_len` yeni bilgi eklemez.
 - **D (Denial of service):** Saldırgan (malicious peer, A3) her chunk'ta tag mismatch üretirse → transfer erken iptal → işini **kolaylaştırır** (eski akışta da kullanıcı-controlled cancel). Yeni DoS vektörü yok. Kapasite tüketimi: her chunk için +32 bayt + proto overhead + 1 ek sequence — ihmal edilebilir.
@@ -316,11 +331,11 @@ Yeni harness: `fuzz/fuzz_targets/fuzz_chunk_hmac_verify.rs`. Girdi: `(key_seed, 
 
 ## 10. Açık Sorular
 
-1. **`CapabilitiesFrame.capability_bits` kaç bit reserve edilmeli?** `uint64` 64 bit; RFC 0003-0005 üçü dolu, kalan 61 bit. Gelecek 2 yıl için bol; ancak geçmiş deneyimle (IPv4 flag field'ları) daha çok bit alanı iyi fikir. **Öneri:** `repeated uint64 capability_bits` (vektör) veya ayrı `extensions map<string, bytes>` eklemek. Ama şimdilik `uint64` yeterli; gerektiğinde `v2` HekaDropFrame açılabilir.
+1. **`Capabilities.features` kaç bit reserve edilmeli?** `uint64` 64 bit; RFC 0003-0005 üçü dolu, kalan 61 bit. Gelecek 2 yıl için bol; ancak geçmiş deneyimle (IPv4 flag field'ları) daha çok bit alanı iyi fikir. **Öneri:** gerekirse `v2` `Capabilities` mesajı `repeated uint64 features` veya ayrı `extensions map<string, bytes>` ile açılır; `Capabilities.version` alanı zaten bu upgrade'i discoverable kılar. Şimdilik `uint64` yeterli.
 2. **Magic prefix `0xA5DEB201` — çakışma riski?** Quick Share `OfflineFrame.version = 1` tipik olarak `0x08 0x01` varint ile başlar. `0xA5` MSB-set varint → prost decode hatası verir. Düşük çakışma riski. Yine de prefix'i `proto/hekadrop_extensions.proto` dokümanında kalıcı olarak sabitlemek gerekli.
-3. **`extra_capabilities` bitmap mi `CapabilitiesFrame` mi?** Quick Share `ConnectionRequestFrame`'de `extra_capabilities` adında bir alan yok (bkz. `proto/offline_wire_formats.proto:71-125` — biz full frame'i kontrol ettik). Dolayısıyla bitmap piggyback seçeneği yok; **ayrı `CapabilitiesFrame` zorunlu**. ROADMAP §Q1 risk tablosunun "Quick Share extra_capabilities çakışma" maddesi bu RFC ile moot oluyor.
+3. **`extra_capabilities` bitmap mi `Capabilities` mi?** Quick Share `ConnectionRequestFrame`'de `extra_capabilities` adında bir alan yok (bkz. `proto/offline_wire_formats.proto:71-125` — biz full frame'i kontrol ettik). Dolayısıyla bitmap piggyback seçeneği yok; **ayrı `Capabilities` zorunlu**. ROADMAP §Q1 risk tablosunun "Quick Share extra_capabilities çakışma" maddesi bu RFC ile moot oluyor.
 4. **Partial file resume interop:** Eğer v0.8.0 alıcısı v0.8.0 göndericisinden 50% aldı, tag mismatch'te partial silindi — sonra aynı peer yeniden bağlandığında chunk 0'dan mı başlar? Evet; RFC 0004 bu yeniden-başlangıcı `partial_hash` ile optimize eder. 0004 merge'ünden önce chunk-HMAC yalnız erken-tespiti sağlar, resume sağlamaz.
-5. **`HEKADROP_DISABLE_CHUNK_HMAC=1` env var gerçekten gerek mi?** A/B metrik ve emergency rollback için faydalı; ama çoğu kullanıcı görmez. `off-by-default via capabilities AND` davranışıyla gereksiz olabilir. Reviewer'a bırakılmış.
+5. **`HEKADROP_DISABLE_CHUNK_HMAC_V1=1` env var gerçekten gerek mi?** A/B metrik ve emergency rollback için faydalı; ama çoğu kullanıcı görmez. `off-by-default via capabilities AND` davranışıyla gereksiz olabilir. Reviewer'a bırakılmış.
 
 ## 11. Referanslar
 
@@ -330,5 +345,5 @@ Yeni harness: `fuzz/fuzz_targets/fuzz_chunk_hmac_verify.rs`. Girdi: `(key_seed, 
 - Stone, J. & Partridge, C. — "When the CRC and TCP Checksum Disagree", SIGCOMM 2000.
 - Google Quick Share protokol proto'ları: `proto/offline_wire_formats.proto`, `proto/wire_format.proto`.
 - HekaDrop internal: `docs/security/threat-model.md` §5.3 (transfer STRIDE), §6.3 (HKDF tablosu), §8 D-2 (deferred risk).
-- İlişkili RFC'ler: 0004 (resume — taslak), 0005 (folder streaming — taslak); her ikisi de bu RFC'deki `CapabilitiesFrame` ve `HekaDropFrame` mekanizmasını yeniden kullanacak.
+- İlişkili RFC'ler: 0004 (resume — taslak), 0005 (folder streaming — taslak); her ikisi de bu RFC'deki `Capabilities` ve `HekaDropFrame` mekanizmasını yeniden kullanacak.
 - Marlinspike, M. — "The Cryptographic Doom Principle" (EtM-before-decrypt disiplinine referans; bu RFC aynı disiplini chunk seviyesinde korur).

--- a/docs/rfcs/0003-chunk-hmac.md
+++ b/docs/rfcs/0003-chunk-hmac.md
@@ -60,16 +60,62 @@ Quick Share `PayloadTransferFrame.PayloadChunk` proto'suna (bkz. `proto/offline_
 
 Kanonik şema (üç RFC'nin tümü bu tanımlara referans verir; çelişki olursa bu bölüm normatiftir):
 
+#### Wire layout — magic prefix protobuf'un dışındadır
+
+`HekaDropFrame` discriminator'ı (4-byte sabit `0xA5DEB201`) **protobuf message
+içinde değil**, payload'ın ham byte prefix'i olarak akar. Aksi halde protobuf
+`fixed32 field=1` wire encoding'i tag-byte (`0x0d`) + little-endian değer
+üretirdi; ilk 4 byte'ı sabit bir prefix olarak okuma garantisi olmaz (Gemini
+PR-85 review). Magic'i protobuf'tan dışlamak hem dispatcher mantığını
+basitleştirir hem de byte sırası belirsizliğini ortadan kaldırır.
+
+Quick Share frame katmanı zaten `[4-byte big-endian length][frame body]`
+formatındadır. HekaDrop frame body'sinin yapısı:
+
+```
++------------------+----------------------------+
+|  magic (4 byte)  |  HekaDropFrame protobuf    |
+|  0xA5 DE B2 01   |  (varint-delimited fields) |
++------------------+----------------------------+
+        ▲
+        └─── big-endian sabit; protobuf dışı; capabilities-gate
+             aktive olmadığında bu prefix asla iletilmez
+```
+
+Dispatcher (alıcı tarafta) mantığı:
+
+```rust
+// pseudocode — gerçek implementation src/frame.rs içinde
+fn dispatch(frame_body: &[u8]) -> Result<Frame, Error> {
+    if frame_body.len() >= 4 && &frame_body[..4] == HEKADROP_MAGIC_BE {
+        let inner = &frame_body[4..];
+        Ok(Frame::HekaDrop(HekaDropFrame::decode(inner)?))
+    } else {
+        Ok(Frame::Offline(OfflineFrame::decode(frame_body)?))
+    }
+}
+
+const HEKADROP_MAGIC_BE: &[u8; 4] = &[0xA5, 0xDE, 0xB2, 0x01];
+```
+
+Eski Quick Share peer'ı `0xA5DEB201` ile başlayan body'yi varint length veya
+field tag olarak parse etmeye çalışır → erken `OfflineFrame::decode` hatası →
+drop. Bu zaten capabilities-gate aktif değilken HekaDrop tarafının böyle bir
+frame **göndermemesi gerekir**; magic + dispatcher kombinasyonu defensive
+backstop'tur.
+
+#### Protobuf şema (magic'siz)
+
 ```proto
 // proto/hekadrop_extensions.proto (yeni dosya, HekaDrop-özel)
 syntax = "proto3";
 package hekadrop.ext;
 
 message HekaDropFrame {
-  // Magic: 0xA5DEB201 (big-endian) — HekaDropFrame discriminator.
-  // Quick Share uyumsuz peer'lar parse edemez; bu kasıtlı.
-  fixed32 magic   = 1;
-  uint32  version = 2;  // v0.8 = 1; monoton artar
+  // NOT: Magic discriminator (0xA5DEB201) bu mesaj tipinin ham byte
+  // prefix'idir, protobuf field değildir. Wire layout açıklaması §3.2'nin
+  // başında. Dispatcher 4 byte'lık prefix'i strip eder ve buradan başlar.
+  uint32 version = 1;  // v0.8 = 1; monoton artar
   oneof payload {
     Capabilities    capabilities  = 10;  // bu RFC
     ChunkIntegrity  chunk_tag     = 11;  // bu RFC
@@ -87,7 +133,7 @@ message Capabilities {
 
 // Feature bitleri — üç RFC de bu sabit numaralara referans verir.
 // (Proto sabit değil; dokümantasyon. Rust tarafı `pub const` olarak tutar.)
-//   CHUNK_HMAC_V1_V1     = 0x0001   // bit 0, bu RFC
+//   CHUNK_HMAC_V1     = 0x0001   // bit 0, bu RFC
 //   RESUME_V1         = 0x0002   // bit 1, RFC-0004
 //   FOLDER_STREAM_V1  = 0x0004   // bit 2, RFC-0005
 //   0x0008..0x8000    — reserved for v0.8–v1.0
@@ -102,8 +148,6 @@ message ChunkIntegrity {
 ```
 
 **Oneof slot stratejisi:** Slot numaraları **10'dan başlar** — 1..9 arası ileriki sürümlerde (v0.9+) temel (non-payload) alanlar için bilinçli olarak açık bırakılır. 10–14 bu RFC paketinde sabitlenmiş beş slot'tur; 15..63 minor eklemeler için rezerve. Önemli: proto3'te `oneof` içinde `reserved` numara aralığı **yasaklama anlamına gelir ve oneof'un ileride genişlemesini engeller**, dolayısıyla burada `reserved` bloğu **kullanılmaz**; bunun yerine kullanılmayan slot numaraları sadece terkedilmiş olarak bırakılır ve yukarıdaki policy tablosu ile dokümante edilir.
-
-**Not:** `HekaDropFrame` magic prefix yaklaşımı, proto3'ün "unknown field silently preserved" davranışından bilinçli ayrılır; karşı taraf HekaDrop değilse frame parse hatası verip drop eder, bu zaten peer capabilities'i yok demek → ekosistemimizde bu frame oraya hiç gönderilmeyecektir (capabilities-gate §4 altında). Magic prefix defansiftir: capabilities-gate bug'ı durumunda sessiz interop hatası yerine sert parse hatası ile erken tanı.
 
 ### 3.3 Capabilities Negotiation Akışı
 

--- a/docs/rfcs/0003-chunk-hmac.md
+++ b/docs/rfcs/0003-chunk-hmac.md
@@ -1,0 +1,334 @@
+# RFC 0003 — Chunk-level HMAC-SHA256
+
+- **Başlatan:** @ebubekir (HekaDrop core team)
+- **Durum:** Draft
+- **Oluşturulma tarihi:** 2026-04-24
+- **Hedef sürüm:** v0.8.0 ("Protokol Sağlamlaştırma", ROADMAP §Q1 v0.8.0)
+- **İlgili issue:** #— (henüz açılmadı); deferred risk tablosu `threat-model.md` §8 D-2.
+- **İlişkili RFC'ler:** 0004 (resume protokolü) ve 0005 (folder streaming) bu RFC'nin tanımlayacağı `CapabilitiesFrame` ve chunk-integrity primitive'ini yeniden kullanacak. Her üç RFC paralel yazılıyor; `CapabilitiesFrame` tasarımının burada "first mover" olarak konumlanması gerek.
+
+## 1. Özet
+
+HekaDrop'a **chunk başına** HMAC-SHA256 bütünlük etiketi eklenir. Mevcut durumda `SecureCtx` (bkz. `src/secure.rs:42-84`) UKEY2 türevi `send_hmac_key` ile her **frame**'in tamamını Encrypt-then-MAC sargısı altında korur; ancak bir `PayloadTransferFrame.payload_chunk.body` bu sargıdan geçtikten sonra düz metindir ve ilgili dosya/bytes payload'ı için bütünlük yalnızca son chunk'tan sonra `sink.hasher.finalize()` ile doğrulanır (`src/payload.rs:409`). Bu RFC, her `PayloadChunk`'ın **düz metin gövdesine** — frame-level HMAC'in dışında, ek bir katman olarak — HKDF ile ayrılmış, yeni bir `chunk_hmac_key` altında üretilen 32 bayt HMAC-SHA256 etiketi ekler. Etiket, `PayloadChunk` gönderildikten **hemen sonra** ayrı bir `ChunkIntegrity` shared-frame ile iletilir; alıcı her chunk'ı diske yazmadan önce tag'i doğrular, mismatch'te transfer derhal iptal edilir ve placeholder dosya silinir. Wire-level capabilities negotiation peer her iki taraf da bu özelliği duyurmuşsa aktifleşir; aksi hâlde mevcut "end-of-file SHA-256" davranışı korunur. Upstream Quick Share proto şemasına breaking değişiklik getirilmez.
+
+## 2. Motivasyon
+
+### 2.1 Problem 1 — Geç Tespit
+
+Mevcut akış, bir `FileSink` için SHA-256 hasher'ı chunk geldikçe besler (`src/payload.rs:409`) ve yalnız `last_chunk=true` geldiğinde `hasher.finalize()`'i `FileMetadata.payload_hash` ile karşılaştırır; yani **ilk chunk tampered ise bile 10 GiB'lik bir dosya için 10 GiB trafik harcanır ve sonunda reddedilir.** Pratikte bu iki senaryoda ciddi sorundur:
+
+- **Aktif LAN saldırganı (A2)** Encrypt-then-MAC sarmalayıcısının bir bug'ı üzerinden tek bir ciphertext bit'ini flip etse bile bugün mimari onu frame-level HMAC ile yakalar; ancak ileride AES-GCM'e geçiş düşünüldüğünde (ayrı RFC) veya yanlış proto decode'da güvenlik-hot-path dışı bit bozulması olduğunda, payload-level bağımsız bir integrity katmanı derinliği artırır.
+- **Ağ (non-adversarial) bit bozulması / disk path'inde sessiz corruption:** TCP checksum 16-bit'tir ve ≈2^16 mesajda bir false-negative bekleniyor; gigabaytlık dosyalarda bu deneyimlenmiştir (Stone & Partridge, SIGCOMM 2000). AES-CBC + HMAC frame-level tag bunu yakalar, ama yine **frame bazında**; büyük bir chunk içinde gömülü, frame sınırlarına saygılı bir gürültü geç ortaya çıkabilir.
+
+Somut ölçüm: 10 GiB dosya, 100 MiB/s gerçek Wi-Fi throughput → **100 s**. Chunk-HMAC ile ilk bozulan chunk (`CHUNK_SIZE = 512 KiB`) **ilk 0.005 s** içinde tespit edilir (chunk 1). Mevcut tasarımda 100 s kaybedilir.
+
+### 2.2 Problem 2 — Resume Protokolünün Önkoşulu
+
+RFC 0004 transfer resume'i tanımlıyor: alıcı yarım dosyayı `~/.hekadrop/partial/` altında tutacak ve sender'a "ofset X'e kadar sende hangi byte range intact?" önergesi sunacak. Bunun için **sender'ın alıcının intact byte range iddiasına güvenebilmesi** gerekir. Mevcut end-of-file SHA-256 bu iddiayı doğrulamayacak granülariteye sahiptir — tüm dosya tamamlanmadan hash çıkmaz. Chunk-HMAC ile alıcı "chunk 0..k-1 tag'leri benim nezdimde doğrulandı; lütfen chunk k'dan itibaren gönder" diyebilir; sender aynı `chunk_hmac_key`'i yeniden türettiği için (deterministic HKDF) iddianın doğru olup olmadığını tag'leri karşılaştırarak cross-check edebilir.
+
+Dolayısıyla chunk-HMAC **resume'den önce merge edilmelidir**. Bu RFC, 0004'ün zeminidir.
+
+## 3. Ayrıntılı Tasarım
+
+### 3.1 Wire Format — Seçenek (a) vs. (b)
+
+Quick Share `PayloadTransferFrame.PayloadChunk` proto'suna (bkz. `proto/offline_wire_formats.proto:188-196`) yeni alan ekleyemeyiz çünkü bu upstream Google spec'idir; Android tarafı bilmediği alanı yok sayar ama bu durumda capabilities negotiation'dan söz edemez ve davranış sessizce sessize alınmaz — yalnızca bizim iki uçlu trafiğimiz işe yarar.
+
+**Seçenek (a): Chunk body'sinin son 32 baytı tag.** `effective_body = body[..body.len()-32]`. Geri uyumsuz: eski HekaDrop sürümleri bu 32 baytı payload'ın parçası olarak disk'e yazar → dosya bozulur, SHA-256 mismatch. Feature flag gerektirir ve yine de kullanıcı başka bir Quick Share peer'i ile (Android, rquickshare) konuşurken bu kip kapatılmalı. Protokol katmanlamasını kirletir: `PayloadChunk.body` anlambilimsel olarak "dosya içeriği"dir; integrity metadata'sı orada yaşamamalı.
+
+**Seçenek (b): Ayrı `ChunkIntegrity` shared-frame.** `PayloadChunk` normalde nasılsa öyle gönderilir. Hemen ardından (aynı `SecureCtx::encrypt` zinciri altında, yani mevcut sequence counter disiplinine uyarak) ayrı bir shared-frame tipi — HekaDrop-özel — iletilir. Bu frame Quick Share peer'i tarafından alındığında parse hatası verir mi? **Hayır**: alıcı peer'ın capabilities'i yok ise sender zaten bu frame'i göndermez (bkz. §4). Peer eşit seviyedeki HekaDrop ise frame tanınır. Shared-frame tipini mevcut `OfflineFrame` değil, `NearbyFrame` (paired-key shared) hattında kullanırız — zira `OfflineFrame.V1Frame.FrameType` Google-tanımlıdır; biz orada yeni enum varyantı ekleyemeyiz. Çözüm: `PAIRED_KEY_ENCRYPTION` yolunu kullanmak yerine kendi `HekaDropFrame` proto'muzu (ayrı proto file) `SecureCtx::encrypt` payload'ı olarak gömüp karşı tarafa yolluyoruz — iç düzeyde bizim parser'ımız bu seri-numarasını `OfflineFrame` mı yoksa `HekaDropFrame` mi olduğunu **magic prefix** (ilk 4 bayt sabit `0xA5 0xDE 0xB2 0x01`) ile ayırt eder. HekaDrop olmayan peer prefix'i tanımaz → `OfflineFrame::decode` hatası → frame drop; ama bu duruma zaten capabilities-gate sayesinde girilmez.
+
+**Öneri: (b).** Karar gerekçeleri:
+
+1. Upstream wire format'ı breaking yapmıyor.
+2. Protokol katmanlama temiz kalıyor: integrity verisi integrity frame'inde.
+3. Capabilities-gate üzerinde çalışır → 3rd-party Quick Share peer'leri etkilenmez.
+4. 0004 (resume) ve 0005 (folder) aynı shared-frame mekanizmasını kullanabilir.
+
+### 3.2 `CapabilitiesFrame` (first mover — 0004/0005 ortak)
+
+```proto
+// proto/hekadrop_extensions.proto (yeni dosya, HekaDrop-özel)
+syntax = "proto3";
+package hekadrop.ext;
+
+message HekaDropFrame {
+  // Magic: 0xA5DEB201 (big-endian) — HekaDropFrame discriminator.
+  // Quick Share uyumsuz peer'lar parse edemez; bu kasıtlı.
+  fixed32 magic = 1;
+  uint32 version = 2;  // sürüm 1 = v0.8.0 bootstrap
+  oneof payload {
+    CapabilitiesFrame capabilities = 3;
+    ChunkIntegrity chunk_integrity = 4;
+    // Reserved 5..15 — 0004 ResumeHint, 0005 FolderManifest vb.
+    // (oneof slot reservation; kritik: yeni field eklerken numarayı
+    // koru — 0004/0005 RFC'leri 5 ve 6'yı alacak.)
+  }
+  reserved 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15;
+  reserved "resume_hint", "folder_manifest";
+}
+
+message CapabilitiesFrame {
+  // Bitmask. Gelecekte genişleyebilir; bilinmeyen bit sessiz yok sayılır.
+  // Bit 0 = CHUNK_HMAC_SHA256 (bu RFC)
+  // Bit 1 = RESUME_V1 (RFC 0004)
+  // Bit 2 = FOLDER_STREAM_V1 (RFC 0005)
+  // Bit 3..63 reserved
+  uint64 capability_bits = 1;
+
+  // Peer'ın HekaDrop sürümü (diagnostics; trust kararı için kullanılmaz).
+  string version = 2;
+}
+
+message ChunkIntegrity {
+  int64 payload_id = 1;   // PayloadHeader.id ile eşleşir
+  int64 chunk_index = 2;  // 0'dan başlayan monotonik sayaç
+  int64 offset = 3;       // PayloadChunk.offset aynası (redundant integrity)
+  uint32 body_len = 4;    // Ayrı doğrulama: len(body) bu değere eşit olmalı
+  bytes tag = 5;          // HMAC-SHA256 (32 bayt), ayrıntı §3.4
+}
+```
+
+**Not:** `HekaDropFrame` magic prefix yaklaşımı, proto3'ün "unknown field silently preserved" davranışından bilinçli ayrılır; karşı taraf HekaDrop değilse frame parse hatası verip drop eder, bu zaten peer capabilities'i yok demek → ekosistemimizde bu frame oraya hiç gönderilmeyecektir (capabilities-gate §4 altında). Magic prefix defansiftir: capabilities-gate bug'ı durumunda sessiz interop hatası yerine sert parse hatası ile erken tanı.
+
+### 3.3 Capabilities Negotiation Akışı
+
+```
+ConnectionRequest → UKEY2 handshake → ConnectionResponse(ACCEPT)
+    → PairedKeyEncryption (mevcut)
+    → CapabilitiesFrame (YENI — SecureCtx altında, her iki taraf gönderir)
+    → payload akışı
+```
+
+Ekleme noktası: `connection.rs` Introduction öncesi. PairedKeyEncryption phase'i tamamlanır tamamlanmaz her iki uç kendi `CapabilitiesFrame`'ini yollar (sender → receiver ve receiver → sender). Karşı taraftan 2 sn içinde `CapabilitiesFrame` almazsa: **legacy mode** (peer HekaDrop değil veya <v0.8.0). Legacy mode'da `chunk_hmac_key` asla türetilmez, `ChunkIntegrity` frame'i gönderilmez, alıcı da beklenmez.
+
+Timeout neden 2 sn? PairedKeyEncryption ile Introduction arası mevcut akışta genellikle <100 ms; 2 sn cömert bir margin, handshake `HANDSHAKE_READ_TIMEOUT = 30 s` limitinin çok altında. `CapabilitiesFrame` zorunlu değil — legacy Quick Share peer'ı asla göndermez; o akışta receiver `CapabilitiesFrame` beklemek yerine Introduction frame'ini ilk gördüğünde "peer capabilities bildirmemiş = 0" varsayar.
+
+Negotiated `active_caps = my_caps & peer_caps`. Bit-AND seçimi: bir taraf bir özelliği kapatmışsa (örn. CLI flag `HEKADROP_DISABLE_CHUNK_HMAC=1`) ikili AND ile sessizce devre-dışı.
+
+### 3.4 HMAC Anahtar Türetmesi
+
+**Ayrı HKDF dalı** kullanılır. Gerekçe: domain separation — `send_hmac_key` frame-level authenticate için kullanılmaktadır; aynı anahtarı chunk-level MAC için yeniden kullanmak cross-protocol confusion saldırı yüzeyi açar (teorik; uygulamada HMAC-SHA256 multi-use'a dayanıklı olsa da NIST SP 800-108 ve RFC 5869 §3.1 ayrı kullanım-etiketleri önerir).
+
+```
+IKM  = next_secret          # mevcut UKEY2 türevi, src/crypto.rs Level-2 (§6.3 threat-model)
+salt = sha256("hekadrop:chunk-hmac:v1")
+info = b"hekadrop chunk-hmac v1"
+chunk_hmac_key = HKDF-Expand(HKDF-Extract(salt, IKM), info, 32)
+```
+
+Her iki yön için **aynı** `chunk_hmac_key` kullanılır (dosya transferi tek yönlüdür; ama simetri korunur). `next_secret` halihazırda `DerivedKeys` içinde yaşıyor (bkz. threat-model §6.3 Level-1); yeni bir UKEY2 round-trip gerekmez.
+
+### 3.5 Tag Hesaplama
+
+```
+message = payload_id (8 bayt big-endian)
+        || chunk_index (8 bayt big-endian)
+        || offset (8 bayt big-endian)
+        || body_len (4 bayt big-endian)
+        || body (raw plaintext chunk)
+
+tag = HMAC-SHA256(chunk_hmac_key, message)
+```
+
+**Neden offset + chunk_index ikisi de?** Redundancy; saldırgan reordering yapmaya kalkarsa her iki alan da hash altında, dolayısıyla tag doğrulama yer-değiştirmeyi yakalar. `body_len` de hash altına alınır — length-extension ya da pre-image confusion korunur (HMAC zaten length-extension immune'dur ama açık netlik iyi dokümantasyon).
+
+**Neden plaintext body?** Frame-level HMAC'ten çıkan plaintext'i chunk-level MAC altında da authenticate ediyoruz — "defense in depth". Ciphertext üstünden MAC (MtE-like) CBC + HMAC'in zaten verdiği şeyi tekrarlar ve padding oracle yüzeyini genişletebilir.
+
+### 3.6 Tag Doğrulama (Alıcı)
+
+`PayloadAssembler::ingest` (`src/payload.rs:233-264`) şu adımlarla genişler:
+
+1. `PayloadChunk` alınır. Eğer `active_caps & CHUNK_HMAC == 0` → mevcut akış (değişiklik yok).
+2. Eğer `CHUNK_HMAC` aktif: `PayloadChunk` işleme **almadan** aynı `SecureCtx` stream'inde bir sonraki frame'i oku, `HekaDropFrame.ChunkIntegrity` ile eşleşmesi beklenir.
+3. Sıra uyumu kontrolleri:
+   - `ChunkIntegrity.payload_id == PayloadHeader.id`
+   - `ChunkIntegrity.chunk_index == expected_next_index[payload_id]` (monotonik artan, `expected_next_index` `PayloadAssembler` state'ine eklenir)
+   - `ChunkIntegrity.offset == PayloadChunk.offset`
+   - `ChunkIntegrity.body_len == body.len()`
+4. `expected_tag = HMAC-SHA256(chunk_hmac_key, message)` hesapla (§3.5 formatı).
+5. `subtle::ConstantTimeEq::ct_eq(&expected_tag, &ChunkIntegrity.tag)` — **constant-time** karşılaştırma (mevcut kullanım `src/crypto.rs:82`). Mismatch → `HekaError::ChunkHmacMismatch { payload_id, chunk_index }`, transfer abort, placeholder dosya silinir (`remove_partial_file` helper — `src/payload.rs:480+` civarındaki mevcut cleanup yolu üzerinden).
+6. `expected_next_index[payload_id] += 1`, chunk body `sink.writer.write_all`'a devam eder.
+
+Hata yolu kritik: tag mismatch'te **partial_file disk'ten mutlaka silinmelidir**, çünkü resume protokolü (RFC 0004) bozuk chunk içeren partial'i geçerli sayarsa attacker-controlled corruption kalıcı olur. Silme başarısızsa log'a `error!` seviyesinde uyarı + dosya `.corrupt` uzantısıyla rename.
+
+### 3.7 Gönderim Sırası
+
+```
+for chunk in file.chunks(CHUNK_SIZE):
+    payload_transfer = wrap_payload_transfer(..., body=chunk, flags=last?)
+    enc1 = ctx.encrypt(payload_transfer.encode())
+    write_frame(socket, enc1)
+
+    integrity = HekaDropFrame { ChunkIntegrity { payload_id, chunk_index, ..., tag } }
+    enc2 = ctx.encrypt(integrity.encode())
+    write_frame(socket, enc2)
+```
+
+İki ayrı `SecureCtx::encrypt` çağrısı → iki ayrı sequence number. Bu sender'ı `client_seq` tarafında 2× hızlı tüketir; mevcut overflow guard `checked_add` 2^31 mesajla yeterli (2^30 chunk = 512 GiB × 512 KiB = 512 PiB, nasıl olsa erişilmez).
+
+**Alternatif:** Tek frame içinde `HekaDropFrame` ile `PayloadTransferFrame`'i concatenate et. Reddedildi: wire format'ta frame = 4-byte length prefix + protobuf; her seferinde bir mesaj. Composite frame için yeni parser gerekir.
+
+### 3.8 Efor Kırılımı
+
+| İş | Saat | 0004 ile Kesişim |
+|---|---|---|
+| `proto/hekadrop_extensions.proto` + build.rs integration | 2 | ✓ (ortak dosya; 0004 reserved slot açar) |
+| `CapabilitiesFrame` negotiation (`src/capabilities.rs` yeni modül) | 4 | ✓ (0004/0005 aynı modülü genişletir) |
+| `HekaDropFrame` magic-prefix dispatcher (`src/frame.rs` ext) | 3 | ✓ |
+| `chunk_hmac_key` HKDF türetme + `DerivedKeys` genişletme | 2 | — |
+| Sender yolunda `ChunkIntegrity` üretimi (`src/sender.rs`) | 3 | — |
+| Receiver yolunda tag doğrulama (`src/payload.rs`) | 4 | ○ (0004 partial resume logic aynı yeri değiştirir; merge çakışması beklenir) |
+| Unit + property test'ler | 4 | — |
+| Integration test (1 GiB + corruption injection) | 3 | — |
+| Fuzz harness (`fuzz_chunk_hmac_verify`) | 2 | — |
+| Benchmark (`benches/chunk_hmac.rs`, Criterion) | 2 | — |
+| Dokümantasyon (`docs/protocol/chunk-hmac.md`) | 2 | ✓ (0004 aynı dizine yazar) |
+| **Toplam** | **31** | — |
+
+Paralel çalışılırsa 0004 ile ortak primitifler (`proto/hekadrop_extensions.proto`, `src/capabilities.rs`) iki RFC arasında tek kez yazılır; 0003 onları tanımlayan RFC'dir.
+
+## 4. Alternatifler
+
+### 4.1 AES-GCM'e Geçiş
+
+**Reddedildi (bu RFC kapsamında).** AES-GCM per-record AEAD sağlardı, ama:
+- Upstream Quick Share spec'i AES-CBC + HMAC'tir; Android peer'ları AES-GCM'yi anlamaz.
+- Migration breaking; feature-flag'li çift-katlı implementasyon gerekir.
+- Ayrı bir RFC konusu (ileride).
+
+### 4.2 Salt SHA-256 chunk hash (MAC'siz)
+
+**Reddedildi.** MAC anahtarı yoksa tampering yakalanmaz; saldırgan hem body hem hash'i tamperler. Mid-stream corruption için gürültü-bazlı senaryoda işe yararlar (§2.1 ikinci madde), ama resume protokolünde receiver'ın iddiasını sender doğrulayamadığından 0004'e zemin olmaz.
+
+### 4.3 BLAKE3 / Poly1305
+
+**Reddedildi.** BLAKE3 daha hızlı (benchmark: ~3× SHA-256) ama yeni crypto primitif → audit yüzeyi büyür. SHA-256 zaten `sha2` crate üzerinden hot path'teki hasher (`src/payload.rs:378`). HMAC-SHA256 ek kod yolu yok, yalnızca yeni key. Poly1305 one-time MAC; key re-use catastrophic — nonce yönetimi zorlaşır. HMAC-SHA256 key-reuse safe.
+
+### 4.4 Seçenek (a) — Chunk body suffix
+
+§3.1'de detaylı tartışıldı. Reddedildi: protokol katmanlama ihlali + interop kırılımı.
+
+## 5. Geriye Uyumluluk / Migration
+
+- **Wire format:** Quick Share proto'larına değişiklik yok. Yeni proto: `proto/hekadrop_extensions.proto` (bizim yönetimimizde).
+- **Peer interop:** `CapabilitiesFrame` yoksa legacy mode; tam geri uyumlu. Android / rquickshare / NearDrop peer'ları etkilenmez.
+- **Config:** `HEKADROP_DISABLE_CHUNK_HMAC=1` env var ile sender-side opt-out (debug / A/B için). Receiver zaten peer capabilities'i bildirmemişse legacy.
+- **Feature flag gerekir mi?** Hayır — capabilities-gate zaten flag görevi görür. Ama release sonrası ilk iki hafta telemetry (diag panel) için `stats.json` içine `chunk_hmac_used: bool` field'ı eklenir.
+
+## 6. Güvenlik Değerlendirmesi
+
+### 6.1 Threat Model Etkisi
+
+Mevcut `threat-model.md` §5.3 "Transfer" STRIDE tablosunda etkilenen hücreler:
+
+- **T (Tampering) — `A2: Ciphertext bit-flip (CBC malleability)`:** Mevcut mitigation "HMAC-SHA256 tag header_and_body üzerine" — frame-level. Chunk-HMAC bu korumayı payload içeriği seviyesinde **tekrarlar**; defense-in-depth. Frame-level HMAC'in bir bug'ı (örn. `subtle::ConstantTimeEq` mis-invocation, sequence counter wrap) chunk-HMAC ile hâlâ yakalanır.
+- **T — Mid-stream silent corruption:** Bugün "end-of-file SHA-256" ile yakalanır ama geç; chunk-HMAC ile her chunk'ta yakalanır. Threat model'e yeni satır eklenecek: "Chunk-level tag (§3.5); mismatch → immediate abort + partial cleanup."
+- **I (Information disclosure):** Tag plaintext gönderilir ama HMAC one-way → IKM (`chunk_hmac_key`) sızdırmaz. Timing oracle: constant-time verify (§3.6/5). Payload hacmi anlamına gelebilecek length-leak zaten `PayloadChunk.body` boyutundan var; `ChunkIntegrity.body_len` yeni bilgi eklemez.
+- **D (Denial of service):** Saldırgan (malicious peer, A3) her chunk'ta tag mismatch üretirse → transfer erken iptal → işini **kolaylaştırır** (eski akışta da kullanıcı-controlled cancel). Yeni DoS vektörü yok. Kapasite tüketimi: her chunk için +32 bayt + proto overhead + 1 ek sequence — ihmal edilebilir.
+- **E (Elevation):** Yeni kod yolu `PayloadAssembler`'da proto decode + HMAC verify; her ikisi de safe Rust + constant-time. Yeni `unsafe` yok.
+
+### 6.2 Nonce/IV Analizi
+
+- `ChunkIntegrity` şifreli `SecureCtx` stream'inde taşınır → kendi IV'si var (mevcut frame-level CBC).
+- Tag-content IV kullanımı yok; HMAC deterministic.
+- Replay: saldırgan eski bir (chunk_index, tag) çiftini replay ederse? `expected_next_index` monotonik → eski index'e dönüş `HekaError::ChunkHmacMismatch` (index mismatch) ile reddedilir.
+- Cross-session replay: `chunk_hmac_key` her oturumda farklı (HKDF `next_secret` ephemeral) → cross-session tag reuse imkansız.
+
+### 6.3 Domain Separation
+
+HKDF info string: `"hekadrop chunk-hmac v1"`. Gelecek sürümlerde `v2` gerekirse ayrı anahtar; saldırgan v1 tag'ini v2 context'inde replay edemez.
+
+### 6.4 Timing Side-Channel
+
+`subtle::ConstantTimeEq::ct_eq` (`src/crypto.rs:10,82`) zaten kullanılıyor. Yeni verify aynı API'yi kullanır. Early-return `body_len` mismatch'ten once yapılabilir (sabit "invalid length" branch); length kendi başına plaintext'tir, zaten açık → length-bazlı timing leak yok.
+
+### 6.5 Audit Checklist (Trail of Bits / Cure53)
+
+- [ ] HKDF info string `"hekadrop chunk-hmac v1"` RFC 5869 domain separation için yeterli mi?
+- [ ] `next_secret`'in iki farklı HKDF dalına beslenmesi (mevcut L2 + yeni chunk-hmac) ikili Level-2 türev olarak kabul edilir mi?
+- [ ] `ChunkIntegrity` frame'inin replay koruması `expected_next_index` ile yeterli; monotonic counter overflow `i64` → pratik değil.
+- [ ] Partial file cleanup'ın fail'i `.corrupt` rename ile resume protokolünü yanıltmaz mı? (0004'te eşgüdüm.)
+
+## 7. Performans Değerlendirmesi
+
+### 7.1 Bandwidth Overhead
+
+- `ChunkIntegrity` proto serialized ≈ 60 bayt (tag 32 + payload_id + chunk_index + offset + body_len + overhead).
+- `CHUNK_SIZE = 512 * 1024 = 524 288 bayt`.
+- Overhead: `60 / 524288 ≈ 0.011%`. Ayrıca frame header (4-byte length prefix) ve `SecureCtx` HMAC + IV padding ≈ 60 bayt ek → toplam ~120 bayt / 512 KiB = **~0.023%**.
+
+### 7.2 CPU Overhead
+
+- HMAC-SHA256 hesaplaması 512 KiB için ~0.5 ms modern x86 (AES-NI yok, SHA-NI var/yok'a göre). Mevcut dosya-geneli SHA-256 hasher zaten aynı 512 KiB'i işliyor (`src/payload.rs:409`); chunk-HMAC bunu ~2× yapar (hash + HMAC).
+- Tahmini throughput regresyon: **%3-5** tek çekirdek, CPU-bound senaryoda. Ağ-bound senaryoda (Wi-Fi ~100 MiB/s): görünmez.
+
+### 7.3 Benchmark Planı
+
+`benches/chunk_hmac.rs` — Criterion. Ölçümler:
+
+1. `bench_chunk_hmac_sign` — tek 512 KiB chunk için tag üretim süresi.
+2. `bench_chunk_hmac_verify` — tek chunk verify.
+3. `bench_pipeline_1gib` — 1 GiB virtual file pipeline (in-memory, disk I/O hariç); legacy vs chunk-HMAC aktif throughput karşılaştırması.
+
+Regression gate: CI'da %10'dan fazla throughput düşüşü → PR red.
+
+## 8. Test Planı
+
+### 8.1 Unit
+
+- `crypto::chunk_hmac_sign_verify_roundtrip` — rastgele key + chunk, sign → verify true.
+- `crypto::chunk_hmac_verify_fails_on_body_tamper` — bir byte flip → verify false.
+- `crypto::chunk_hmac_verify_fails_on_index_tamper` — chunk_index 0 → 1, verify false.
+- `capabilities::negotiation_and_off_by_peer_absence` — legacy peer timeout → `active_caps == 0`.
+
+### 8.2 Property (proptest)
+
+```rust
+proptest! {
+    #[test]
+    fn chunk_tag_any_body_flip_detected(body in any::<Vec<u8>>(), flip_at in 0usize..65536) {
+        let k = [7u8; 32];
+        let tag = chunk_hmac_sign(&k, 0, 0, 0, &body);
+        if body.is_empty() { return Ok(()); }
+        let mut bad = body.clone();
+        bad[flip_at % bad.len()] ^= 0x01;
+        prop_assert!(!chunk_hmac_verify(&k, 0, 0, 0, &bad, &tag));
+    }
+}
+```
+
+### 8.3 Integration
+
+- `tests/chunk_hmac_1gib_flip.rs` — 1 GiB random file; sender karşı 5. chunk'ın orta byte'ını flip eder (test harness'taki bir "man-in-the-pipe" adapter üzerinden). Beklenti: alıcı chunk 5 ingest'inde `ChunkHmacMismatch` hatası, placeholder dosya `~/Downloads/` altından silinmiş, `stats.json`'a abort kaydedilmiş.
+- `tests/chunk_hmac_legacy_peer_fallback.rs` — capabilities bildirmeyen fake peer; alıcı `ChunkIntegrity` beklemez, mevcut end-of-file SHA-256 akışı.
+
+### 8.4 Fuzz
+
+Yeni harness: `fuzz/fuzz_targets/fuzz_chunk_hmac_verify.rs`. Girdi: `(key_seed, payload_id, chunk_index, offset, body_len, body_bytes, tag_bytes)` — crash-free + no UB. Corpus seed'leri: 1024 rastgele valid + 1024 mutated.
+
+## 9. Dokümantasyon Etkisi
+
+- `README.md` §Protokol: yeni özellik "per-chunk HMAC-SHA256 integrity (v0.8.0+, peer capabilities gated)" satırı.
+- `docs/protocol/chunk-hmac.md` — wire format, key schedule, test vector KAT.
+- `docs/security/threat-model.md` §5.3 tabloda "Chunk-level tag" satırı eklenir; §8 D-2 "accepted deferred" → "resolved in v0.8.0 via RFC-0003".
+- `CHANGELOG.md` — v0.8.0 bölümü altında "Protocol: chunk-level HMAC-SHA256 (opt-in via capabilities; peer negotiated)".
+
+## 10. Açık Sorular
+
+1. **`CapabilitiesFrame.capability_bits` kaç bit reserve edilmeli?** `uint64` 64 bit; RFC 0003-0005 üçü dolu, kalan 61 bit. Gelecek 2 yıl için bol; ancak geçmiş deneyimle (IPv4 flag field'ları) daha çok bit alanı iyi fikir. **Öneri:** `repeated uint64 capability_bits` (vektör) veya ayrı `extensions map<string, bytes>` eklemek. Ama şimdilik `uint64` yeterli; gerektiğinde `v2` HekaDropFrame açılabilir.
+2. **Magic prefix `0xA5DEB201` — çakışma riski?** Quick Share `OfflineFrame.version = 1` tipik olarak `0x08 0x01` varint ile başlar. `0xA5` MSB-set varint → prost decode hatası verir. Düşük çakışma riski. Yine de prefix'i `proto/hekadrop_extensions.proto` dokümanında kalıcı olarak sabitlemek gerekli.
+3. **`extra_capabilities` bitmap mi `CapabilitiesFrame` mi?** Quick Share `ConnectionRequestFrame`'de `extra_capabilities` adında bir alan yok (bkz. `proto/offline_wire_formats.proto:71-125` — biz full frame'i kontrol ettik). Dolayısıyla bitmap piggyback seçeneği yok; **ayrı `CapabilitiesFrame` zorunlu**. ROADMAP §Q1 risk tablosunun "Quick Share extra_capabilities çakışma" maddesi bu RFC ile moot oluyor.
+4. **Partial file resume interop:** Eğer v0.8.0 alıcısı v0.8.0 göndericisinden 50% aldı, tag mismatch'te partial silindi — sonra aynı peer yeniden bağlandığında chunk 0'dan mı başlar? Evet; RFC 0004 bu yeniden-başlangıcı `partial_hash` ile optimize eder. 0004 merge'ünden önce chunk-HMAC yalnız erken-tespiti sağlar, resume sağlamaz.
+5. **`HEKADROP_DISABLE_CHUNK_HMAC=1` env var gerçekten gerek mi?** A/B metrik ve emergency rollback için faydalı; ama çoğu kullanıcı görmez. `off-by-default via capabilities AND` davranışıyla gereksiz olabilir. Reviewer'a bırakılmış.
+
+## 11. Referanslar
+
+- RFC 2104 — HMAC. <https://datatracker.ietf.org/doc/html/rfc2104>
+- RFC 5869 — HKDF. <https://datatracker.ietf.org/doc/html/rfc5869>
+- NIST SP 800-108 — KDF in counter/feedback mode, domain separation guidance.
+- Stone, J. & Partridge, C. — "When the CRC and TCP Checksum Disagree", SIGCOMM 2000.
+- Google Quick Share protokol proto'ları: `proto/offline_wire_formats.proto`, `proto/wire_format.proto`.
+- HekaDrop internal: `docs/security/threat-model.md` §5.3 (transfer STRIDE), §6.3 (HKDF tablosu), §8 D-2 (deferred risk).
+- İlişkili RFC'ler: 0004 (resume — taslak), 0005 (folder streaming — taslak); her ikisi de bu RFC'deki `CapabilitiesFrame` ve `HekaDropFrame` mekanizmasını yeniden kullanacak.
+- Marlinspike, M. — "The Cryptographic Doom Principle" (EtM-before-decrypt disiplinine referans; bu RFC aynı disiplini chunk seviyesinde korur).

--- a/docs/rfcs/0004-transfer-resume.md
+++ b/docs/rfcs/0004-transfer-resume.md
@@ -115,26 +115,48 @@ cevaptan biriyle devam eder:
   akışı, sender chunk'ları byte 0'dan yollar.
 - **Yarım dosya mevcut** → `ResumeHint` frame gönderir.
 
-Protobuf tanımı (proto ağacına `proto/v2/resume.proto` olarak eklenir):
+Protobuf tanımı (RFC-0003'te tanımlanan `proto/hekadrop_extensions.proto` dosyasına
+eklenir; package `hekadrop.ext`):
 
 ```protobuf
-syntax = "proto3";
-package hekadrop.protocol.resume.v1;
-
 message ResumeHint {
-  int64  session_id         = 1;   // UKEY2 auth_key low-8 bytes (bkz. §3.4)
-  int64  payload_id         = 2;   // Introduction frame'deki file id
-  int64  offset             = 3;   // Receiver'ın diske sağlam yazdığı byte sayısı
-  bytes  partial_hash       = 4;   // SHA-256(file[0..offset]) (32 byte)
-  int32  capabilities_version = 5; // RFC-0003 capabilities frame versiyonu
-  bytes  last_chunk_tag     = 6;   // Opsiyonel: son doğrulanmış chunk-HMAC tag'i
-                                    //   (RFC-0003 aktifse; yoksa boş)
+  int64  session_id           = 1;  // UKEY2 auth_key SHA-256 low-8 bytes (bkz. §3.4)
+  int64  payload_id           = 2;  // Introduction frame'deki file id
+  int64  offset               = 3;  // Receiver'ın diske sağlam yazdığı byte sayısı
+  bytes  partial_hash         = 4;  // SHA-256(file[0..offset]) (32 byte)
+  uint32 capabilities_version = 5;  // RFC-0003 Capabilities.version değeri
+  bytes  last_chunk_tag       = 6;  // Opsiyonel: son doğrulanmış chunk-HMAC tag'i
+                                    //   (CHUNK_HMAC_V1 aktifse; yoksa boş)
+}
+
+message ResumeReject {
+  int64 payload_id = 1;  // echo of the rejected hint
+  Reason reason    = 2;
+  enum Reason {
+    REASON_UNSPECIFIED = 0;
+    HASH_MISMATCH      = 1;
+    INVALID_OFFSET     = 2;
+    VERSION_MISMATCH   = 3;
+    PAYLOAD_UNKNOWN    = 4;
+    SESSION_MISMATCH   = 5;
+    INTERNAL_ERROR     = 6;
+  }
 }
 ```
 
-Frame `V1Frame` içine yeni bir `FrameType::ResumeHint = 7` olarak eklenir
-(mevcut 1-6 değerleri `HandshakeBegin`, `ConnectionRequest`, `Introduction`,
-`PayloadTransfer`, `KeepAlive`, `Disconnection`; `7` serbest).
+**Wire yerleşimi (kritik):** `ResumeHint` ve `ResumeReject` **upstream
+`V1Frame.FrameType` enum'una slot eklemez** — orası Google Quick Share / Nearby
+Connections spec'idir ve slot 7 (`PAIRED_KEY_ENCRYPTION`) dahil mevcut tanımlar
+dokunulmazdır. Bunun yerine her iki mesaj RFC-0003'te tanımlanan `HekaDropFrame`
+wrapper'ının `oneof payload` alanında taşınır; slot atamaları:
+
+- `HekaDropFrame.resume_hint   = 12`
+- `HekaDropFrame.resume_reject = 13`
+
+`HekaDropFrame` ise `SecureCtx::encrypt` payload'ı olarak magic prefix
+(`0xA5DEB201`) ile gönderilir; detaylar RFC-0003 §3.1–§3.2. HekaDrop'a
+uyumsuz peer'lar magic prefix'i parse edemez ve capabilities-gate sayesinde
+bu frame'ler oraya hiç gönderilmez.
 
 ### 3.3 Partial-hash doğrulama
 
@@ -163,10 +185,10 @@ hesaplanıyor; burada sadece ek olarak kalıcı tutuluyor.
 
 `session_id` UKEY2 handshake sonrası türetilen `auth_key`'in
 **SHA-256(auth_key) fingerprint'inin düşük 8 byte'ı** olarak tanımlanır.
-Helper `crypto::session_fingerprint` (bkz. `src/ukey2.rs:134-139`) zaten
+Helper `crypto::session_fingerprint` (bkz. `src/crypto.rs:59`) zaten
 mevcut; 16 hex karakter olarak log'da görülüyor. Bu RFC ilgili helper'ı
 `pub(crate) fn session_id_i64(auth_key: &[u8]) -> i64` şeklinde
-export eder:
+export eder (aynı modülde):
 
 ```rust
 pub(crate) fn session_id_i64(auth_key: &[u8]) -> i64 {
@@ -265,36 +287,20 @@ integrity primer olacak.
 
 ## 4. Capabilities negotiation (RFC-0003 ile koordinasyon)
 
-RFC-0003 capabilities frame'i tanımlıyorsa (henüz draft — **bkz 0003 açık
-sorular**), resume şu bit'i talep eder:
+`Capabilities` mesajı **tek bir kanonik tanıma** sahiptir ve RFC-0003 §3.2'de
+yer alır. Tekrarı kaldırıldı; buradaki özet sadece 0004'ün ilgilendiği bit'i
+isimlendirir:
 
 ```
-capability bit: RESUME_V1 = 0x0002   (RFC-0003: CHUNK_HMAC_V1 = 0x0001)
-capabilities_version (u32): monoton artan; v1 = 1
+CHUNK_HMAC_V1    = 0x0001   (RFC-0003, bit 0)
+RESUME_V1        = 0x0002   (bu RFC,   bit 1)
+FOLDER_STREAM_V1 = 0x0004   (RFC-0005, bit 2)
 ```
 
-**Önerilen capabilities frame iskeleti** (RFC-0003'e giriş olarak):
-
-```protobuf
-message Capabilities {
-  uint32 version  = 1;  // monoton artar
-  uint64 features = 2;  // bitfield: RESUME_V1 | CHUNK_HMAC_V1 | ...
-}
-```
-
-RFC-0003 capabilities tasarımını üstlenmezse, 0004 kendi `resume_capabilities`
-frame'ini minimal tutar:
-
-```protobuf
-message ResumeCapabilities { uint32 version = 1; bool supported = 2; }
-```
-
-Ancak iki ayrı capabilities frame'i yerine **paylaşılmış tek frame tercih
-edilir** — 0003 yazarıyla koordinasyon: "RESUME_V1 bit'ini rezerv edin,
-biz 0004'te tanımlamayacağız". Koordinasyon tamamlanana kadar `0003-chunk-hmac.md`
-açık sorular bölümüne "RESUME_V1 = 0x0002 bit'i 0004 RFC tarafından talep
-edildi; paylaşılmış enum'a ekleyin" notu düşer (bu RFC merge edilirken
-PR açıklamasında hatırlatılır).
+`ResumeHint.capabilities_version` alanı, handshake sırasında değiş-tokuş edilen
+`Capabilities.version` ile **eşit olmalıdır**; uyuşmazlık → `ResumeReject{VERSION_MISMATCH}`.
+Ayrı bir `ResumeCapabilities` frame'i **tanımlanmaz**; tek `Capabilities`
+mesajı üç RFC'nin ortak zeminidir.
 
 ## 5. Alternatifler
 
@@ -331,9 +337,11 @@ semantik overkill; SHA-256 equal check yeterli.
   sabiti; config'te override edilebilir.
 - **Feature flag**: v0.8.0'da default **açık**. Config'te
   `resume.enabled: bool` ile disable edilebilir (paranoya / bug workaround için).
-- **Proto versioning**: `proto/v1/` (mevcut) dokunulmaz; `proto/v2/resume.proto`
-  yeni dosya olarak eklenir. Build zamanı cargo feature flag'lemez; v1+v2
-  aynı binary'de yan yana.
+- **Proto versioning**: Upstream Quick Share proto'ları (`proto/v1/` dizini)
+  dokunulmaz; `ResumeHint`/`ResumeReject` mesajları RFC-0003'te açılan
+  `proto/hekadrop_extensions.proto` dosyasına eklenir (package `hekadrop.ext`).
+  Build zamanı cargo feature flag'lemez; upstream proto'lar ile yan yana
+  derlenir.
 
 ## 7. Güvenlik değerlendirmesi
 
@@ -416,7 +424,7 @@ byte input ile panic-free decode'u).
 
 | # | İş | Süre |
 |---|----|-----:|
-| 1 | `proto/v2/resume.proto` tanım + build.rs entegrasyon | 2 s |
+| 1 | `proto/hekadrop_extensions.proto`'a `ResumeHint`/`ResumeReject`/oneof slot 12-13 ekle + build.rs | 2 s |
 | 2 | `session_id_i64` helper + test | 1 s |
 | 3 | `.meta` JSON struct + serde + read/write + atomic rename | 4 s |
 | 4 | Partial dir creation + perms (Unix chmod, Windows ACL) | 3 s |
@@ -448,8 +456,10 @@ byte input ile panic-free decode'u).
 5. **Resume UI affordance:** Kullanıcı "bu %92 partial var, devam et/sıfırla"
    seçebilsin mi, yoksa otomatik resume tercih edilsin mi? Önerim: otomatik
    (sessiz) + Settings > Diagnostics'te partial list görünür + manual delete.
-6. **Capabilities frame ownership:** RFC-0003'te mi, burada mı tanımlanacak?
-   Koordinasyon gerekir.
+6. ~~**Capabilities frame ownership:** RFC-0003'te mi, burada mı tanımlanacak?~~
+   **Kapandı:** `Capabilities` mesajı tek kanonik tanım olarak RFC-0003 §3.2'de,
+   `HekaDropFrame` wrapper'ı içinde yaşar; bu RFC `RESUME_V1 = 0x0002` bit'ini
+   ve `ResumeHint`/`ResumeReject` oneof slot'larını (12 ve 13) kullanır.
 7. **Klasör payload'ları:** RFC-0005 folder streaming için resume nasıl
    çalışır? Per-file mi (her dosya bağımsız partial), yoksa folder manifest
    seviyesinde mi? Önerim: **per-file**. RFC-0005 paralel yazılırken bu

--- a/docs/rfcs/0004-transfer-resume.md
+++ b/docs/rfcs/0004-transfer-resume.md
@@ -1,0 +1,468 @@
+# RFC 0004 — Transfer Resume
+
+- **Başlatan:** @architect (destek@sourvice.com)
+- **Durum:** Draft
+- **Oluşturulma tarihi:** 2026-04-24
+- **Hedef sürüm:** v0.8.0 ("Protokol Sağlamlaştırma", 2026-07-31)
+- **İlgili issue:** ROADMAP.md v0.8.0 §"Transfer resume" (satır 122-124)
+- **İlgili RFC'ler:** `0003-chunk-hmac.md` (capabilities frame + partial chunk integrity — paralel yazılıyor), `0005-folder-payload.md` (klasör payload'ları için resume — paralel)
+- **Wire-level spec:** `docs/protocol/resume.md`
+
+---
+
+## 1. Özet
+
+Bu RFC HekaDrop v0.8.0 için **transfer resume** mekanizmasını tanımlar. Bugün bir
+10 GiB ISO transferi 50. chunk'ta kopan Wi-Fi yüzünden kesildiğinde, kullanıcı
+tekrar bağlandığında byte 0'dan başlamak zorunda kalıyor. Önerilen tasarım:
+yeni bir `ResumeHint` protokol frame'i ile **receiver**, elinde tuttuğu yarım
+dosyayı (`~/.hekadrop/partial/<session_id>_<payload_id>.part`) sender'a
+"`offset`'e kadar geldim, SHA-256 şöyle" diye bildirir; sender yerel dosyayı
+aynı offset'e kadar hash'leyip doğrularsa `send_file_chunks` döngüsünü o
+offset'ten başlatır. Frame capabilities negotiation ile gate'lenir (bkz. RFC
+0003); resume-capable olmayan peer'larla davranış bugünkü tam-restart akışıdır.
+Partial dosyalar 7 gün TTL + 5 GiB disk bütçesi LRU eviction ile yönetilir,
+dizin izinleri `0700 / 0600`, session kimliği UKEY2 auth-key fingerprint'in
+düşük 8 byte'ından türetilir — böylece farklı handshake = farklı session =
+resume yok.
+
+## 2. Motivasyon
+
+v0.7'de `PayloadAssembler` (`src/payload.rs:250-470`) her chunk'ı
+`~/Downloads/` altında `<name>.part` olarak yazıyor; dosya tamamlanana kadar
+`.part` uzantısıyla kalıyor ve ancak `last_chunk=true` gelince final isme
+rename ediliyor. Peer tamamlamadan disconnect ederse
+`remove_partial_file` (`src/payload.rs:474`) partial'ı siliyor — yani
+**mevcut kod resume'u aktif olarak öldürüyor**. Bu davranış GC-per-connection
+için doğru (kısa ömürlü memory'yi tutmayalım) ama kullanıcı deneyimi için kötü:
+
+1. **10 GiB ISO, Wi-Fi cut @ %92** → 20+ dakika iş, baştan başla. Otel/cafe
+   Wi-Fi'lerinde ve kalabalık 2.4 GHz spektrumunda günlük vaka.
+2. **Battery death / sleep** → laptop sender ekranı kapandığında
+   `tokio::select!` blokesi sonlanır, TCP RST; telefon alıcı `.part` dosyasını
+   cleanup eder, kullanıcı uyandığında "yarım iş yok" sürprizi.
+3. **Network switch mid-transfer** → kullanıcı Wi-Fi'dan Ethernet'e atladı;
+   routing tablosu değişti, socket koptu. Bugün resume yok, dolayısıyla bu
+   kullanıcıya "büyük dosya paylaşmak için önce kabloyu tak" önermek zorundayız.
+4. **Mobil hotspot zaman sınırı** → Android tethering 30 dakikada battery-save
+   kesiyor; 4 GiB proje tarball'ı asla tamamlanmıyor.
+
+Rakip LAN paylaşım araçları (LocalSend, Syncthing) chunk seviyesinde resume
+destekliyor; HekaDrop'un Quick Share protokolüne bağlı kalmak için ekstra iş
+yapması gerekiyor (Quick Share upstream'de ResumeHint yok — aşağıda
+geriye uyumluluk bölümünde ele alınıyor).
+
+## 3. Ayrıntılı tasarım
+
+### 3.1 Partial dosya yönetimi (receiver-side)
+
+**Dizin yapısı:**
+
+```
+~/.hekadrop/
+  partial/                      (mode 0700, yalnız owner)
+    <session_id>_<payload_id>.part   (mode 0600)
+    <session_id>_<payload_id>.meta   (mode 0600, JSON)
+```
+
+`<session_id>` 16 karakterlik lowercase hex (8 byte, bkz. §3.4),
+`<payload_id>` Quick Share Introduction frame'inden gelen `i64`'ün decimal
+gösterimi. Böylece isim `a3f1b82e6cd07419_5138472819.part` gibi olur.
+
+`.meta` dosyası resume bilgisinin kalıcı halidir:
+
+```json
+{
+  "version": 1,
+  "session_id": "a3f1b82e6cd07419",
+  "payload_id": 5138472819,
+  "file_name": "ubuntu-24.04.iso",
+  "total_size": 10737418240,
+  "received_bytes": 9876543210,
+  "chunk_hmac_chain": "base64(last-verified-chunk-HMAC)",
+  "peer_endpoint_id": "ANDROID_PIXEL_8",
+  "created_at": "2026-07-15T14:32:11Z",
+  "updated_at": "2026-07-15T14:51:03Z"
+}
+```
+
+**Neden ayrı meta dosyası?** `.part` sadece dosya byte'larını taşıyor
+(`std::fs::File::set_len` ile `total_size`'a sparse-pre-allocate edilmiyor —
+platform cross-compat için naive append). Resume için "hangi peer, hangi
+session, hangi chunk'ta kaldık" bilgisi gerekli; bunu `.part` header'ına
+koymak protocol byte'larını kirletirdi. Ayrı meta JSON okuma kolaylığı +
+human-debug için.
+
+**Finalize:** Son chunk geldiğinde (`last_chunk=true`) `PayloadAssembler`
+dosyayı `~/Downloads/<name>` altına rename eder ve **hem `.part` hem `.meta`**
+dosyalarını siler (`src/payload.rs` içinde mevcut `remove_partial_file`
+genişletilir; 0.8'de `remove_partial_resource(session_id, payload_id)`
+olarak refactor).
+
+**Çekilen rename:** Rename best-effort; başarısız olursa (cross-device,
+permission) final dizin üzerinde `.tmp` kopya + atomic rename fallback
+uygulanır. Mevcut kod zaten böyle yapıyor (bkz. `src/payload.rs` ingest_file);
+0.8'de sadece "rename sonrası `.meta` sil" adımı eklenir.
+
+### 3.2 `ResumeHint` frame
+
+**Yerleşim:** Capabilities negotiation'ı (RFC 0003) müteakip,
+**Introduction frame**'inden sonra, payload'ın ilk `PayloadTransfer` chunk'ı
+gelmeden önce. Sender Introduction gönderdikten sonra receiver iki olası
+cevaptan biriyle devam eder:
+
+- **Tazecik dosya** (partial yok veya süresi dolmuş) → normal `ConnectionResponse`
+  akışı, sender chunk'ları byte 0'dan yollar.
+- **Yarım dosya mevcut** → `ResumeHint` frame gönderir.
+
+Protobuf tanımı (proto ağacına `proto/v2/resume.proto` olarak eklenir):
+
+```protobuf
+syntax = "proto3";
+package hekadrop.protocol.resume.v1;
+
+message ResumeHint {
+  int64  session_id         = 1;   // UKEY2 auth_key low-8 bytes (bkz. §3.4)
+  int64  payload_id         = 2;   // Introduction frame'deki file id
+  int64  offset             = 3;   // Receiver'ın diske sağlam yazdığı byte sayısı
+  bytes  partial_hash       = 4;   // SHA-256(file[0..offset]) (32 byte)
+  int32  capabilities_version = 5; // RFC-0003 capabilities frame versiyonu
+  bytes  last_chunk_tag     = 6;   // Opsiyonel: son doğrulanmış chunk-HMAC tag'i
+                                    //   (RFC-0003 aktifse; yoksa boş)
+}
+```
+
+Frame `V1Frame` içine yeni bir `FrameType::ResumeHint = 7` olarak eklenir
+(mevcut 1-6 değerleri `HandshakeBegin`, `ConnectionRequest`, `Introduction`,
+`PayloadTransfer`, `KeepAlive`, `Disconnection`; `7` serbest).
+
+### 3.3 Partial-hash doğrulama
+
+Receiver `.part` dosyasının `[0..offset]` aralığının SHA-256'sını hesaplar ve
+`partial_hash` alanına yazar. Sender `ResumeHint` alınca:
+
+1. `payload_id` Introduction'da zaten ilan edilmişti; local dosyayı aç.
+2. Local dosyanın `[0..offset]` aralığını streaming SHA-256 ile hash'le
+   (chunk başına 1 MiB okuma, `sha2::Sha256::update`).
+3. Hash `ResumeHint.partial_hash` ile `constant-time eq` karşılaştırması
+   (`subtle::ConstantTimeEq` zaten dependency).
+4. **Eşit** → sender `send_file_chunks` döngüsünü `offset`'ten başlatır; ilk
+   frame'de `PayloadChunk.offset = offset`.
+5. **Eşit değil** → sender `ResumeReject { reason: HASH_MISMATCH }` frame'i
+   yollar; receiver `.part` + `.meta` siler ve normal akışa düşer (byte 0'dan).
+
+**Neden full-hash, incremental değil?** 10 GiB SHA-256 modern x86_64'te
+~30 saniye (SHA-NI olmadan 200 MB/s). 20 dakika baştan-yükleme'den çok daha
+kısa. İyileştirme RFC-0003 ile birlikte geldiğinde: her chunk'ın HMAC tag'i
+`.part`'a yanına yazılır (ayrı `.hmacs` side-file veya `.meta` içinde base64
+dizisi), sender sadece `last_chunk_tag`'i doğrular — O(1) karşılaştırma,
+bandwidth-sabit. RFC-0003 ve 0004 için **ortak primitif**: chunk-HMAC zaten
+hesaplanıyor; burada sadece ek olarak kalıcı tutuluyor.
+
+### 3.4 Session identity
+
+`session_id` UKEY2 handshake sonrası türetilen `auth_key`'in
+**SHA-256(auth_key) fingerprint'inin düşük 8 byte'ı** olarak tanımlanır.
+Helper `crypto::session_fingerprint` (bkz. `src/ukey2.rs:134-139`) zaten
+mevcut; 16 hex karakter olarak log'da görülüyor. Bu RFC ilgili helper'ı
+`pub(crate) fn session_id_i64(auth_key: &[u8]) -> i64` şeklinde
+export eder:
+
+```rust
+pub(crate) fn session_id_i64(auth_key: &[u8]) -> i64 {
+    use sha2::{Digest, Sha256};
+    let digest = Sha256::digest(auth_key);
+    i64::from_be_bytes(digest[0..8].try_into().expect("SHA-256 output ≥ 8 byte"))
+}
+```
+
+**Özellik:** Deterministic per-handshake (aynı ECDH shared secret + aynı nonce
+→ aynı `session_id`). Fakat Quick Share UKEY2 handshake her bağlantıda
+yeni ephemeral P-256 key çifti üretir → pratikte **her bağlantı yeni session**.
+Yani resume sadece aynı peer-pair'inin bir önceki transfer'inden kalmış
+`.meta` dosyası ile eşleşir ve **sadece** aynı peer (aynı long-term identity)
+başarılı bir yeni UKEY2 + PIN doğrulamasıyla yeni bir session kurduğunda
+çalışır. Rastgele saldırganın partial enumerate etmesi mümkün değil (§7).
+
+**Not:** `session_id`'in kendisi UKEY2 sonrası bilindiği için sender da
+aynı hesabı yapar; frame üzerinde doğrulama olarak kullanırız (receiver
+gönderdiği `session_id` ≠ sender'ın hesapladığı `session_id` → frame drop).
+Böylece replay/fake-resume saldırıları frame validation seviyesinde düşer.
+
+### 3.5 Trust boundary
+
+Resume işlemi **her yeni successful handshake + Introduction** akışı içinde
+gerçekleşir. PIN doğrulaması her seferinde yapıldığı için ayrıca "trusted
+device" (config.json'daki trust list) olma koşulu aranmaz; yani yeni bir peer
+bile aynı `session_id`'ı üretebilir eğer önceki handshake aynı auth_key'e
+çözülürse (ki UKEY2 bunu engelliyor). Tek ek: config'te
+`resume_require_trusted: bool` (default `false`) flag'i bulunur — paranoya
+kullanıcıları resume'u sadece daha önce trust edilmiş cihazlarla yapabilmek
+için aktifleştirebilir.
+
+### 3.6 Partial cleanup
+
+İki tetikleyici + iki limit:
+
+| Parametre | Default | Override | Açıklama |
+|-----------|---------|----------|----------|
+| TTL | 7 gün | `config.resume.ttl_days` | `.meta.updated_at` bu süreden eskiyse sil |
+| Disk bütçesi | 5 GiB | `config.resume.budget_bytes` | `partial/` toplamı aşarsa LRU (oldest `updated_at` önce) |
+| Tetikleyici | Uygulama açılışı | — | `spawn` anında `tokio::spawn(cleanup_sweep())` |
+| Tetikleyici | Günlük | OS-scheduler | Linux `systemd --user timer`, macOS `launchd` plist, Windows Scheduled Task |
+
+**LRU seçimi:** `updated_at` artan sırada sırala, budget aşılana kadar sil.
+Aktif transfer sırasında silinmesin diye `PayloadAssembler` çalışan bir
+session için `<session_id>_<payload_id>.*` dosyalarını **in-use lock**
+olarak işaretler (memory'de HashSet; cleanup bu seti skip eder).
+
+**Startup cleanup yeterli mi?** HekaDrop tray app — kullanıcı günlerce kapatmaz.
+Bu yüzden OS scheduler gerekli. systemd template `dist/linux/hekadrop-cleanup.timer`,
+launchd template `dist/macos/tr.sourvice.hekadrop.cleanup.plist`, Windows
+Scheduled Task XML'i `dist/windows/hekadrop-cleanup.xml` olarak birlikte
+gönderilir.
+
+### 3.7 Sender tarafındaki döngü değişikliği
+
+`send_file_chunks` (`src/sender.rs:767`) bugün `offset: i64 = 0` ile başlıyor.
+Resume aktifse `start_offset` parametresi alacak:
+
+```rust
+async fn send_file_chunks(
+    socket: &mut TcpStream,
+    ctx: &mut SecureCtx,
+    payload_id: i64,
+    path: &Path,
+    file_size: i64,
+    peer_label: &str,
+    file_name: &str,
+    bytes_sent_before: i64,
+    total_bytes: i64,
+    start_offset: i64,         // <-- YENİ (default 0, resume ile >0)
+    cancel: &CancellationToken,
+) -> Result<()> {
+    let mut file = tokio::fs::File::open(path).await?;
+    if start_offset > 0 {
+        file.seek(SeekFrom::Start(start_offset as u64)).await?;
+    }
+    let mut offset: i64 = start_offset;
+    // ... kalan döngü aynen devam
+}
+```
+
+Hash hesaplama SHA-256 final digest için "full file" istiyor; resume'da
+`hasher` state'i kayboluyor. Çözüm: **dosyanın tamamı üzerinden bağımsız
+SHA-256 sender tarafında** (zaten log'a bastığımız final hash) — resume
+doğrulama hash'i ile karıştırılmamalı. Burada iki seçenek:
+
+- (a) Resume'da final SHA-256'yı atla (log'a "resumed, SHA unknown" yaz).
+- (b) `start_offset = 0`'dan file'ı paralel hash'le (background task), transfer
+  bittiğinde join et.
+
+**Karar: (a)**. Final SHA-256 zaten chunk-HMAC (RFC-0003) tarafından subsumed
+edilir; v0.8'de "file-level SHA" zaten görsel/debug seviyesinde değil, chunk
+integrity primer olacak.
+
+## 4. Capabilities negotiation (RFC-0003 ile koordinasyon)
+
+RFC-0003 capabilities frame'i tanımlıyorsa (henüz draft — **bkz 0003 açık
+sorular**), resume şu bit'i talep eder:
+
+```
+capability bit: RESUME_V1 = 0x0002   (RFC-0003: CHUNK_HMAC_V1 = 0x0001)
+capabilities_version (u32): monoton artan; v1 = 1
+```
+
+**Önerilen capabilities frame iskeleti** (RFC-0003'e giriş olarak):
+
+```protobuf
+message Capabilities {
+  uint32 version  = 1;  // monoton artar
+  uint64 features = 2;  // bitfield: RESUME_V1 | CHUNK_HMAC_V1 | ...
+}
+```
+
+RFC-0003 capabilities tasarımını üstlenmezse, 0004 kendi `resume_capabilities`
+frame'ini minimal tutar:
+
+```protobuf
+message ResumeCapabilities { uint32 version = 1; bool supported = 2; }
+```
+
+Ancak iki ayrı capabilities frame'i yerine **paylaşılmış tek frame tercih
+edilir** — 0003 yazarıyla koordinasyon: "RESUME_V1 bit'ini rezerv edin,
+biz 0004'te tanımlamayacağız". Koordinasyon tamamlanana kadar `0003-chunk-hmac.md`
+açık sorular bölümüne "RESUME_V1 = 0x0002 bit'i 0004 RFC tarafından talep
+edildi; paylaşılmış enum'a ekleyin" notu düşer (bu RFC merge edilirken
+PR açıklamasında hatırlatılır).
+
+## 5. Alternatifler
+
+### 5.1 HTTP Range semantics
+LocalSend HTTP `Range: bytes=N-` header'ı ile resume yapıyor. **Reddedildi:**
+Quick Share tamamen TCP stream tabanlı, HTTP katmanı yok, kendi payload
+framing'i var. Range semantiği upstream'e uymak Quick Share'i kırar.
+
+### 5.2 Chunk-başına checkpoint
+Her chunk'tan sonra `.meta`'ya fsync. **Reddedildi:** 10 GiB / 512 KiB chunk =
+20,480 fsync → NVMe'de bile 60+ sn overhead. Onun yerine **her 16 chunk'ta
+bir** (8 MiB) checkpoint fsync; resume'da en kötü 8 MiB tekrar indirilir.
+Bu rakam `config.resume.checkpoint_interval_chunks` ile tunable.
+
+### 5.3 Kalıcı, peer-bağımsız content-hash indeksi
+"Aynı content-hash'e sahip dosya tekrar geliyorsa hiç indirme" (content-addressed
+dedup). **Reddedildi:** Threat model'e yeni side-channel açıyor (peer X'in
+hangi dosyaları önceden aldığını peer Y sorgulayabilir), implementasyon
+karmaşık, v0.8 scope'u dışı.
+
+### 5.4 Rsync rolling hash
+Değişmiş byte'ları patch'le. **Reddedildi:** HekaDrop resume senaryosu
+"dosya aynı, sadece transfer yarıda kesildi" — byte'lar değişmedi. Rsync
+semantik overkill; SHA-256 equal check yeterli.
+
+## 6. Geriye uyumluluk ve migration
+
+- **Eski peer (v0.7.x)** capabilities frame göndermez → sender RESUME_V1
+  bit'ini görmez → resume yolu **asla denenmez**, bugünkü akış (tam restart)
+  korunur.
+- **Yeni sender, eski receiver**: sender Introduction sonrası
+  `ResumeHint` bekler ama receiver göndermez. Sender **2 saniye timeout**
+  sonra normal akışa geçer (offset=0). Timeout değeri `RESUME_HINT_TIMEOUT_MS`
+  sabiti; config'te override edilebilir.
+- **Feature flag**: v0.8.0'da default **açık**. Config'te
+  `resume.enabled: bool` ile disable edilebilir (paranoya / bug workaround için).
+- **Proto versioning**: `proto/v1/` (mevcut) dokunulmaz; `proto/v2/resume.proto`
+  yeni dosya olarak eklenir. Build zamanı cargo feature flag'lemez; v1+v2
+  aynı binary'de yan yana.
+
+## 7. Güvenlik değerlendirmesi
+
+Threat model (`docs/security/threat-model.md`) TB-3 (App ↔ Peer) ve TB-5
+(App ↔ Filesystem) sınırlarını etkiler.
+
+| Saldırı | Risk | Mitigation |
+|---------|------|------------|
+| Partial file enumeration (local başka user) | Orta | `~/.hekadrop/partial/` mode `0700`, dosyalar `0600`; Linux/macOS'ta POSIX perm + Windows ACL "Owner only" |
+| Session hijack via forged `session_id` | Düşük | `session_id` UKEY2 auth_key'den derive; attacker predict edemez (128-bit ECDH shared secret'ten) |
+| Partial_hash fingerprinting | Düşük | `ResumeHint` yalnız **mevcut valid session**'da gönderilir; sender sadece kendi Introduction'ına cevap olarak alır. Attacker "bu cihazda X dosyası var mı" sorgulayamaz çünkü Introduction olmadan hint kabul edilmez |
+| Symlink race (`partial/` içinde attacker symlink koyar) | Düşük | Dosya açma `O_NOFOLLOW` (Linux), `FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_BACKUP_SEMANTICS` negate (Windows); meta okuma path canonicalize + `starts_with(partial_dir)` kontrol |
+| TOCTOU: attacker `.part` bytes'ını flip, partial_hash receiver'da tutarlı ama sender `[0..offset]` farklı | **DOĞAL** | `partial_hash` mismatch → `ResumeReject` → receiver `.part` + `.meta` silip byte 0'dan başlar. Saldırgan corruption gerçekleştirse bile data yenisini alır (sadece resume avantajı kaybolur) |
+| Disk fill DoS (attacker 5 GiB partial yaratır) | Düşük | Budget + LRU; ayrıca per-peer rate limit (`src/state.rs:89-127`) mevcut. Kullanıcı consent'siz kimse partial yazamaz |
+| Partial-leak via crash dump | Çok düşük | `.part` dosyaları şifrelenmemiş **payload plaintext** içerir — bu mevcut davranış, yeni risk değil. Dokümana ekle: "Shared makinede hassas dosya paylaşımı yapılıyorsa `~/.hekadrop/partial/` dizini sensitive, kullanıcı disk encryption açmalı" |
+
+**Yeni attack surface?** Evet, ama kontrollü: `ResumeHint` frame parser'ı
+yeni bir giriş noktası. Fuzz harness `fuzz_resume_hint_parse` (ROADMAP
+satır 196'da zaten listeli) v0.9.0 fuzzing sprint'inde aktive edilir.
+
+## 8. Performans değerlendirmesi
+
+| Metric | Bugün | Resume ile | Açıklama |
+|--------|-------|------------|----------|
+| Kesik 10 GiB sonrası re-transfer | 20 dk (tüm dosya) | 30 sn hash + kalan %X | SHA-NI'siz; chunk-HMAC ile <1 sn |
+| Resume olmadan bandwidth | 100% re-download | 100% re-download | Değişmedi |
+| Resume ile bandwidth (başarılı) | — | Kalan offset kadar | ~%92 transfer'den sonra sadece %8 |
+| Receiver disk I/O | Chunk write | +`.meta` update her 16 chunk | ~%1 overhead |
+| Sender CPU (resume verify) | 0 | SHA-256 `[0..offset]` | 30 sn / 10 GiB |
+| Memory | ~1 MiB/connection | +128 byte/session (meta cache) | İhmal edilebilir |
+
+Hot path etkisi minimal: normal (resume-miss) akışta ek overhead **tek
+RESUME_HINT_TIMEOUT bekleyiş** (eski peer'larla 2 sn'lik geç başlangıç).
+v0.8 capabilities bit ile bu timeout eski peer'lar için tetiklenir; yeni
+peer'lar capabilities negotiation ile anında "resume yok" sinyali verir.
+
+## 9. Test planı
+
+**Integration:**
+
+1. `test_resume_happy_path`: 1 GiB dosya üret; sender + receiver loopback;
+   50. chunk'ta receiver socket kill; sender tarafında 500 ms bekle, yeniden
+   bağlan; receiver `.meta` mevcut → ResumeHint gönder → sender seek → transfer
+   tamam; final dosya SHA-256 eşit.
+2. `test_resume_hash_mismatch`: Aynı senaryo + disconnect sonrası receiver
+   `.part`'ın ortasındaki bir byte'ı flip; yeniden bağlan; sender hash
+   karşılaştırma fail → `ResumeReject` → receiver partial sil → byte 0'dan
+   restart → sonuç final dosya doğru.
+3. `test_resume_expired_ttl`: `.meta.updated_at` 8 gün önce; cleanup sweep
+   çalıştır; `.part` silindi; yeni handshake → resume yok, byte 0'dan.
+4. `test_resume_budget_lru_eviction`: `partial/` dir'de 6 GiB'lık partial'lar;
+   cleanup sweep; en eski olanlar 5 GiB'a düşene kadar silinir.
+5. `test_resume_capabilities_old_peer`: Mock receiver capabilities
+   göndermez; sender 2 sn timeout → byte 0'dan.
+
+**Unit:**
+
+6. `session_id_i64_deterministic`: Aynı auth_key → aynı i64.
+7. `partial_hash_calculation_streaming_matches_one_shot`: 100 MiB rastgele
+   buffer; streaming (1 MiB parça) SHA-256 = tek seferlik SHA-256.
+8. `resume_hint_frame_roundtrip`: Encode → decode; fields eşit.
+9. `partial_cleanup_skips_in_use_sessions`: Aktif session kayıtlı; cleanup
+   onu silmemeli.
+10. `partial_path_traversal_reddedilir`: `session_id = "../../etc"` içeren
+    meta → parser reject.
+
+**Fuzzing:** `fuzz_resume_hint_parse` (protobuf-derived frame'in random
+byte input ile panic-free decode'u).
+
+## 10. Dokümantasyon etkisi
+
+- `README.md` — "v0.8 özellikleri" bölümüne "Transfer Resume" maddesi ekle.
+- `CHANGELOG.md` — v0.8.0 entry.
+- `docs/protocol/resume.md` — **bu RFC ile aynı PR'da** merge olacak wire spec.
+- `docs/security/threat-model.md` — §3 assets'e `~/.hekadrop/partial/`
+  eklenir; §TB-5 satırlarına resume notu.
+- `docs/architecture.md` — PayloadAssembler diagramı güncel.
+
+## 11. Efor kırılımı
+
+| # | İş | Süre |
+|---|----|-----:|
+| 1 | `proto/v2/resume.proto` tanım + build.rs entegrasyon | 2 s |
+| 2 | `session_id_i64` helper + test | 1 s |
+| 3 | `.meta` JSON struct + serde + read/write + atomic rename | 4 s |
+| 4 | Partial dir creation + perms (Unix chmod, Windows ACL) | 3 s |
+| 5 | `PayloadAssembler` meta yazma (her 16 chunk + finalize) | 4 s |
+| 6 | Receiver: Introduction sonrası `.meta` lookup + `ResumeHint` send | 3 s |
+| 7 | Sender: `ResumeHint` parse + hash verify + seek + `send_file_chunks(start_offset)` | 5 s |
+| 8 | `ResumeReject` frame + mismatch cleanup | 2 s |
+| 9 | Capabilities bit koordinasyonu (RFC-0003 ile) | 1 s |
+| 10 | Cleanup sweep + budget LRU | 4 s |
+| 11 | OS scheduler template'leri (systemd/launchd/Windows Task) | 3 s |
+| 12 | Integration testleri (5 adet) | 6 s |
+| 13 | Unit testleri (5 adet) | 3 s |
+| 14 | Fuzz harness iskeleti | 2 s |
+| 15 | Dokümantasyon (README + CHANGELOG + protocol/resume.md peer-review) | 3 s |
+| | **Toplam** | **~46 saat (≈ 1 hafta)** |
+
+## 12. Açık sorular
+
+1. **Cleanup tetikleyici önceliği:** Startup-only yeterli mi (tray uzun
+   çalışır), yoksa OS scheduler şart mı? Önerim: **her ikisi**, çünkü
+   kullanıcı başlatmayı unutursa scheduler bekçi görevi görür.
+2. **Disk budget default:** 5 GiB uygun mu? Mobil laptoplarda 256 GB SSD
+   düşünüldüğünde %2. Alternatif: disk free'ye göre dinamik (`min(5 GiB,
+   free * 0.05)`).
+3. **Chunk checkpoint aralığı:** 16 chunk (8 MiB) iyi trade-off mı? NVMe'de
+   32 chunk bile asenkron fsync ile maliyetsiz. Bench ile karar.
+4. **Trust gating (`resume_require_trusted`):** Default false haklı mı?
+   Güvenlik-paranoid kullanıcılar için UI toggle.
+5. **Resume UI affordance:** Kullanıcı "bu %92 partial var, devam et/sıfırla"
+   seçebilsin mi, yoksa otomatik resume tercih edilsin mi? Önerim: otomatik
+   (sessiz) + Settings > Diagnostics'te partial list görünür + manual delete.
+6. **Capabilities frame ownership:** RFC-0003'te mi, burada mı tanımlanacak?
+   Koordinasyon gerekir.
+7. **Klasör payload'ları:** RFC-0005 folder streaming için resume nasıl
+   çalışır? Per-file mi (her dosya bağımsız partial), yoksa folder manifest
+   seviyesinde mi? Önerim: **per-file**. RFC-0005 paralel yazılırken bu
+   notu reviewer'a geçir.
+
+## 13. Referanslar
+
+- `docs/ROADMAP.md` v0.8.0 §"Transfer resume" (satır 122-124), erişim 2026-04-24.
+- `docs/rfcs/0003-chunk-hmac.md` (paralel, henüz merge edilmemiş).
+- `docs/rfcs/0005-folder-payload.md` (paralel).
+- `docs/security/threat-model.md` TB-3, TB-5.
+- LocalSend resume protocol: https://github.com/localsend/localsend/blob/main/documentation/protocol-v2.md (erişim 2026-04-24).
+- rquickshare partial handling: https://github.com/Martichou/rquickshare (erişim 2026-04-24).
+- IETF RFC 7233 (HTTP Range) — karşılaştırma için, bizim modelin alternatifi, erişim 2026-04-24.
+- NIST FIPS 180-4 (SHA-256).
+- `src/sender.rs::send_file_chunks` (mevcut implementation), `src/payload.rs::PayloadAssembler` (GC + partial handling).

--- a/docs/rfcs/0005-folder-payload.md
+++ b/docs/rfcs/0005-folder-payload.md
@@ -1,0 +1,473 @@
+# RFC 0005 — Folder Payload
+
+- **Başlatan:** @maintainers
+- **Durum:** Draft
+- **Oluşturulma tarihi:** 2026-04-24
+- **Hedef sürüm:** v0.8.0
+- **İlgili issue:** —
+- **İlgili RFC'ler:** 0003 (chunk-HMAC, capabilities frame), 0004 (transfer resume)
+
+---
+
+## 1. Özet
+
+HekaDrop bugün klasörü drag-drop eden kullanıcıya *flat* bir çoklu-dosya gönderim
+deneyimi veriyor: `src/sender.rs` recursive walk yapıyor, her dosya için ayrı
+`FileMetadata` üretiyor, tek bir `Introduction` içinde N metadata birden
+yolluyor. Alıcı tarafta bu N dosya `~/Downloads/` içine *flat* düşer; dizin
+yapısı, ortak klasör adı, aralarındaki bütünlük ilişkisi kaybolur. Bu RFC, Quick
+Share wire format'ını kırmadan klasör semantiğini taşıyan bir **FolderPayload**
+tipi önerir: receiver'ın gözünde tek bir `FILE` payload — ancak MIME marker'ı
+`application/x-hekadrop-folder` — içinde tar-benzeri *custom binary* bir bundle
+(`HEKABUND` magic + length-prefixed JSON manifest + concatenated file data)
+taşınır. Her iç dosya için ayrı SHA-256, manifest bütünlüğü için bundle-level
+SHA-256, hot path için RFC-0003 chunk-HMAC stacking ile entegre. Receiver
+`~/Downloads/.hekadrop-temp-<session>/` altına stream eder ve bitince atomic
+rename ile görünür hâle getirir. Eski peer'lara fallback: flatten + multiple
+FILE (bugünkü davranış), capabilities frame'deki `folder_v1` biti ile müzakere
+edilir.
+
+## 2. Motivasyon
+
+**Senaryo 1 — Aile fotoları:** "Geçen yaz tatilinden 50 fotoyu telefonuna at"
+diyorsunuz. Bugün alıcıda 50 ayrı bildirim + 50 dosya `Downloads` içinde dağılıyor;
+ortak `tatil-2025/` klasörü kayboluyor. NearDrop'un [issue
+#211](https://github.com/grishka/NearDrop/issues/211) iki yıldan uzun süredir
+açık; rquickshare ve LocalSend de klasör semantiğini *folder path* alanıyla
+işaretlemiyor (LocalSend ayrı request per file yapar). Çözümü 0. günden
+kendimize yazarsak v0.8 cutoff'unu kaçırmayız.
+
+**Senaryo 2 — Web dev → telefon:** Developer `~/projects/landing-page/` klasörünü
+telefondaki tarayıcıda açılacak şekilde göndermek istiyor. Klasör yapısı
+(`index.html`, `assets/css/…`, `assets/img/…`) korunmazsa göreli linkler kırılır.
+
+**Senaryo 3 — İç içe klasör derinliği:** `~/Documents/vergi-2025/Q1/…`,
+`Q2/…`. 3+ seviye iç içe yapılar bugün flat gelirse isim çakışmaları ve
+manuel yeniden organize etme maliyeti doğar.
+
+**Mevcut kod yetersizliği:** `src/sender.rs:905-935` `build_introduction_multi`
+planları `FileMetadata` array'i olarak paketler. `FileMetadata.parent_folder`
+alanı proto'da (`proto/wire_format.proto:63`) mevcut ama receiver'da yoksayılır
+— ayrıca path traversal vektörü olduğu için güvenle kullanılabilmesi için per-
+segment sanitize gerekir. Yani "parent_folder'ı canlandır" seçeneği bile bu
+RFC'nin yaptığının küçük bir altkümesi (bundle integrity, atomic rename,
+symlink policy vb. yine bizim işimiz).
+
+## 3. Ayrıntılı tasarım
+
+### 3.1 Wire seviyesi — mevcut Quick Share format'ı korunur
+
+Klasör, receiver'a `IntroductionFrame` içinde **tek** `FileMetadata` olarak
+görünür:
+
+```
+FileMetadata {
+  name:         "tatil-2025.hekabundle",   // iç formatın ismi
+  type:         UNKNOWN,
+  payload_id:   <i64>,
+  size:         <bundle toplam byte sayısı>,
+  mime_type:    "application/x-hekadrop-folder",
+  id:           <i64 attachment id>,
+  parent_folder: "",
+  // --- HekaDrop uzantısı (aşağı bakın) ---
+  attachment_hash: <manifest SHA-256 ilk 8 byte i64 olarak>,
+}
+```
+
+MIME marker `application/x-hekadrop-folder` **ayırt edici**: peer `folder_v1`
+capability reklam ettiyse bu MIME'ı bundle olarak açar; etmediyse dosyayı ham
+olarak kaydeder — ama zaten `folder_v1` yoksa sender fallback'e geçer (§3.6).
+`attachment_hash` alanı proto'da 64-bit opak; biz bundle manifest SHA-256'sının
+ilk 8 byte'ını network-endian big-endian int64 olarak yerleştiririz. Bu,
+introduction-time integrity pre-commit sağlar: peer manifest'i receive edince
+karşılaştırır, eşleşmezse bundle reddedilir (§3.5).
+
+### 3.2 İç format — `HEKABUND` v1
+
+Bundle, receiver `PayloadAssembler` (bkz. `src/payload.rs:113+`) tarafından
+`FileSink` aracılığıyla diske yazılır; yazım bittikten sonra sync olarak
+deserialize edilir (stream-parse değil; MVP'de basitlik > latency). Layout,
+offset 0'dan itibaren:
+
+```
+offset  size       alan                         açıklama
+------  ---------  ---------------------------  --------------------------------
+0       8          magic                        ASCII "HEKABUND"
+8       4          version (u32 BE)             0x0000_0001
+12      4          manifest_len (u32 BE)        N byte, JSON UTF-8 uzunluğu
+16      N          manifest_json                serialize edilmiş manifest
+16+N    M          concat_file_data             manifest sırasıyla append
+16+N+M  32         bundle_sha256                magic..concat_file_data üzerinde
+                                                hesaplanmış SHA-256 (trailer)
+```
+
+Trailer SHA-256 `bundle_sha256` **manifest + dosya datası + magic + version**
+bütününü kapsar. Manifest tampering veya data swap tespit edilir.
+`manifest_len` maksimum `8 MiB` — 10k dosya × ~600 byte kayıt rahatça sığar;
+bu üstüne çıkarsa reddedilir (DoS limiti).
+
+**Manifest JSON schema (v1):**
+
+```jsonc
+{
+  "version": 1,
+  "root_name": "tatil-2025",          // receiver klasör adı (sanitize edilir)
+  "created_utc": "2026-04-24T12:34:56Z",
+  "entries": [
+    {
+      "type": "file",
+      "path": "IMG_0001.jpg",          // root-relative, POSIX separator
+      "size": 3145728,
+      "sha256": "<hex 64>",
+      "mode": 420,                     // opsiyonel, POSIX mode (decimal)
+      "mtime_utc": "2025-07-15T14:02:11Z"  // opsiyonel
+    },
+    {
+      "type": "directory",
+      "path": "albums/istanbul"
+    },
+    // symlink girişi YOK (§3.4)
+  ]
+}
+```
+
+Parser strict: unknown **top-level** field ignore; unknown **entry** field
+ignore; bilinmeyen `type` degeri → tüm bundle reject. `path` alanı ASCII
+`/` separator; Windows'ta `\` içerir gelirse reject. `path` her segment için
+`sanitize_received_name` muadilinden geçirilir (§3.5).
+
+### 3.3 Maksimum sınırlar
+
+| Sınır | Değer | Gerekçe |
+|---|---|---|
+| `manifest_len` | 8 MiB | 10k dosya × ~600 byte + slack |
+| Dosya sayısı / bundle | 10 000 | DoS (open-file deskriptör, inode basınç); tipik tatil-klasörü <1000 |
+| Per-file size | `i64::MAX` | `FileMetadata.size` ile aynı clamp (mevcut `file_size_guard`) |
+| Toplam bundle size | `i64::MAX` (1 TiB praktik) | `PayloadTransferFrame.total_size` |
+| Dizin derinliği | 32 | `..`/symlink saldırılarına karşı ek tabula |
+| Path segment uzunluğu | 200 byte (mevcut sanitizer sınırı) | `connection.rs:1056` ile tutarlı |
+
+10k seçimi: LocalSend'in pratik limiti yok ama CI testlerinde >5k dosyada OS
+limit'i (macOS `ulimit -n` default 256–2048) sürekli patlıyor; 10k bize 3–4×
+headroom verir.
+
+### 3.4 Symlink ve özel dosya davranışı
+
+**Sender tarafı:**
+
+- `std::fs::symlink_metadata` ile entry tipi tespit edilir (resolve etmeden).
+- Symlink → **skip**, `warn!` log'a basılır (`src/log_redact::path_basename`
+  ile redact), kullanıcı UI'a toplu özet: "3 symlink atlandı."
+- Regular file → bundle'a dahil.
+- Directory → recurse + `type: "directory"` entry (boş klasörler dahil).
+- Pipe, socket, block/char device → skip + warn.
+
+**Receiver tarafı:**
+
+- Manifest'te `type: "symlink"` **yok** (sender yazmaz). Gelirse → bundle reject.
+- Her `path` her segmentte `sanitize_received_name` uygulanır; `..`, absolute
+  path, Windows reserved, NUL/control karakterler reject.
+- Dosya yazmadan önce parent directory `create_dir_all` + `symlink_metadata`
+  kontrol: parent symlink ise bundle reject (TOCTOU guard, `payload.rs:349-360`
+  paterninin klasör genellemesi).
+
+Alternatif (reddedildi): Relative symlink'i target-içinde kalıyorsa takip et →
+MVP'nin 5× karmaşıklığı; v0.9+ ayrı RFC.
+
+### 3.5 Path sanitization katmanı
+
+`src/connection.rs:1006-1065` `sanitize_received_name` *basename-only*
+çalışıyor. Folder payload'ı için **per-segment** bir wrapper ekleyeceğiz
+(aynı dosyaya, isim: `sanitize_received_relative_path`):
+
+```
+fn sanitize_received_relative_path(raw: &str) -> Result<Vec<String>, PathErr>
+```
+
+Davranış:
+
+1. `raw.split('/').map(sanitize_received_name)` — her segment ayrı ayrı
+   mevcut kurallardan geçer.
+2. Segment `"."` → skip. Segment `".."` → `PathErr::Traversal` (reject; mevcut
+   `sanitize_received_name` bunu `"dosya"`a çevirir, klasörde bu yetmez
+   çünkü sessizce yer değiştirir).
+3. Segment listesi boş → `PathErr::Empty`.
+4. Derinlik >32 → `PathErr::TooDeep`.
+
+Bundle-level integrity: manifest SHA-256 `attachment_hash` ile introduction'a
+commit edildiğinden, alıcı manifest'i parse etmeden önce bundle_sha256 trailer
+doğrular; trailer geçerse manifest de güvenilir kabul edilir. Per-file SHA-256
+yine de dosya yazımı sırasında streaming olarak hesaplanır; uyuşmazsa **o
+dosya** quarantine'a alınır, bundle'ın gerisi kabul edilir ama UI uyarır —
+partial success düşmez çünkü aile tatil klasörünün 49/50'si doğru geldiyse
+silmek kullanıcıya zarar verir.
+
+### 3.6 Atomic rename ve receive state machine
+
+Receiver flow (`src/connection.rs` dispatch + `src/payload.rs` assembler):
+
+1. Introduction'da `application/x-hekadrop-folder` MIME + `folder_v1`
+   capability → `PayloadAssembler::register_file_destination` ile
+   `~/Downloads/.hekadrop-temp-<session_id>.bundle` dosyası rezerve edilir
+   (`unique_downloads_path` ile; mevcut `OpenOptions::create_new(true)`
+   guard'ı aynen geçerli).
+2. Payload bitince trailer SHA-256 doğrulanır. Uyuşmazsa temp silinir, UI error.
+3. `manifest_json` parse. `root_name` sanitize edilir → `safe_root`.
+4. `~/Downloads/.hekadrop-temp-<session_id>/` oluşturulur (`create_new` klasör;
+   Unix'te `mkdir` EEXIST race ile idempotent değildir, burada session-id
+   unique olduğu için problem yok).
+5. Manifest entries sırayla extract:
+   - `type: "directory"` → `create_dir_all` (sanitize path).
+   - `type: "file"` → path açılır (`create_new` flag), parent symlink kontrol
+     sonra bundle'dan `size` byte kopyalanır; streaming SHA-256 hesaplanır;
+     yanlışsa dosya silinir, bundle iptal.
+6. Başarılı ekstraksiyon → `unique_downloads_path(&safe_root)` ile hedef
+   isim seçilir (çakışmada `tatil-2025 (2)`), temp `rename` ile hedefe taşınır.
+   `rename` cross-device EXDEV olursa fallback: recursive copy + delete.
+7. Bundle dosyası (`.bundle`) silinir.
+
+Kısmi başarısızlık (bazı dosya SHA mismatch):
+
+- Hatalı dosyalar `<temp>/_failed/` altına ismi korunarak taşınır.
+- Rename yine yapılır; kullanıcı "47/50 dosya doğrulandı, 3 dosya `_failed/`
+  altında" bildirimi görür.
+
+### 3.7 Capabilities müzakeresi (RFC-0003 entegrasyonu)
+
+RFC-0003 `PairedKeyEncryption` sonrası eklenecek `CapabilitiesFrame` içinde
+bitfield'a yeni bit:
+
+```
+bit 0: chunk_hmac_v1     (RFC-0003)
+bit 1: resume_v1         (RFC-0004)
+bit 2: folder_v1         (bu RFC)
+bit 3+: reserved
+```
+
+Sender `folder_v1` peer'da set değilse:
+- Fallback path: bundle oluşturma. `build_introduction_multi` ile flat gönderim
+  (bugünkü kod). Log: `warn!("[sender] peer folder_v1 desteklemiyor, flat gönderim")`.
+- Kullanıcıya UI'da discrete bir uyarı: "Bu alıcıda klasör yapısı korunmayacak."
+
+### 3.8 Chunk-HMAC stacking (RFC-0003 entegrasyonu)
+
+RFC-0003 chunk-HMAC bundle'ın **wire level** chunk'larına uygulanır — yani
+`PayloadTransferFrame` içindeki bytes'a. Bundle'ın *iç* SHA-256 kontrolü
+(per-file + trailer) bundan bağımsız: chunk-HMAC koparılmış wire'ı tespit
+eder; iç SHA-256 sender disk'ten bundle oluştururken corruption'a veya
+kötü niyetli sender'a karşı korur. Double-check maliyeti ~%1 (chunk-HMAC
+zaten olacak; iç SHA-256 sender'da dosya okuma sırasında 0-cost, receiver'da
+stream-compute).
+
+### 3.9 Resume (RFC-0004 entegrasyonu)
+
+RFC-0004 resume, file-granularity önerir: bundle içinde yarım kalmış dosya
+bir sonraki resume'da **baştan** değil, kaldığı yerden. Bunun için bundle iç
+yapısı manifest sırasını garanti eder — receiver `partial/<session_id>/`
+altında hem `.bundle` temp'ini hem de `progress.json` tutar:
+
+```json
+{ "entries_completed": 23, "current_entry_offset": 1048576 }
+```
+
+Resume gelince sender `ResumeHint { payload_id, offset: 16+N+<file_offset> }`
+ile byte-level devam eder. Manifest seek pozisyonu anlık olarak bilindiği için
+bu doğrudan haritalanır. TTL 7 gün — roadmap'teki kural aynı.
+
+### 3.10 UX
+
+**Sender:**
+- Drag-drop folder → tray menüde iki seçenek: *Send as folder (default)*
+  veya *Send as individual files*. Tercih per-session, "remember" yok (MVP).
+- CLI yok (v0.8 tray app).
+
+**Receiver:**
+- Accept dialog yeni metin: "`{peer}` cihazından `{root_name}` klasörü — N
+  dosya, X MB. Kabul edilsin mi?" — mevcut `ui.rs` dialog'unun bir varyantı.
+- Progress: toplam byte + "dosya 23/50" her dosya tamamlanınca güncellenir.
+- Completion notification'ında "Klasörü Aç" aksiyonu → platform `reveal`
+  (macOS Finder `open -R`, Windows `explorer /select,`, Linux best-effort
+  `xdg-open` parent).
+
+## 4. Alternatifler
+
+**A. Flat rename convention (`name = "tatil/photo1.jpg"`)** — FileMetadata
+`name` field'ına `/` koyup receiver'da parse. Reddedildi: (1) `sanitize_received_name`
+zaten `/` filtreliyor (`connection.rs:1023`), bypass için kod değişikliği
+gerek; (2) Windows `\` ile tutarsızlık; (3) atomic rename yok, partial delivery
+yarım klasör bırakır; (4) manifest bütünlüğü yok — tek dosya corrupt olursa
+diğerleri zehirlenmiş kabul edilir mi belirsiz.
+
+**B. Standart tar (`tar` crate)** — Reddedildi: `tar` crate 180+ KB bağımlılık
+ekler (`hekadrop-core` minimalizm ilkesi, RFC dependency-policy). Sparse files,
+GNU/POSIX tar header farkları, UStar vs PAX uzantıları — maintenance kuyruğu.
+Kontrolü bize dışarı çıkarır. Özel binary format 200 satır Rust; tar parser
+3k satır.
+
+**C. ZIP** — Sıkıştırma opsiyonel gelse bile deflate-bomb vektörü ve entry-level
+encryption karmaşası MVP dışı. Sıkıştırma ayrı RFC (v0.9+).
+
+**D. Her dosya için ayrı payload + grouping metadata field** — `parent_folder`
+alanı (`wire_format.proto:63`). Reddedildi: introduction'da N metadata göndermek
+zorunda, atomic rename'e introduction-level semantik gerekir, receiver "klasör
+tamamlandı mı?" sorusunu her dosyanın SHA-256'sı üzerinden mark-off map tutarak
+cevaplar — karmaşıklık bundle'dan az değil, üstelik partial-introduction
+(sender yarıda düşerse) recovery belirsiz.
+
+**E. Bundle'ı sender diskte oluştur, sonra normal FILE payload gibi yolla**
+(reddedildi *bu RFC'de değil*, ama tasarım kararı belirginleştirmek için):
+biz bundle'ı **bellekte streaming** oluşturuyoruz (`src/sender.rs::send_file_chunks`
+paterni genişletilir). Disk'e tar yaz → diski 2× şişirir, 50 GB klasörde
+kullanıcı diski dolar. Streaming daha iyi.
+
+## 5. Geriye uyumluluk ve migration
+
+- Eski peer (`folder_v1` yok) → sender fallback flatten. Alıcı hiçbir kod
+  değişikliği görmez; bugünkü davranışın aynısı.
+- Quick Share Android / Chrome ile interop: Android zaten folder desteklemez;
+  sender `folder_v1` yokluğunu peer signature'ından (endpoint_id prefix'i)
+  değil capabilities frame'inden anlayacak — yani Android peer her durumda
+  flatten alır. Introduction formatı Quick Share uyumlu kalır.
+- Mevcut testler (`src/sender.rs` integration) folder path'ini test etmiyor;
+  yeni testler ekleyeceğiz, eski testler etkilenmez.
+- Feature flag: `HEKADROP_FOLDER_V1=0` env ile kapatılabilir (debug amaçlı).
+  Production default: açık.
+
+## 6. Güvenlik değerlendirmesi
+
+| Vektör | Mitigation |
+|---|---|
+| Path traversal (`../etc/passwd`) | Per-segment `sanitize_received_relative_path`, `..` → reject |
+| Absolute path (`/etc/passwd`) | Manifest `path` leading `/` → reject parse |
+| Symlink race (parent temp) | Write-time `symlink_metadata` parent check |
+| Zip-slip equivalent | Bundle iç path'leri root-relative olarak kilitlenir, `create_new` open flag |
+| Manifest injection | Strict JSON, unknown entry-type reject, manifest_len ≤ 8 MiB |
+| Resource exhaustion (çok dosya) | 10 000 entry cap, >8 MiB manifest reject |
+| Resource exhaustion (derinlik) | Depth 32 cap |
+| Partial bundle poisoning | Trailer bundle SHA-256; uyuşmazsa temp silinir |
+| Per-file corruption (malicious sender) | Entry SHA-256 mismatch → `_failed/` klasörü, kullanıcıya net uyarı |
+| Disk doldurma (sender kötü niyetli) | Receiver disk quota check v0.8.1'e ertelendi — açık soru |
+| TOCTOU rename | `rename` atomic aynı FS üzerinde; cross-device fallback copy-delete sırasında hedef `create_dir_all` + `create_new` guard |
+
+Threat model dokümanı `docs/security/threat-model.md` §7.1 (Path Traversal) ve
+§7.3 (Symlink Race) bölümleri bu RFC sonrası güncellenecek: per-segment
+sanitize çağrısı STRIDE tablosuna eklenir, bundle-level depth limit not düşer.
+
+Yeni crypto primitive **yok** — SHA-256 ve AES-GCM mevcut stack (`src/secure.rs`)
+üzerinden geliyor; audit yüzeyi sabit.
+
+## 7. Performans değerlendirmesi
+
+| Metrik | Etki | Not |
+|---|---|---|
+| Manifest overhead | ~600 byte/dosya × 10k = 6 MB worst case | 10k dosya senaryosunda %0.01 overhead (TB-scale) |
+| Sender CPU | Per-file SHA-256 | Zaten yapılıyor; bundle yapımı ek ~5 ns/byte append |
+| Receiver CPU | Bundle trailer SHA-256 + per-file SHA-256 | Stream-compute, disk I/O'ya paralel; bottleneck I/O |
+| Bellek | Bundle stream, manifest ≤ 8 MiB yüklenir | Konstant; dosya verisi diske direkt akar |
+| Latency (küçük klasör) | Bundle wrap ~5-10 ms | Introduction'dan önce manifest hash hesaplanır |
+| Disk (sender) | Ek disk **yok** — streaming | Kritik fark: tar crate disk'e yazar, biz yazmayız |
+| Throughput | Chunk-HMAC ile birlikte ~%5 overhead | RFC-0003'ten |
+
+Hot path: receiver `ingest_file` chunk yazımı. Bundle için değişiklik: trailer
+buffer'ı son 32 byte'ı holdback et, rest'i disk'e yaz; payload tam gelince
+trailer'ı doğrula. Net ek: 0.
+
+## 8. Test planı
+
+**Unit:**
+- `sanitize_received_relative_path`: traversal, absolute, unicode, reserved,
+  depth limit, empty segment edge case'leri.
+- Manifest serde: round-trip, unknown field, malformed JSON, oversized,
+  bilinmeyen entry type reject.
+- Bundle trailer: doğru hash geçer, 1-bit flip yakalanır.
+
+**Integration:**
+- 100 dosyalı klasör roundtrip; SHA karşılaştırmaları.
+- İç içe 5 seviye klasör, tüm yapı korunur.
+- Boş klasör: manifest'te directory entry var, receiver yaratır.
+- 1 dev dosya (5 GiB) — streaming limit testi.
+- Aynı ad çakışması: `~/Downloads/foo/` zaten varsa `foo (2)/` alınır.
+
+**Edge:**
+- Symlink dolu klasör sender atlar, manifest'te görünmez.
+- Windows path separator `\` — sender POSIX'e normalize eder.
+- Unicode emoji/RTL dosya adları.
+- Manifest tampering (trailer yeniden hesapla, data swap) → trailer yakalar.
+
+**Attack fuzz:**
+- `fuzz/` altına `fuzz_bundle_parser.rs` hedefi: manifest + bundle layout
+  fuzzing. Traversal/injection vektörleri oss-fuzz'a eklenir (roadmap §198).
+
+**Interop:**
+- Android Quick Share ile test: `folder_v1` yok → flatten fallback'in
+  beklendiği gibi çalıştığı doğrulanır.
+
+## 9. Dokümantasyon etkisi
+
+- `README.md` özellik listesi: "klasör gönderimi (dizin yapısını korur)".
+- `docs/ROADMAP.md` v0.8.0 bölümü: folder streaming checkmark.
+- `docs/security/threat-model.md` §7.1 ve §7.3: bundle path-sanitize ve
+  derinlik limiti notu.
+- `CHANGELOG.md`: "Added: folder payload (RFC-0005)".
+- `docs/rfcs/README.md` RFC index tablosuna satır.
+
+## 10. Efor kırılımı
+
+| Adım | Tahmini efor | Dosyalar |
+|---|---|---|
+| `sanitize_received_relative_path` + testler | 3 saat | `src/connection.rs`, test bloğu |
+| Bundle serializer (sender stream) | 6 saat | `src/sender.rs` (yeni `bundle.rs` submodule) |
+| Bundle deserializer + extract state machine | 8 saat | `src/payload.rs` genişletme |
+| Capabilities frame `folder_v1` hook | 2 saat | RFC-0003 PR'ıyla sync, 1 satır bit |
+| Fallback flatten path glue | 2 saat | `src/sender.rs` dispatcher |
+| UI accept dialog varyantı | 3 saat | `src/ui.rs`, i18n key'leri (tr/en) |
+| Progress entegrasyonu | 3 saat | `src/progress.rs` (varsayılan) |
+| Atomic rename + temp cleanup | 3 saat | `src/payload.rs` + platform-specific EXDEV |
+| Integration testler | 6 saat | yeni `tests/folder_payload.rs` |
+| Fuzz target | 2 saat | `fuzz/` |
+| Dokümantasyon güncellemeleri | 2 saat | README, threat-model, CHANGELOG |
+
+**Toplam:** ~40 saat (≈1 hafta dedicated). v0.8.0 2026-07-31 hedefiyle tutarlı.
+
+## 11. Açık sorular
+
+1. **POSIX mode korunsun mu?** Windows→Unix yönünde default `0644`/`0755`,
+   Unix→Windows yönünde mode yok sayılır. Unix→Unix'te manifest'ten oku. MVP
+   öneri: **yaz ama yok sayılabilir** — `mode` manifest alanı opsiyonel,
+   receiver platformu uygulayamıyorsa ignore. Karar verilecek: mode alanı
+   zorunlu mu yoksa opsiyonel mi?
+
+2. **mtime korunsun mu?** UX için faydalı (fotograflar chronological kalır)
+   ama implementation maliyeti düşük. Öneri: **yaz ve uygula**; platformda
+   desteklenmezse ignore.
+
+3. **Symlink policy kesin skip mi yoksa reject-whole-folder opsiyonu mu?**
+   Öneri: **skip + toplu UI uyarısı**. Alternatif: UI prompt ("N symlink bulundu,
+   atlansın mı?") — v0.8.1'e ertelenir.
+
+4. **Max dosya sayısı 10k çok mu, az mı?** Vergi arşivi kullanıcılarından
+   geri bildirim gelene dek 10k. `HEKADROP_MAX_BUNDLE_ENTRIES` env override'ı
+   opt-in güç kullanıcılar için.
+
+5. **Disk quota check:** receiver diski doldurmaktan nasıl korunur? Bundle
+   size introduction'da belli; `std::fs::available_space` (Linux/macOS `statvfs`,
+   Windows `GetDiskFreeSpaceEx`) ile pre-check. MVP dışı, v0.8.1.
+
+6. **Kısmi başarı (bazı dosya SHA mismatch) partial-accept mi, atomic-reject mi?**
+   §3.6 *partial-accept + `_failed/`* öneriyor. Audit'de güvenlik takımı
+   "zehirli dosya receiver'da kalır" itirazı gelebilir. Alternatif: `.hekadrop-quarantine/`
+   altına taşı, kullanıcı eksplicit açmak ister.
+
+## 12. Referanslar
+
+- `docs/rfcs/0000-template.md` — şablon.
+- `docs/rfcs/0003-chunk-hmac.md` (parallel draft) — capabilities frame kaynağı.
+- `docs/rfcs/0004-transfer-resume.md` (parallel draft) — resume entegrasyonu.
+- `docs/ROADMAP.md:116,125` — v0.8.0 folder streaming gereksinimi.
+- `docs/security/threat-model.md` §7.1, §7.3 — path traversal ve symlink race.
+- `src/payload.rs:113-470` — `PayloadAssembler` + `FileSink`.
+- `src/connection.rs:922-1065` — `unique_downloads_path`, `sanitize_received_name`.
+- `src/sender.rs:905-935` — `build_introduction_multi` fallback reference.
+- `proto/wire_format.proto:30-71` — `FileMetadata`.
+- NearDrop issue #211 — <https://github.com/grishka/NearDrop/issues/211> (erişim 2026-04-24).
+- LocalSend protokol spesifikasyonu v2 — <https://github.com/localsend/protocol> (erişim 2026-04-24).

--- a/docs/rfcs/0005-folder-payload.md
+++ b/docs/rfcs/0005-folder-payload.md
@@ -197,10 +197,11 @@ Davranış:
 Bundle-level integrity: manifest SHA-256 `attachment_hash` ile introduction'a
 commit edildiğinden, alıcı manifest'i parse etmeden önce bundle_sha256 trailer
 doğrular; trailer geçerse manifest de güvenilir kabul edilir. Per-file SHA-256
-yine de dosya yazımı sırasında streaming olarak hesaplanır; uyuşmazsa **o
-dosya** quarantine'a alınır, bundle'ın gerisi kabul edilir ama UI uyarır —
-partial success düşmez çünkü aile tatil klasörünün 49/50'si doğru geldiyse
-silmek kullanıcıya zarar verir.
+yine de dosya yazımı sırasında streaming olarak hesaplanır; **herhangi bir
+dosyanın SHA-256 mismatch'i → tüm bundle reject** (atomic-reject politikası;
+§3.6 state machine'i buna göre tanımlıdır). "49/50 doğru" gibi kısmi kabul
+senaryosu desteklenmez; kullanıcıya yanlış güven vermemek + receiver state
+machine'i basit tutmak için bu karar verildi.
 
 ### 3.6 Atomic rename ve receive state machine
 
@@ -216,35 +217,46 @@ Receiver flow (`src/connection.rs` dispatch + `src/payload.rs` assembler):
 4. `~/Downloads/.hekadrop-temp-<session_id>/` oluşturulur (`create_new` klasör;
    Unix'te `mkdir` EEXIST race ile idempotent değildir, burada session-id
    unique olduğu için problem yok).
-5. Manifest entries sırayla extract:
+5. Manifest entries sırayla extract (stream; in-place into
+   `.hekadrop-temp-<session_id>/`):
    - `type: "directory"` → `create_dir_all` (sanitize path).
    - `type: "file"` → path açılır (`create_new` flag), parent symlink kontrol
-     sonra bundle'dan `size` byte kopyalanır; streaming SHA-256 hesaplanır;
-     yanlışsa dosya silinir, bundle iptal.
-6. Başarılı ekstraksiyon → `unique_downloads_path(&safe_root)` ile hedef
-   isim seçilir (çakışmada `tatil-2025 (2)`), temp `rename` ile hedefe taşınır.
-   `rename` cross-device EXDEV olursa fallback: recursive copy + delete.
+     sonra bundle'dan `size` byte kopyalanır; streaming SHA-256 hesaplanır.
+     **Herhangi bir dosyada mismatch → atomic reject:** `.hekadrop-temp-<session_id>/`
+     dizini ve `.bundle` dosyası tamamen silinir, receiver UI "bundle reddedildi:
+     dosya `<path>` integrity kontrolünü geçemedi" hatası gösterir, `stats.json`'a
+     abort kaydedilir. **Kısmi kabul yok**; "49/50 doğru" senaryosunda bile tüm
+     bundle atılır.
+6. Tüm entry'ler başarılı extract edildiyse → `unique_downloads_path(&safe_root)`
+   ile hedef isim seçilir (çakışmada `tatil-2025 (2)`), temp dizini `rename`
+   ile hedefe taşınır. `rename` cross-device EXDEV olursa fallback: recursive
+   copy + delete.
 7. Bundle dosyası (`.bundle`) silinir.
 
-Kısmi başarısızlık (bazı dosya SHA mismatch):
-
-- Hatalı dosyalar `<temp>/_failed/` altına ismi korunarak taşınır.
-- Rename yine yapılır; kullanıcı "47/50 dosya doğrulandı, 3 dosya `_failed/`
-  altında" bildirimi görür.
+**Atomic-reject gerekçesi:** (a) receiver state machine basit kalır — tek
+"commit" noktası, partial cleanup yolları yok; (b) kullanıcıya yanlış güven
+verme riski yok (kısmi kabul "klasörün tamamı geldi" illüzyonu yaratır);
+(c) corrupted sender veya MITM senaryosunda "eksik dosya var mı?" sorusunu
+kullanıcıya yıkmaktan kaçınır; (d) resume (§3.9) bundle'ı yeniden denemeye
+olanak tanıyacağından kullanıcı için pratikte maliyet sınırlı.
 
 ### 3.7 Capabilities müzakeresi (RFC-0003 entegrasyonu)
 
-RFC-0003 `PairedKeyEncryption` sonrası eklenecek `CapabilitiesFrame` içinde
-bitfield'a yeni bit:
+Kanonik `Capabilities` mesajı RFC-0003 §3.2'de tanımlı; bu RFC yalnız kendi
+bit'ini talep eder. Feature bitleri (üç RFC ortak sabit tablosu):
 
 ```
-bit 0: chunk_hmac_v1     (RFC-0003)
-bit 1: resume_v1         (RFC-0004)
-bit 2: folder_v1         (bu RFC)
-bit 3+: reserved
+CHUNK_HMAC_V1    = 0x0001   (RFC-0003, bit 0)
+RESUME_V1        = 0x0002   (RFC-0004, bit 1)
+FOLDER_STREAM_V1 = 0x0004   (bu RFC,   bit 2)
+0x0008..0x8000   — reserved for v0.8–v1.0
 ```
 
-Sender `folder_v1` peer'da set değilse:
+Ayrıca `FolderManifest` mesajı (in-bundle manifest JSON'unu wire'da
+reprezente eder; bkz. §3.2) `HekaDropFrame.folder_mft = 14` slot'unu
+kullanır. Quick Share upstream `V1Frame.FrameType` enum'una dokunulmaz.
+
+Sender `FOLDER_STREAM_V1` peer'da set değilse:
 - Fallback path: bundle oluşturma. `build_introduction_multi` ile flat gönderim
   (bugünkü kod). Log: `warn!("[sender] peer folder_v1 desteklemiyor, flat gönderim")`.
 - Kullanıcıya UI'da discrete bir uyarı: "Bu alıcıda klasör yapısı korunmayacak."
@@ -345,7 +357,7 @@ kullanıcı diski dolar. Streaming daha iyi.
 | Resource exhaustion (çok dosya) | 10 000 entry cap, >8 MiB manifest reject |
 | Resource exhaustion (derinlik) | Depth 32 cap |
 | Partial bundle poisoning | Trailer bundle SHA-256; uyuşmazsa temp silinir |
-| Per-file corruption (malicious sender) | Entry SHA-256 mismatch → `_failed/` klasörü, kullanıcıya net uyarı |
+| Per-file corruption (malicious sender) | Entry SHA-256 mismatch → **atomic reject**: `.hekadrop-temp-<session>/` komple silinir, hiçbir dosya `~/Downloads/`'a taşınmaz, UI net hata |
 | Disk doldurma (sender kötü niyetli) | Receiver disk quota check v0.8.1'e ertelendi — açık soru |
 | TOCTOU rename | `rename` atomic aynı FS üzerinde; cross-device fallback copy-delete sırasında hedef `create_dir_all` + `create_new` guard |
 
@@ -453,10 +465,12 @@ trailer'ı doğrula. Net ek: 0.
    size introduction'da belli; `std::fs::available_space` (Linux/macOS `statvfs`,
    Windows `GetDiskFreeSpaceEx`) ile pre-check. MVP dışı, v0.8.1.
 
-6. **Kısmi başarı (bazı dosya SHA mismatch) partial-accept mi, atomic-reject mi?**
-   §3.6 *partial-accept + `_failed/`* öneriyor. Audit'de güvenlik takımı
-   "zehirli dosya receiver'da kalır" itirazı gelebilir. Alternatif: `.hekadrop-quarantine/`
-   altına taşı, kullanıcı eksplicit açmak ister.
+6. ~~**Kısmi başarı (bazı dosya SHA mismatch) partial-accept mi, atomic-reject mi?**~~
+   **Kapandı: atomic-reject seçildi.** §3.6 tek politika olarak atomic-reject
+   tanımlar — bir dosyada SHA mismatch olursa tüm bundle atılır, temp dizini
+   silinir. Gerekçeler §3.6'da; "zehirli dosya receiver'da kalır" riski
+   ortadan kalkar, state machine basitleşir. Resume (§3.9) bundle'ı yeniden
+   denemeye olanak tanıdığı için kullanıcı maliyeti sınırlı.
 
 ## 12. Referanslar
 

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -132,7 +132,10 @@ Bu dizin otomatik güncellenmez. Yeni RFC eklendiğinde aşağıya ekleyin.
 | # | Başlık | Durum | Sürüm |
 |---|---|---|---|
 | 0001 | Workspace refactor | Draft | v0.7.0 |
-| 0002 | URL payload decision | Draft | v0.7.0 |
+| 0002 | URL payload decision | Accepted (implemented in bb2cedf + 393c74c) | v0.7.0 |
+| 0003 | Chunk-level HMAC-SHA256 | Draft | v0.8.0 |
+| 0004 | Transfer resume | Draft | v0.8.0 |
+| 0005 | Folder payload (HEKABUND) | Draft | v0.8.0 |
 
 ---
 


### PR DESCRIPTION
## Özet

v0.8.0 "Protokol Sağlamlaştırma" milestone'unun tasarım paketi. Üç büyük protokol özelliği
(chunk-level HMAC, transfer resume, folder streaming) için RFC'ler + wire-level spec + ortak
capabilities negotiation mimarisi. **Sadece doküman — kod değişikliği yok.** Implementation
her RFC için ayrı PR'da iner (v0.8 roadmap'i gereği).

> #82 (v0.7 foundation) merge edildi; bu PR artık doğrudan `main`'i base alıyor. Önceki
> stacked PR #83 GitHub tarafından otomatik kapatıldı (base branch silindi); içerik
> buraya rebase edildi.

## Tür

- [x] Dokümantasyon — 3 RFC + 1 wire-level spec

## Değişiklikler

| Dosya | Satır | Ne |
|---|---|---|
| `docs/rfcs/0003-chunk-hmac.md` | 334 | Per-chunk HMAC-SHA256 + `HekaDropFrame` magic + `CapabilitiesFrame` tasarımı |
| `docs/rfcs/0004-transfer-resume.md` | 468 | ResumeHint + partial/ dizini + 7 gün TTL + chunk-HMAC entegrasyonu |
| `docs/rfcs/0005-folder-payload.md` | 473 | HEKABUND binary format + 10k cap + symlink skip |
| `docs/protocol/resume.md` | 318 | Wire-level spec (3rd-party implementer'lar için) |
| `docs/protocol/README.md` | 60 | Protokol doküman indeksi (yeni dizin) |
| `docs/rfcs/README.md` | +3 | RFC index tablosu güncellendi |

**Toplam:** +1659 satır, tek commit.

## Koordinasyon

Üç RFC **birbirini tanıyarak** yazıldı:

- **`CapabilitiesFrame`** (RFC-0003 tanımlıyor) — capability_bits bitmask: bit 0
  `CHUNK_HMAC_SHA256`, bit 1 `RESUME_V1`, bit 2 `FOLDER_STREAM_V1`.
- **`HekaDropFrame` magic `0xA5DEB201`** — Quick Share `OfflineFrame`'den ayrılıyor;
  `payload` oneof slots 5..15 rezerve (0004 `ResumeHint`, 0005 `FolderManifest` için).
- **Session identity:** UKEY2 `auth_key` fingerprint (tek türetme, iki RFC paylaşıyor).
- **Partial chunk integrity:** 0004 resume fast-path'i 0003 chunk-HMAC tag'lerini reuse eder.

**Upstream Quick Share proto'suna dokunulmuyor** — tüm eklentiler capabilities-gated +
magic-prefix dispatcher ile ayrılıyor. Samsung/Pixel/NearDrop/rquickshare peer'ları
görmezden gelir, fallback legacy akış.

## Review'ında Çözülecek Uyuşmazlıklar

1. **Capabilities frame field naming:**
   - RFC-0003 önerisi: `CapabilitiesFrame { capability_bits: uint64 }`
   - RFC-0004 önerisi: `Capabilities { version: uint32, features: uint64 }`
   - **Öneri:** `version + features` imzası kabul edilsin (version alanı forward-compat).
2. **`V1Frame.FrameType` enum slot çakışması:**
   - 0003 `ChunkIntegrity` ve 0004 `ResumeHint` ikisi de slot 7 veya 8'e aday.
   - Implementation PR'ı frame numaralarını kilitleyecek (RFC'lerde hardcode yok).
3. **Mevcut `src/payload.rs:474` GC:**
   - `remove_partial_file` resume'u öldürüyor — v0.8 implementation fazında finalize-only
     cleanup'a çevrilmeli (RFC-0004 §3.1'de belirtildi).

## Test

- [x] Sadece doküman — `cargo test` etkisi yok
- [x] RFC'ler `docs/rfcs/README.md` index'inden erişilebilir
- [x] `docs/protocol/resume.md` wire-level alan boyutları protobuf tanımıyla hizalı
- [x] `cargo build --lib` başarılı (rebase sonrası doğrulama)
- [ ] Implementation PR'larında regression testleri inecek (v0.8.0 milestone'u)

## İlgili

- Follows #82 (v0.7 foundation, merged)
- Supersedes #83 (closed, base silindi)
- Starts v0.8.0 milestone (hedef 2026-07-31 per `docs/ROADMAP.md`)

## Notlar

**Breaking change yok** — upstream wire format korunuyor, tüm eklentiler opt-in
capabilities-gated.

**RFC-0001 (workspace refactor) implementation bu PR'da değil.** v0.7 merge edildiğine
göre artık o ayrı branch (`feature/v0.7-workspace-step-N`) başlatılabilir — 8 kademeli PR.

**CHANGELOG güncelleme yok** — implementation PR'ları inerken CHANGELOG [Unreleased]
bölümü v0.8 için genişletilecek.

🤖 Generated with [Claude Code](https://claude.com/claude-code)