### PR TITLE
refactor(workspace): Adım 6+7+8 — net + cli stub + kapanış (RFC-0001 §5 finale)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
+### Added — Workspace Refactor (RFC-0001 §5, Adım 1-8 tamamlandı)
+- **5 üyeli Cargo workspace**: `hekadrop-proto` (leaf, prost wire types) →
+  `hekadrop-core` (protocol engine: crypto, frame, UKEY2, secure, payload,
+  state, connection, sender, server, identity, stats, settings, error,
+  log_redact, file_size_guard, config, discovery_types, ui_port) →
+  `hekadrop-net` (mDNS keşif + advertise) → `hekadrop-cli` (v0.10.0 stub) →
+  `hekadrop-app` (binary + UI/tao+wry/tray-icon + platform shims + i18n).
+- **`UiPort` trait + `UiNotification` channel** (Adım 5b): `hekadrop-core`
+  artık UI bağımsız; eski `crate::ui::*` çağrıları async trait üzerinden
+  geçiyor. `ui_adapter` (app) trait'i implement eder.
+- **`AppState` plain struct** (Adım 5a): `OnceLock<AppState>` singleton
+  app'te kaldı, gerçek tipler core'da; `Arc<AppState>` parametre olarak gezer.
+- **`hekadrop-cli` binary stub**: `cargo run --bin hekadrop-cli` "coming in
+  v0.10.0" basar. Workspace topology + build sırası doğrulayan ileri-bağlantı.
+- **Strict workspace lint policy** (PR #87): `[workspace.lints]` enforce —
+  `unwrap_used`, `expect_used`, `panic`, `dbg_macro`, `cast_possible_truncation`,
+  `undocumented_unsafe_blocks`, `redundant_clone` vb. 23 lint warn/deny.
+  Mevcut codebase 0 violation; yeni kod CI ile bloklanır.
+- **CLAUDE.md kuruluş prensipleri** + pre-commit kontrol listesi (PR #91 sonrası).
+
+### Added — v0.7 öncesi
 - **24 aylık yol haritası**: `docs/ROADMAP.md`, `docs/MILESTONES.md` — v1.0.0 hedef
   2028-04-24. Paket yöneticisi (Homebrew Cask, Winget, Scoop, Flathub, Snap, AUR,
   Nixpkgs) yayınları v1.0.0'a ertelendi; süre boyunca GitHub Releases beta kanal.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1508,6 +1508,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "hekadrop-cli"
+version = "0.7.0"
+dependencies = [
+ "hekadrop-core",
+ "hekadrop-net",
+]
+
+[[package]]
 name = "hekadrop-core"
 version = "0.7.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1482,12 +1482,11 @@ dependencies = [
  "criterion",
  "elliptic-curve",
  "hekadrop-core",
+ "hekadrop-net",
  "hekadrop-proto",
  "hex",
  "hkdf",
  "hmac",
- "if-addrs",
- "mdns-sd",
  "notify-rust",
  "p256",
  "parking_lot",
@@ -1537,6 +1536,19 @@ dependencies = [
  "tokio-util",
  "tracing",
  "windows",
+]
+
+[[package]]
+name = "hekadrop-net"
+version = "0.7.0"
+dependencies = [
+ "anyhow",
+ "base64",
+ "hekadrop-core",
+ "if-addrs",
+ "mdns-sd",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["crates/hekadrop-app", "crates/hekadrop-core", "crates/hekadrop-net", "crates/hekadrop-proto"]
+members = ["crates/hekadrop-app", "crates/hekadrop-cli", "crates/hekadrop-core", "crates/hekadrop-net", "crates/hekadrop-proto"]
 
 [workspace.package]
 version = "0.7.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["crates/hekadrop-app", "crates/hekadrop-core", "crates/hekadrop-proto"]
+members = ["crates/hekadrop-app", "crates/hekadrop-core", "crates/hekadrop-net", "crates/hekadrop-proto"]
 
 [workspace.package]
 version = "0.7.0"

--- a/crates/hekadrop-app/Cargo.toml
+++ b/crates/hekadrop-app/Cargo.toml
@@ -19,6 +19,7 @@ categories = ["network-programming", "command-line-utilities"]
 # RFC-0001 §5 Adım 2: hekadrop-proto. Adım 3: hekadrop-core (kripto, frame,
 # UKEY2, secure, error, log_redact, file_size_guard, config taşındı).
 hekadrop-core = { path = "../hekadrop-core", version = "=0.7.0" }
+hekadrop-net = { path = "../hekadrop-net", version = "=0.7.0" }
 hekadrop-proto = { path = "../hekadrop-proto", version = "=0.7.0" }
 
 # RFC-0001 §5 Adım 5b — `ui_adapter::UiAdapter` core'un `UiPort` trait'ini
@@ -30,12 +31,12 @@ async-trait = "0.1"
 # Cargo feature unification ile hepsi tek build.
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "io-util", "sync", "signal", "time", "fs"] }
 tokio-util = { version = "0.7", features = ["rt"] }
-mdns-sd = "0.19"
+# RFC-0001 §5 Adım 6: mdns-sd + if-addrs hekadrop-net crate'ine taşındı —
+# app artık mDNS adapter'larına yalnız re-export ile erişir.
 hex = "0.4"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing-appender = "0.2"
-if-addrs = "0.15"
 tray-icon = "0.22"
 tao = "0.35"
 wry = "0.55"

--- a/crates/hekadrop-app/src/lib.rs
+++ b/crates/hekadrop-app/src/lib.rs
@@ -34,14 +34,22 @@
     )
 )]
 
-// RFC-0001 §5 Adım 3 — `hekadrop-core` shim'i.
+// RFC-0001 §5 — workspace refactor implementation tamamlandı (Adım 1-8):
+//   1. Cargo workspace iskele (#85)
+//   2. hekadrop-proto crate (#86)
+//   3. hekadrop-core pure-crypto core iskele (#89)
+//   4. identity/stats/settings/payload core'a (#90)
+//   5a. AppState plain struct (#91)
+//   5b. UiPort trait + UiNotification (#92)
+//   5c. state/connection/sender/server core'a (#93)
+//   6. hekadrop-net crate (mdns/discovery adapter) (bu PR)
+//   7. hekadrop-cli stub (bu PR)
+//   8. lib.rs shim'in kalıcı dokümantasyonu (bu blok)
 //
-// 8 leaf modül (`crypto`, `secure`, `frame`, `ukey2`, `error`,
-// `file_size_guard`, `log_redact`, `config`) artık `hekadrop-core` crate'inde.
-// `crate::crypto::xxx`, `use crate::secure::SecureCtx` gibi yüzlerce
-// in-tree çağrı noktası bu re-export'lar sayesinde dokunulmadan derlenir.
-// `tests/*.rs` ve `benches/*.rs` ise `hekadrop::crypto::xxx` formuyla bu
-// shim üzerinden core'a ulaşır.
+// Bu re-export'lar `tests/*.rs`, `benches/*.rs` ve fuzz harness'larının
+// `hekadrop::xxx` formuyla core sembollerine erişebilmesi için kalır
+// (binary `src/main.rs` direkt `hekadrop_core::xxx` kullanır; lib bağımsız
+// derlenir). Yeni core sembolü eklendiğinde tek mecburi update buradadır.
 pub use hekadrop_core::{
     config, connection, crypto, discovery_types, error, file_size_guard, frame, identity,
     log_redact, payload, secure, sender, server, settings, stats, ui_port, ukey2,

--- a/crates/hekadrop-app/src/main.rs
+++ b/crates/hekadrop-app/src/main.rs
@@ -71,9 +71,11 @@ fn device_kind_label(kind: DeviceKind) -> &'static str {
     }
 }
 
-mod discovery;
+// RFC-0001 §5 Adım 6: discovery + mdns hekadrop-net crate'inde. Mevcut
+// `crate::discovery::*` ve `crate::mdns::*` çağrıları re-export shim ile
+// dokunulmadan derlenir.
+use hekadrop_net::{discovery, mdns};
 mod i18n;
-mod mdns;
 mod paths;
 mod platform;
 mod state;

--- a/crates/hekadrop-app/src/main.rs
+++ b/crates/hekadrop-app/src/main.rs
@@ -71,9 +71,11 @@ fn device_kind_label(kind: DeviceKind) -> &'static str {
     }
 }
 
-// RFC-0001 §5 Adım 6: discovery + mdns hekadrop-net crate'inde. Mevcut
-// `crate::discovery::*` ve `crate::mdns::*` çağrıları re-export shim ile
-// dokunulmadan derlenir.
+// RFC-0001 §5 Adım 6: discovery + mdns hekadrop-net crate'inde. Bu `use`
+// crate root'ta yalnız crate-içi alias oluşturur (in-tree
+// `crate::discovery::*` ve `crate::mdns::*` çağrıları dokunulmadan derlenir).
+// Dış tüketiciler için re-export değildir; öyle bir surface gerekirse
+// `pub use` ile lib.rs'e ayrıca eklenmelidir. (Copilot PR #100 review.)
 use hekadrop_net::{discovery, mdns};
 mod i18n;
 mod paths;

--- a/crates/hekadrop-cli/Cargo.toml
+++ b/crates/hekadrop-cli/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "hekadrop-cli"
+description = "HekaDrop CLI — headless send/receive entry point (v0.10.0+ icin stub)"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+publish = false
+
+# RFC-0001 §5 Adım 7: bu crate v0.7'de yalnız stub'tur. ROADMAP §Q1 v0.10.0
+# `hekadrop-cli`'in send/receive/list-peers/trust/doctor komutlarıyla
+# şişeceğini öngörür; o zaman bu Cargo.toml'a clap + IPC + per-command
+# subcrate'ler eklenir. Şimdilik path-dep'leri ileri-bağlantı kontrolü
+# (workspace çevriminde core+net erişilebilir, build doğru sıralanır)
+# için tutuyoruz.
+
+[[bin]]
+name = "hekadrop-cli"
+path = "src/main.rs"
+
+[dependencies]
+hekadrop-core = { path = "../hekadrop-core", version = "=0.7.0" }
+hekadrop-net = { path = "../hekadrop-net", version = "=0.7.0" }
+
+[lints]
+workspace = true
+
+# v0.10.0'da CLI komutları core+net'e dokunduğunda kaldırılır.
+[package.metadata.cargo-machete]
+ignored = ["hekadrop-core", "hekadrop-net"]

--- a/crates/hekadrop-cli/src/main.rs
+++ b/crates/hekadrop-cli/src/main.rs
@@ -1,0 +1,25 @@
+//! HekaDrop CLI — v0.7'de yalnız stub. v0.10.0'da `send`, `receive`,
+//! `daemon`, `list-peers`, `trust`, `doctor`, `version`, `gui` komutları
+//! ile şişecek (ROADMAP §Q1 v0.10.0).
+//!
+//! Şu an bu binary "coming soon" yazıp çıkar — workspace topology'sinin
+//! core+net'e erişilebilirliğini doğrulamanın yanı sıra v0.10'a kadar
+//! release pipeline'ında hayalet artifact üretmesi engellenir
+//! (`publish = false`, `[[bin]] hekadrop-cli`).
+//!
+//! RFC-0001 §5 Adım 7 (PR #G).
+
+// hekadrop-core + hekadrop-net path-dep olarak çekilse de v0.7 stub'ında
+// hiçbir sembol kullanılmıyor — `cargo machete` false-pozitif önlenmiş
+// (ignore listesi `Cargo.toml`'da). v0.10.0'da kaldırılacak.
+#![allow(unused_imports)]
+
+// CLI binary stdout output legitimate use case; workspace-wide
+// `clippy::print_stdout = "warn"` (PR #87 Tier 1) UI/library kodu için
+// konuldu. v0.10.0'da clap subcommand layer + structured output (--json
+// flag) gelince bu allow kaldırılır.
+#[allow(clippy::print_stdout)]
+fn main() {
+    println!("HekaDrop CLI v0 — coming in v0.10.0");
+    println!("Şimdilik GUI tarafını kullanın: `hekadrop` (workspace binary).");
+}

--- a/crates/hekadrop-net/Cargo.toml
+++ b/crates/hekadrop-net/Cargo.toml
@@ -18,8 +18,10 @@ publish = false
 # Workspace internal — domain tipleri ve config (Adım 4'te core'a taşındı).
 hekadrop-core = { path = "../hekadrop-core", version = "=0.7.0" }
 
-# Async runtime — discovery loop ve task spawn için.
-tokio = { version = "1", features = ["rt", "sync", "time", "net"] }
+# Async runtime — yalnız `tokio::task::spawn_blocking` (discovery.rs:39)
+# kullanılıyor; başka tokio API'sı yok. `rt` feature spawn için yeterli.
+# (Gemini PR #100 review: minimal feature set.)
+tokio = { version = "1", features = ["rt"] }
 
 # mDNS — sadece bu crate kullanır (RFC §5 Adım 6 ile core'dan kaldırıldı).
 mdns-sd = "0.19"
@@ -33,7 +35,7 @@ base64 = "0.22"
 # Logging.
 tracing = "0.1"
 
-# Hata + serde (config tipleri serde derive ile gelir).
+# Hata yönetimi.
 anyhow = "1"
 
 [lints]

--- a/crates/hekadrop-net/Cargo.toml
+++ b/crates/hekadrop-net/Cargo.toml
@@ -1,0 +1,40 @@
+[package]
+name = "hekadrop-net"
+description = "HekaDrop network adapter — mDNS discovery + peer browse"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+publish = false
+
+# RFC-0001 §5 Adım 6: discovery.rs + mdns.rs core'dan ayrı, network bağımlı
+# adapter'lar buraya. Domain tipleri (`DiscoveredDevice` vb.) core'un
+# `discovery_types` modülünde kalır — net → core kenarı tek yönlü.
+
+[dependencies]
+# Workspace internal — domain tipleri ve config (Adım 4'te core'a taşındı).
+hekadrop-core = { path = "../hekadrop-core", version = "=0.7.0" }
+
+# Async runtime — discovery loop ve task spawn için.
+tokio = { version = "1", features = ["rt", "sync", "time", "net"] }
+
+# mDNS — sadece bu crate kullanır (RFC §5 Adım 6 ile core'dan kaldırıldı).
+mdns-sd = "0.19"
+
+# Local IP enumeration (mDNS interface seçimi için).
+if-addrs = "0.15"
+
+# Base64 — Quick Share endpoint_info encoding (mDNS TXT record'larında).
+base64 = "0.22"
+
+# Logging.
+tracing = "0.1"
+
+# Hata + serde (config tipleri serde derive ile gelir).
+anyhow = "1"
+
+[lints]
+workspace = true

--- a/crates/hekadrop-net/src/discovery.rs
+++ b/crates/hekadrop-net/src/discovery.rs
@@ -4,10 +4,10 @@
 //! "Herkes" (Everyone) ayarlı olması gerekir. Aksi halde BLE discovery şart —
 //! bu modül yalnız mDNS/WLAN üzerinden çalışır (BLE ileri bir iterasyonda).
 
-use crate::config;
 use anyhow::Result;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use base64::Engine;
+use hekadrop_core::config;
 use mdns_sd::{ResolvedService, ServiceDaemon, ServiceEvent};
 use std::net::IpAddr;
 use std::time::Duration;

--- a/crates/hekadrop-net/src/lib.rs
+++ b/crates/hekadrop-net/src/lib.rs
@@ -1,0 +1,12 @@
+//! HekaDrop network adapter — mDNS discovery + peer browse.
+//!
+//! Bu crate, Quick Share'in keşif katmanı için tek noktadır. Domain tipleri
+//! (`DiscoveredDevice` vb.) `hekadrop-core::discovery_types` içindedir; bu
+//! crate yalnızca network I/O yapan adapter'ları barındırır. Bağımlılık
+//! ağacında kenar yönü tek başınadır: `hekadrop-net → hekadrop-core`.
+//!
+//! RFC-0001 §5 Adım 6 ile çıkarıldı; `mdns-sd` bağımlılığı core'dan buraya
+//! taşınarak core'un dependency footprint'i küçültüldü.
+
+pub mod discovery;
+pub mod mdns;

--- a/crates/hekadrop-net/src/mdns.rs
+++ b/crates/hekadrop-net/src/mdns.rs
@@ -1,5 +1,5 @@
-use crate::config;
 use anyhow::Result;
+use hekadrop_core::config;
 use mdns_sd::{ServiceDaemon, ServiceInfo};
 use std::net::IpAddr;
 use tracing::{info, warn};


### PR DESCRIPTION
## Özet

RFC-0001 workspace refactor implementation **finale** — Adım 6, 7 ve 8 birleşik tek PR.
Workspace 5 üyeli son haline geldi: `hekadrop-proto` → `hekadrop-core` →
`hekadrop-net` → `hekadrop-cli` → `hekadrop-app`.

> Sekans tamamlandı: #85 (Step 1) → #86 (Step 2) → #89 (Step 3) → #90 (Step 4) →
> #91 (Step 5a) → #92 (Step 5b) → #93 (Step 5c) → **bu PR (Step 6+7+8)**.

## Tür

- [x] Refactor / temizlik (davranış değişmedi)
- [x] Dokümantasyon (CHANGELOG + lib.rs notu)

## Adım 6 — `hekadrop-net`

`mDNS keşif + advertise` adapter'ları ayrı crate'e taşındı; `mdns-sd` + `if-addrs` core'dan kaldırıldı.

- `crates/hekadrop-net/{Cargo.toml, src/lib.rs}` yeni
- `discovery.rs` (113 LOC) + `mdns.rs` (92 LOC) git mv (içerik dokunulmadı, tek değişim `use crate::config` → `use hekadrop_core::config`)
- `app/Cargo.toml`: `hekadrop-net = { path = ..., version = "=0.7.0" }`; `mdns-sd` + `if-addrs` çıkarıldı
- `app/src/main.rs`: `mod discovery; mod mdns;` → `use hekadrop_net::{discovery, mdns};`

## Adım 7 — `hekadrop-cli` stub

`cargo run --bin hekadrop-cli` "coming in v0.10.0" basar — workspace topology + build sırası doğrulayan ileri-bağlantı.

- `crates/hekadrop-cli/{Cargo.toml, src/main.rs}` yeni
- `[[bin]] hekadrop-cli` + `hekadrop-core`/`hekadrop-net` path-dep (=0.7.0)
- Item-scoped `#[allow(clippy::print_stdout)]` + gerekçeli yorum (CLI binary için legitimate; v0.10.0'da clap structured output gelince kaldırılır)
- `cargo machete` 0 unused (path-dep ignore listesi `[package.metadata.cargo-machete]`)

## Adım 8 — Kapanış

- `app/src/lib.rs` shim yorum güncellemesi — 8 adımlık zincir tek yerde özet, lib'in neden kalıcı kalacağı belgeli (tests + benches + fuzz `hekadrop::xxx` consumer'ı)
- `CHANGELOG.md` `[Unreleased]` workspace refactor entry'si — 5 üyeli topology, UiPort trait, AppState plain struct, strict lint policy, CLAUDE.md hep tek listede

**Not:** RFC §5 Adım 8 "lib.rs silinir" maddesi pratikte uygulanmadı — silmek 17 integration test + benchmark + fuzz harness'i kırardı. RFC orijinal niyeti "dual-include borcu kapansın"dı; o Adım 2'de kapandı (#86).

## Workspace bağımlılık ağacı (final)

```
hekadrop-proto    leaf — prost wire types
   ↑
hekadrop-core    config + discovery_types + crypto + frame + ukey2 + secure +
                   payload + identity + settings + stats + state + connection +
                   sender + server + error + log_redact + file_size_guard +
                   ui_port (UI bağı channel arkasında)
   ↑                ↑
hekadrop-net    │    discovery + mdns adapter'ları
   ↑            │
hekadrop-cli    │    stub (v0.10.0'da clap + IPC ile şişer)
   ↑            ↑
hekadrop-app    binary + UI/tao+wry+tray-icon + platform shims +
                   i18n + paths + state singleton (OnceLock<AppState>)
```

Tek yön kenarları; circular yok. `hekadrop-core` artık `cargo publish --dry-run` hazır (semver v0.1.0 commitment v0.7.0 release tag'i ile aktif).

## Test

- [x] `cargo build --workspace` — yeşil (5 crate)
- [x] `cargo test --workspace` — 164 main + 11 lib + integration'lar pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — temiz
- [x] `cargo fmt --check` — temiz
- [x] `cargo doc -p hekadrop-net` + `-p hekadrop-cli` — HTML üretildi
- [x] `cargo machete` — 0 unused dep
- [x] `cargo run --bin hekadrop-cli` — stub çalışıyor

## Sıradaki

- **v0.7.0 release tag** ayrı PR'da (paket yöneticisi submission yok — v1.0.0'a ertelendi)
- **v0.8.0 implementation**: chunk-HMAC (RFC-0003), transfer resume (RFC-0004), folder payload (RFC-0005) — RFC paketi hazır (#84 merged)
- **Tier 2 lint sweep**: `cast_possible_wrap` (36 hit, security), `must_use_candidate` (71 hit), `unreachable_pub` (349 hit) — atomik PR'lar

🤖 Generated with [Claude Code](https://claude.com/claude-code)