### PR TITLE
chore(lint): cast_possible_wrap security audit — 15 hit fix + lint enforce

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ expect_used = "warn"
 panic = "warn"
 # Numerik güvenlik — silent truncation/overflow tespiti
 cast_possible_truncation = "warn"
+cast_possible_wrap = "warn"     # cast_wrap audit PR'ı sonrası enforce — 15 hit fix'lendi
 cast_sign_loss = "warn"
 cast_precision_loss = "warn"
 cast_lossless = "warn"

--- a/crates/hekadrop-app/src/lib.rs
+++ b/crates/hekadrop-app/src/lib.rs
@@ -23,6 +23,7 @@
         clippy::print_stderr,
         clippy::redundant_clone,
         clippy::cast_possible_truncation,
+        clippy::cast_possible_wrap,
         clippy::cast_sign_loss,
         clippy::cast_lossless,
         clippy::cast_precision_loss,

--- a/crates/hekadrop-app/src/main.rs
+++ b/crates/hekadrop-app/src/main.rs
@@ -11,6 +11,7 @@
         clippy::print_stderr,
         clippy::redundant_clone,
         clippy::cast_possible_truncation,
+        clippy::cast_possible_wrap,
         clippy::cast_sign_loss,
         clippy::cast_lossless,
         clippy::cast_precision_loss,
@@ -1082,13 +1083,18 @@ fn push_stats_to_ui() {
         i18n::t("time.none").to_string()
     };
 
+    // SAFETY-CAST: stat counter `b: u64`. `human_size` legacy `i64` alıyor
+    // (3 yerde duplicate fn — DRY temizliği ayrı PR). u64 → i64 büyük
+    // değerlerde wrap eder; saturating: 8 EiB üstü "ulaşılamaz" zaten,
+    // i64::MAX "—" göstergesinden iyi UI sinyali.
+    let to_i64_sat = |b: u64| -> i64 { i64::try_from(b).unwrap_or(i64::MAX) };
     let top_rx = s
         .top_rx_device()
-        .map(|(n, b)| format!("{} ({})", n, human_size(b as i64)))
+        .map(|(n, b)| format!("{} ({})", n, human_size(to_i64_sat(b))))
         .unwrap_or_else(|| "—".to_string());
     let top_tx = s
         .top_tx_device()
-        .map(|(n, b)| format!("{} ({})", n, human_size(b as i64)))
+        .map(|(n, b)| format!("{} ({})", n, human_size(to_i64_sat(b))))
         .unwrap_or_else(|| "—".to_string());
 
     let payload = serde_json::json!({
@@ -1098,8 +1104,8 @@ fn push_stats_to_ui() {
         "port": state::listen_port(),
         "log_dir": platform::logs_dir().to_string_lossy(),
         "config_path": paths::config_path().to_string_lossy(),
-        "bytes_received": human_size(s.bytes_received as i64),
-        "bytes_sent": human_size(s.bytes_sent as i64),
+        "bytes_received": human_size(to_i64_sat(s.bytes_received)),
+        "bytes_sent": human_size(to_i64_sat(s.bytes_sent)),
         "files_received": s.files_received,
         "files_sent": s.files_sent,
         "first_use": first_use_human,

--- a/crates/hekadrop-app/src/platform.rs
+++ b/crates/hekadrop-app/src/platform.rs
@@ -545,8 +545,11 @@ pub(crate) mod win {
             // windows-rs `HRESULT` → `ok()` S_OK/S_FALSE'ı tamam sayar,
             // gerçek hataları `Err` olarak geri verir. RPC_E_CHANGED_MODE da
             // kabul: COM zaten farklı modda init — bizim için OK.
+            // SAFETY-CAST: HRESULT bit pattern kasıtlı u32 → i32 reinterpretation
+            // (high-bit error encoding). `cast_signed()` Rust 1.85+ stable
+            // (MSRV 1.90 ≥ kullanılabilir); `as i32` yerine lint-clean alternatif.
             const RPC_E_CHANGED_MODE: windows::core::HRESULT =
-                windows::core::HRESULT(0x80010106u32 as i32);
+                windows::core::HRESULT(0x80010106u32.cast_signed());
             if hr.is_ok() || hr == RPC_E_CHANGED_MODE {
                 flag.set(true);
             } else {

--- a/crates/hekadrop-app/tests/common/mod.rs
+++ b/crates/hekadrop-app/tests/common/mod.rs
@@ -12,7 +12,10 @@
 //! açabilir. `#[allow(dead_code)]` her yardımcıyı bireysel olarak bu beklenen
 //! durumdan muaf tutar.
 
-#![allow(dead_code)]
+// Test-only allow set — production lint'leri test idiom'unu engellemesin.
+// `cast_possible_wrap` PIN hash helper'ı (`b as i8`) için kasıtlı, NearDrop
+// algoritma uyumu (bkz. `hekadrop_core::crypto::pin_code_from_auth_key`).
+#![allow(dead_code, clippy::cast_possible_wrap)]
 
 use hmac::{Hmac, Mac};
 use sha2::Sha256;

--- a/crates/hekadrop-app/tests/payload_corrupt.rs
+++ b/crates/hekadrop-app/tests/payload_corrupt.rs
@@ -11,6 +11,7 @@
     clippy::missing_panics_doc,
     clippy::redundant_clone,
     clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap,
     clippy::cast_sign_loss,
     clippy::cast_lossless,
     clippy::cast_precision_loss,

--- a/crates/hekadrop-core/src/connection.rs
+++ b/crates/hekadrop-core/src/connection.rs
@@ -1249,8 +1249,12 @@ pub(crate) async fn send_sharing_frame(
     sharing: &SharingFrame,
 ) -> Result<()> {
     let body = sharing.encode_to_vec();
+    // SAFETY-CAST: u64 >> 1 her zaman 0..=i64::MAX aralığında — high bit
+    // shift ile sıfırlanıyor, wrap yok.
+    #[allow(clippy::cast_possible_wrap)]
     let payload_id: i64 = (rand::thread_rng().next_u64() >> 1) as i64;
-    let total = body.len() as i64;
+    let total = i64::try_from(body.len())
+        .with_context(|| format!("sharing frame body i64'a sığmıyor: {} bayt", body.len()))?;
 
     // İlk chunk: tam gövde, offset=0, flags=0.
     // `body` bu satırdan sonra kullanılmıyor → clone yerine move (alokasyon

--- a/crates/hekadrop-core/src/crypto.rs
+++ b/crates/hekadrop-core/src/crypto.rs
@@ -44,6 +44,11 @@ pub fn pin_code_from_auth_key(key: &[u8]) -> String {
     let mut mult: i64 = 1;
     const MOD: i64 = 9973;
     for &b in key {
+        // SAFETY-CAST: NearDrop algoritması birebir uyumu için u8 → i8
+        // signed reinterpretation (0..=255 → -128..=127) kasıtlı.
+        // Quick Share PIN deterministik olmalı — bu cast'i değiştirmek
+        // wire incompat eder.
+        #[allow(clippy::cast_possible_wrap)]
         let signed = i64::from(b as i8);
         hash = (hash + signed * mult).rem_euclid(MOD);
         mult = (mult * 31).rem_euclid(MOD);

--- a/crates/hekadrop-core/src/payload.rs
+++ b/crates/hekadrop-core/src/payload.rs
@@ -387,7 +387,13 @@ impl PayloadAssembler {
                 .ok_or_else(|| anyhow!("file_sink kayıp: id={}", id))?;
             // SECURITY: Cumulative overrun koruması — saldırgan `total_size=10`
             // deklare edip gigabaytlarca chunk yollayarak disk doldurabilir.
-            let body_len = body.len() as i64;
+            // usize → i64: pratikte body 4 MiB ile sınırlı (CHUNK_SIZE),
+            // i64::MAX'e ulaşmak imkânsız ama saldırgan-controlled length
+            // değerini try_from ile defensive sınırlıyoruz. Orijinal
+            // `TryFromIntError` mesaja eklenir.
+            let body_len = i64::try_from(body.len()).map_err(|e| {
+                HekaError::PayloadIo(format!("chunk body i64'a sığmıyor (id={id}): {e}"))
+            })?;
             let new_written = sink
                 .written
                 .checked_add(body_len)
@@ -484,6 +490,7 @@ fn remove_partial_file(path: &std::path::Path) {
 }
 
 #[cfg(test)]
+#[allow(clippy::cast_possible_wrap)]
 mod tests {
     use super::*;
     use hekadrop_proto::location::nearby::connections::payload_transfer_frame::{

--- a/crates/hekadrop-core/src/sender.rs
+++ b/crates/hekadrop-core/src/sender.rs
@@ -111,11 +111,18 @@ pub async fn send(req: SendRequest, state: Arc<AppState>) -> Result<()> {
             }
             .into());
         }
+        // SAFETY-CAST: `raw_size > i64::MAX as u64` üstünde checked oldu
+        // (yukarıdaki `if raw_size > i64::MAX as u64`). u64 >> 1 high-bit
+        // sıfır → her zaman 0..=i64::MAX. İki cast da wrap yapamaz.
+        #[allow(clippy::cast_possible_wrap)]
+        let size_i64 = raw_size as i64;
+        #[allow(clippy::cast_possible_wrap)]
+        let payload_id_i64 = (rand::thread_rng().next_u64() >> 1) as i64;
         plans.push(PlannedFile {
             path: path.clone(),
             name,
-            size: raw_size as i64,
-            payload_id: (rand::thread_rng().next_u64() >> 1) as i64,
+            size: size_i64,
+            payload_id: payload_id_i64,
         });
     }
     // Multi-file toplamda i64 overflow olmaması için checked_add kullan.
@@ -464,6 +471,8 @@ pub async fn send_text(
     // `TryFromIntError`'ı zincirde korur (ZST ama nedeni belgeler).
     let total_bytes: i64 = i64::try_from(text.len())
         .with_context(|| format!("metin payload çok büyük: {} bayt", text.len()))?;
+    // SAFETY-CAST: u64 >> 1 high-bit sıfır → daima 0..=i64::MAX.
+    #[allow(clippy::cast_possible_wrap)]
     let payload_id = (rand::thread_rng().next_u64() >> 1) as i64;
     // URL şeklinde ise TextKind::Url ile etiketliyoruz: Android/alıcı share
     // sheet'te URL'i "Tarayıcıda aç" aksiyonuyla gösterir. Aksi hâlde düz TEXT.
@@ -855,7 +864,12 @@ async fn send_file_chunks(
         let wrapped = wrap_payload_transfer(payload_id, file_size, offset, 0, body);
         let enc = ctx.encrypt(&wrapped.encode_to_vec())?;
         frame::write_frame(socket, &enc).await?;
-        offset += n as i64;
+        // SAFETY-CAST: `n` AsyncReadExt::read'den geliyor, max CHUNK_SIZE
+        // (4 KiB) ile sınırlı; usize → i64 wrap pratik olarak imkânsız.
+        // Defensive: try_from + unwrap_or yerine allow + comment yeterli.
+        #[allow(clippy::cast_possible_wrap)]
+        let n_i64 = n as i64;
+        offset += n_i64;
 
         // İlerleme yüzdesi: kümülatif (tüm dosyalar toplu).
         // total_bytes == 0 entry point'te bail ediliyor (Bug #30); yine de


### PR DESCRIPTION
## Özet

\`Cargo.toml [workspace.lints]\` yorumunda RED-tier olarak işaretli \`cast_possible_wrap (36, security)\` audit'i tamamlandı. Gerçek hit sayısı **15** (memory'deki 36 üst sınır; test-profile allow set'i çoğunu zaten kapsıyordu). Hepsi düzeltildi, lint **\`warn\` olarak enforce edildi**.

## Tür

- [x] Refactor / temizlik (davranış değişmedi)
- [x] Güvenlik (silent integer overflow tespiti)

## Kategori bazlı düzeltme

### Kategori 1 — Kasıtlı, no-wrap (5 hit, SAFETY-CAST yorumlu \`#[allow]\`)
| Yer | Cast | Gerekçe |
|---|---|---|
| \`crypto.rs:47\` | \`b as i8\` | NearDrop PIN hash algoritma uyumu (wire incompat eder) |
| \`connection.rs:1252\` | \`(u64>>1) as i64\` | High-bit shift → always 0..=i64::MAX |
| \`sender.rs:117\` | \`raw_size as i64\` | Yukarıda \`if raw_size > i64::MAX as u64\` checked |
| \`sender.rs:118, 467\` | \`(u64>>1) as i64\` | Always-positive |
| \`sender.rs:858\` | \`n as i64\` | AsyncReadExt::read max CHUNK_SIZE 4 KiB |

### Kategori 2 — usize → i64 \`try_from\` defensive (2 hit)
- \`payload.rs:390\` — attacker-controlled chunk body → \`i64::try_from(...).map_err(...)?\`
- \`connection.rs:1253\` — sharing frame body → \`i64::try_from(...).with_context(...)?\`

### Kategori 3 — u64 → i64 saturating (4 hit)
\`main.rs:1087-1102\` stat counter (\`bytes_received\`/\`bytes_sent\`/\`top_rx\`/\`top_tx\`):
\`\`\`rust
let to_i64_sat = |b: u64| -> i64 { i64::try_from(b).unwrap_or(i64::MAX) };
\`\`\`
8 EiB üstü "ulaşılamaz" pratikte; saturate UI sinyali olarak yeterli (\`human_size\` legacy \`i64\` API — DRY temizliği ayrı PR).

### Kategori 4 — Test-only (4 hit)
- \`payload.rs:496\` (mod tests) → \`#[allow(clippy::cast_possible_wrap)]\` modüle
- \`tests/common/mod.rs\`, \`tests/payload_corrupt.rs\` allow set'lerine ekleme
- \`lib.rs\` + \`main.rs\` \`#![cfg_attr(test, allow(...))]\` set'lerine ekleme

## Lint enforce

\`\`\`toml
[workspace.lints.clippy]
cast_possible_wrap = "warn"   # cast_wrap audit PR'ı sonrası enforce — 15 hit fix'lendi
\`\`\`

PR #87'deki "RED-tier" notu kaldırıldı; yeni kod cast wrap'a bilinçsizce takılırsa CI bloklar.

## Test

- [x] \`cargo build --workspace\` — yeşil
- [x] \`cargo test --workspace\` — **164 main + 16 lib + 17 integration pass**, 0 fail
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — temiz (0 cast_possible_wrap warning)
- [x] \`cargo fmt --check\` — temiz
- [x] \`cargo machete\` — 0 unused dep

## İlgili

- Önceki: PR #100 (RFC-0001 §5 finale, merged)
- ROADMAP §Q1 v0.7+ Tier 2 lint cleanup serisinin ilki
- Bağlam: Cargo.toml [workspace.lints] yorumu \"clippy::cast_possible_wrap (36, security) — issue #TBD (audit gerekiyor)\"

## Sıradaki Tier 2 lint adayları

- \`clippy::must_use_candidate\` (71 hit) — Result-dönen public fn'ler
- \`unreachable_pub\` (349 hit) — kademeli per-crate
- \`clippy::doc_markdown\` (445+792)

🤖 Generated with [Claude Code](https://claude.com/claude-code)