### PR TITLE
feat(core): RFC-0003 §3.2 — Capabilities envelope + magic prefix dispatcher

### DIFF
--- a/crates/hekadrop-core/src/capabilities.rs
+++ b/crates/hekadrop-core/src/capabilities.rs
@@ -1,0 +1,214 @@
+//! HekaDrop protocol extension capability negotiation (RFC-0003 §3.2).
+//!
+//! Bu modül [`hekadrop_proto::hekadrop_ext`] altındaki üretilmiş
+//! `Capabilities` ve `HekaDropFrame` mesajlarını idiomatic Rust API
+//! ile sarar. Wire-byte-exact spec: `docs/protocol/capabilities.md`.
+//!
+//! İki uç da `PairedKeyEncryption` sonrası kendi feature set'ini
+//! gönderir; aktif feature `my & peer` ile hesaplanır. 2 sn timeout
+//! → legacy mode (`active = 0`).
+//!
+//! Magic prefix dispatcher [`crate::frame`]'dedir. Bu modül yalnızca
+//! capability set semantiği ve protobuf encode/decode wrapper'ı sağlar.
+
+use hekadrop_proto::hekadrop_ext::{Capabilities, HekaDropFrame};
+
+/// `Capabilities.features` bit konumları.
+///
+/// Bit'ler stable kontrat — major version bump olmadan yer değiştirmez.
+/// Yeni RFC bit eklerken numerical olarak en küçük serbest pozisyonu alır
+/// ve `ALL_SUPPORTED`'ı günceller.
+pub mod features {
+    /// RFC-0003 — per-chunk HMAC-SHA256 integrity tag.
+    pub const CHUNK_HMAC_V1: u64 = 0x0000_0001;
+
+    /// RFC-0004 — transfer resume hint with partial-hash verification.
+    pub const RESUME_V1: u64 = 0x0000_0002;
+
+    /// RFC-0005 — folder bundle with HEKABUND iç format.
+    pub const FOLDER_STREAM_V1: u64 = 0x0000_0004;
+
+    /// Bu build'in advertise ettiği tüm feature'lar.
+    ///
+    /// Sender `Capabilities.features` alanına bunu yazar; alıcı uç da
+    /// kendi `ALL_SUPPORTED`'ını yollar. Aktif set:
+    /// `my.features & peer.features`. Bilinmeyen üst bit'ler doğal olarak
+    /// AND sonucundan düşer (forward-compat).
+    pub const ALL_SUPPORTED: u64 = CHUNK_HMAC_V1 | RESUME_V1 | FOLDER_STREAM_V1;
+
+    /// Bu build için reserved (henüz hiçbir RFC'nin sahip olmadığı) bit'ler.
+    /// Test'lerde forward-compat akışını doğrulamak için kullanılır.
+    #[cfg(test)]
+    pub const RESERVED_FUTURE: u64 = !ALL_SUPPORTED;
+}
+
+/// `Capabilities` mesaj versiyonu — `Capabilities.version` alanına yazılır.
+///
+/// v0.8.0 = 1. Şema değişirse (ör. yeni alan eklenirse) bump et.
+pub const CAPABILITIES_VERSION: u32 = 1;
+
+/// `HekaDropFrame` envelope versiyonu — `HekaDropFrame.version` alanına yazılır.
+///
+/// v0.8.0 = 1. Envelope yapısı kapsamlı değişirse (ör. yeni reserved
+/// slot kullanımı) bump et.
+pub const ENVELOPE_VERSION: u32 = 1;
+
+/// Aktif (her iki uçça desteklenen) feature kümesi.
+///
+/// Construct edildikten sonra immutable; query method'ları O(1).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ActiveCapabilities {
+    features: u64,
+}
+
+impl ActiveCapabilities {
+    /// İki tarafın advertise ettiği feature set'lerinden aktif olanı türet.
+    ///
+    /// Forward-compat: `peer.features` bu build'in tanımadığı üst bit'leri
+    /// içerse de AND ile elenir; aktif kümede bilinen bit'ler kalır.
+    #[must_use]
+    pub const fn negotiate(my: u64, peer: u64) -> Self {
+        Self {
+            features: my & peer,
+        }
+    }
+
+    /// Capabilities exchange başarısız olduğunda (timeout, parse error)
+    /// fallback değer. Aktif feature'sız = legacy Quick Share davranışı.
+    #[must_use]
+    pub const fn legacy() -> Self {
+        Self { features: 0 }
+    }
+
+    /// Belirli bir feature aktif mi.
+    #[must_use]
+    pub const fn has(&self, feature: u64) -> bool {
+        (self.features & feature) == feature
+    }
+
+    /// Aktif feature bitmask'ı (debug + log için).
+    #[must_use]
+    pub const fn raw(&self) -> u64 {
+        self.features
+    }
+
+    /// Hiç feature aktif değil mi (legacy mode).
+    #[must_use]
+    pub const fn is_legacy(&self) -> bool {
+        self.features == 0
+    }
+}
+
+/// Bu build'in `Capabilities` advertisement'ı — wire'a gönderilecek
+/// protobuf mesajı.
+#[must_use]
+pub fn build_self_capabilities() -> Capabilities {
+    Capabilities {
+        version: CAPABILITIES_VERSION,
+        features: features::ALL_SUPPORTED,
+    }
+}
+
+/// `HekaDropFrame { capabilities = ... }` envelope'unu inşa et.
+#[must_use]
+pub fn build_capabilities_frame(caps: Capabilities) -> HekaDropFrame {
+    use hekadrop_proto::hekadrop_ext::heka_drop_frame::Payload;
+    HekaDropFrame {
+        version: ENVELOPE_VERSION,
+        payload: Some(Payload::Capabilities(caps)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use prost::Message;
+
+    #[test]
+    fn legacy_no_features() {
+        let active = ActiveCapabilities::legacy();
+        assert!(active.is_legacy());
+        assert_eq!(active.raw(), 0);
+        assert!(!active.has(features::CHUNK_HMAC_V1));
+        assert!(!active.has(features::RESUME_V1));
+        assert!(!active.has(features::FOLDER_STREAM_V1));
+    }
+
+    #[test]
+    fn negotiate_intersection() {
+        // Sender supports chunk_hmac + resume; receiver supports
+        // chunk_hmac + folder. Intersection = chunk_hmac only.
+        let active = ActiveCapabilities::negotiate(
+            features::CHUNK_HMAC_V1 | features::RESUME_V1,
+            features::CHUNK_HMAC_V1 | features::FOLDER_STREAM_V1,
+        );
+        assert!(active.has(features::CHUNK_HMAC_V1));
+        assert!(!active.has(features::RESUME_V1));
+        assert!(!active.has(features::FOLDER_STREAM_V1));
+        assert!(!active.is_legacy());
+    }
+
+    #[test]
+    fn forward_compat_unknown_bits_silently_ignored() {
+        // Peer ileri bir versiyondan; bilmediğimiz üst bit'leri
+        // advertise ediyor. Bizim build'imiz bu bit'leri tanımıyor;
+        // intersection sadece bizim de bildiğimiz bit'leri tutmalı.
+        let unknown_future_bit: u64 = 0x0000_8000;
+        let peer = features::CHUNK_HMAC_V1 | unknown_future_bit;
+        let active = ActiveCapabilities::negotiate(features::ALL_SUPPORTED, peer);
+        assert!(active.has(features::CHUNK_HMAC_V1));
+        // Bilmediğimiz bit AND sonucundan düşmüş — kontrol için ALL_SUPPORTED
+        // dışında hiçbir bit aktif olmamalı.
+        assert_eq!(active.raw() & features::RESERVED_FUTURE, 0);
+    }
+
+    #[test]
+    fn build_self_advertises_all_supported() {
+        let caps = build_self_capabilities();
+        assert_eq!(caps.version, CAPABILITIES_VERSION);
+        assert_eq!(caps.features, features::ALL_SUPPORTED);
+    }
+
+    #[test]
+    fn capabilities_protobuf_roundtrip() {
+        let original = build_self_capabilities();
+        let bytes = original.encode_to_vec();
+        let decoded = Capabilities::decode(&*bytes).expect("valid wire encoding");
+        assert_eq!(decoded.version, original.version);
+        assert_eq!(decoded.features, original.features);
+    }
+
+    #[test]
+    fn envelope_carries_capabilities_oneof() {
+        use hekadrop_proto::hekadrop_ext::heka_drop_frame::Payload;
+        let caps = build_self_capabilities();
+        let frame = build_capabilities_frame(caps);
+
+        assert_eq!(frame.version, ENVELOPE_VERSION);
+        match frame.payload {
+            Some(Payload::Capabilities(c)) => {
+                assert_eq!(c.version, caps.version);
+                assert_eq!(c.features, caps.features);
+            }
+            other => panic!("beklenen oneof slot 10 (capabilities), bulundu: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn envelope_protobuf_roundtrip() {
+        let frame = build_capabilities_frame(build_self_capabilities());
+        let bytes = frame.encode_to_vec();
+        let decoded = HekaDropFrame::decode(&*bytes).expect("valid wire encoding");
+        assert_eq!(decoded.version, frame.version);
+        // Payload oneof preserved.
+        assert!(decoded.payload.is_some());
+    }
+
+    #[test]
+    fn all_supported_bitmask_matches_individual_bits() {
+        // Regression: ALL_SUPPORTED'ın tek tek bit'lerin OR'u olduğunu
+        // doğrula; gelecekte yeni bit eklendiğinde bu test güncellenecek.
+        let expected = features::CHUNK_HMAC_V1 | features::RESUME_V1 | features::FOLDER_STREAM_V1;
+        assert_eq!(features::ALL_SUPPORTED, expected);
+    }
+}

--- a/crates/hekadrop-core/src/frame.rs
+++ b/crates/hekadrop-core/src/frame.rs
@@ -54,3 +54,205 @@ pub async fn write_frame(stream: &mut TcpStream, data: &[u8]) -> Result<(), Heka
     stream.write_all(&out).await?;
     Ok(())
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// HekaDrop extension envelope dispatcher (RFC-0003 §3.2)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// `HekaDropFrame` magic prefix — protokol-DIŞINDA, raw 4-byte big-endian.
+///
+/// Wire layout: `[ HEKADROP_MAGIC_BE (4 bytes) ][ HekaDropFrame protobuf ]`.
+/// Magic protobuf field DEĞİL — `fixed32 field=1` olsaydı tag byte `0x0d`
+/// olurdu ve "ilk 4 byte sabit prefix" garantisi yıkılırdı (Gemini PR #85
+/// review). Bu nedenle magic strip'i bu seviyede yapılır, sonra
+/// `HekaDropFrame::decode` çağrılır.
+///
+/// Wire-byte-exact spec: `docs/protocol/capabilities.md` §2.
+pub const HEKADROP_MAGIC_BE: [u8; 4] = [0xA5, 0xDE, 0xB2, 0x01];
+
+/// `dispatch_frame_body`'nin döndürdüğü ayrım — caller frame'in HekaDrop
+/// extension mı yoksa upstream Quick Share mi olduğunu bilir.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FrameKind<'a> {
+    /// Magic prefix eşleşti; `inner` magic'ten sonraki protobuf bytes'ı.
+    /// Caller `HekaDropFrame::decode(inner)` ile parse eder.
+    HekaDrop { inner: &'a [u8] },
+    /// Magic eşleşmedi; bu klasik Quick Share `OfflineFrame` payload'ı.
+    /// Caller `OfflineFrame::decode(body)` ile parse eder.
+    Offline { body: &'a [u8] },
+}
+
+/// `SecureCtx::decrypt`'ten gelen plaintext frame body'sini sınıflandır.
+///
+/// 4-byte magic prefix kontrolü O(1) memcmp'tir; protobuf parse maliyeti
+/// yoktur. Eski Quick Share peer'ı bizim magic'i içeren bir frame görürse
+/// `OfflineFrame::decode` hatası alır ve drop eder — bu zaten capabilities
+/// gate aktif değilken HekaDrop'un GÖNDERMEMESİ gereken bir frame'dir;
+/// dispatcher defense-in-depth.
+#[must_use]
+pub fn dispatch_frame_body(body: &[u8]) -> FrameKind<'_> {
+    if body.len() >= HEKADROP_MAGIC_BE.len() && body[..HEKADROP_MAGIC_BE.len()] == HEKADROP_MAGIC_BE
+    {
+        FrameKind::HekaDrop {
+            inner: &body[HEKADROP_MAGIC_BE.len()..],
+        }
+    } else {
+        FrameKind::Offline { body }
+    }
+}
+
+/// Bir `HekaDropFrame` protobuf encoding'ini wire formatına çevir
+/// (magic prefix + protobuf bytes). `SecureCtx::encrypt`'e besleme öncesi.
+#[must_use]
+pub fn wrap_hekadrop_frame(protobuf_bytes: &[u8]) -> Bytes {
+    let mut out = BytesMut::with_capacity(HEKADROP_MAGIC_BE.len() + protobuf_bytes.len());
+    out.put_slice(&HEKADROP_MAGIC_BE);
+    out.put_slice(protobuf_bytes);
+    out.freeze()
+}
+
+#[cfg(test)]
+mod dispatcher_tests {
+    use super::*;
+
+    #[test]
+    fn magic_prefix_constant_matches_spec() {
+        // Wire-byte-exact: docs/protocol/capabilities.md §2 sabit `0xA5DEB201`.
+        assert_eq!(HEKADROP_MAGIC_BE, [0xA5, 0xDE, 0xB2, 0x01]);
+    }
+
+    #[test]
+    fn dispatch_offline_when_no_magic() {
+        // Klasik Quick Share OfflineFrame'i: ilk byte tipik `0x08` (varint
+        // tag=1) gibi bir şey; magic'le başlamaz → Offline.
+        let body = [0x08u8, 0x05, 0x10, 0x42];
+        match dispatch_frame_body(&body) {
+            FrameKind::Offline { body: b } => assert_eq!(b, &body),
+            other => panic!("Offline beklendi, alındı: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn dispatch_hekadrop_when_magic_present() {
+        // Magic + iki byte fake protobuf payload.
+        let inner = [0x08u8, 0x01]; // version=1
+        let mut body = Vec::new();
+        body.extend_from_slice(&HEKADROP_MAGIC_BE);
+        body.extend_from_slice(&inner);
+
+        match dispatch_frame_body(&body) {
+            FrameKind::HekaDrop { inner: i } => assert_eq!(i, &inner),
+            other => panic!("HekaDrop beklendi, alındı: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn dispatch_offline_when_body_shorter_than_magic() {
+        // 3 byte (magic 4 byte) — slice OOB olmadan Offline'a düşmeli.
+        let body = [0xA5u8, 0xDE, 0xB2];
+        match dispatch_frame_body(&body) {
+            FrameKind::Offline { body: b } => assert_eq!(b, &body),
+            other => panic!("Offline beklendi (kısa body), alındı: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn dispatch_offline_when_first_three_match_but_fourth_differs() {
+        // 0xA5 0xDE 0xB2 0xFF — magic'in 4. byte'ı eşleşmiyor.
+        let body = [0xA5u8, 0xDE, 0xB2, 0xFF, 0x08, 0x01];
+        match dispatch_frame_body(&body) {
+            FrameKind::Offline { body: b } => assert_eq!(b, &body),
+            other => panic!("Offline beklendi (4. byte fark), alındı: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn dispatch_empty_body() {
+        match dispatch_frame_body(&[]) {
+            FrameKind::Offline { body } => assert!(body.is_empty()),
+            other => panic!("boş body Offline'a düşmeli, alındı: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn wrap_prepends_magic() {
+        let pb = [0x08u8, 0x01, 0x52, 0x04];
+        let wrapped = wrap_hekadrop_frame(&pb);
+        assert_eq!(&wrapped[..4], &HEKADROP_MAGIC_BE);
+        assert_eq!(&wrapped[4..], &pb);
+    }
+
+    #[test]
+    fn wrap_then_dispatch_roundtrip() {
+        // Sender: HekaDropFrame protobuf encode + wrap.
+        // Receiver: dispatch → HekaDrop kind, inner bytes orijinal protobuf.
+        let pb = [0x08u8, 0x01, 0x52, 0x04, 0x08, 0x01, 0x10, 0x07];
+        let wire = wrap_hekadrop_frame(&pb);
+        match dispatch_frame_body(&wire) {
+            FrameKind::HekaDrop { inner } => assert_eq!(inner, &pb),
+            other => panic!("roundtrip kırıldı: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn capabilities_kat_legacy_dispatch() {
+        // KAT-CAP-1 (capabilities.md §8): legacy fallback frame (features=0).
+        // On-wire: A5 DE B2 01 08 01 52 04 08 01 10 00.
+        let kat_legacy = [
+            0xA5u8, 0xDE, 0xB2, 0x01, // magic
+            0x08, 0x01, // HekaDropFrame.version = 1
+            0x52, 0x04, // oneof slot 10 (capabilities), length-delimited 4 bytes
+            0x08, 0x01, // Capabilities.version = 1
+            0x10, 0x00, // Capabilities.features = 0
+        ];
+        match dispatch_frame_body(&kat_legacy) {
+            FrameKind::HekaDrop { inner } => {
+                use crate::capabilities::ActiveCapabilities;
+                use hekadrop_proto::hekadrop_ext::{heka_drop_frame::Payload, HekaDropFrame};
+                use prost::Message;
+                let frame = HekaDropFrame::decode(inner).expect("KAT decode");
+                assert_eq!(frame.version, 1);
+                match frame.payload {
+                    Some(Payload::Capabilities(c)) => {
+                        assert_eq!(c.version, 1);
+                        assert_eq!(c.features, 0);
+                        let active = ActiveCapabilities::negotiate(c.features, c.features);
+                        assert!(active.is_legacy());
+                    }
+                    other => panic!("capabilities slot beklendi: {other:?}"),
+                }
+            }
+            other => panic!("magic eşleşmesi bekleniyor, alındı: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn capabilities_kat_all_features_dispatch() {
+        // KAT-CAP-2 (capabilities.md §8): tüm v0.8 features (features=0x07).
+        let kat_full = [
+            0xA5u8, 0xDE, 0xB2, 0x01, // magic
+            0x08, 0x01, // version = 1
+            0x52, 0x04, // oneof slot 10, len 4
+            0x08, 0x01, // Capabilities.version = 1
+            0x10, 0x07, // Capabilities.features = 7
+        ];
+        match dispatch_frame_body(&kat_full) {
+            FrameKind::HekaDrop { inner } => {
+                use crate::capabilities::{features, ActiveCapabilities};
+                use hekadrop_proto::hekadrop_ext::{heka_drop_frame::Payload, HekaDropFrame};
+                use prost::Message;
+                let frame = HekaDropFrame::decode(inner).expect("KAT decode");
+                if let Some(Payload::Capabilities(c)) = frame.payload {
+                    assert_eq!(c.features, 0x07);
+                    let active = ActiveCapabilities::negotiate(features::ALL_SUPPORTED, c.features);
+                    assert!(active.has(features::CHUNK_HMAC_V1));
+                    assert!(active.has(features::RESUME_V1));
+                    assert!(active.has(features::FOLDER_STREAM_V1));
+                } else {
+                    panic!("capabilities oneof beklendi");
+                }
+            }
+            other => panic!("magic eşleşmesi bekleniyor: {other:?}"),
+        }
+    }
+}

--- a/crates/hekadrop-core/src/lib.rs
+++ b/crates/hekadrop-core/src/lib.rs
@@ -40,6 +40,7 @@
     )
 )]
 
+pub mod capabilities;
 pub mod config;
 pub mod crypto;
 pub mod error;

--- a/crates/hekadrop-proto/build.rs
+++ b/crates/hekadrop-proto/build.rs
@@ -9,6 +9,11 @@ fn main() -> Result<()> {
         "proto/sharing_enums.proto",
         "proto/ukey.proto",
         "proto/wire_format.proto",
+        // RFC-0003 §3.2: HekaDrop-only extension envelope
+        // (capabilities, chunk_tag, resume_hint, resume_reject, folder_mft).
+        // Wire layout: 4-byte BE magic (0xA5DEB201) + bu protobuf payload.
+        // Dispatcher: hekadrop-core::frame.
+        "proto/hekadrop_extensions.proto",
     ];
 
     for p in &protos {

--- a/crates/hekadrop-proto/proto/hekadrop_extensions.proto
+++ b/crates/hekadrop-proto/proto/hekadrop_extensions.proto
@@ -1,0 +1,99 @@
+// HekaDrop protocol extensions — wire-level proto definitions.
+//
+// **Bu file HekaDrop-only**, upstream Quick Share / Nearby Connections
+// proto ağacında YOKTUR. Burada tanımlanan `HekaDropFrame` envelope ve
+// inner mesajları magic-prefixed bir wrapper içinde taşınır
+// (4-byte big-endian `0xA5DEB201`, **protobuf-DIŞINDA**, raw prefix).
+//
+// Wire-byte-exact spec: `docs/protocol/capabilities.md`.
+// Normative RFC:        `docs/rfcs/0003-chunk-hmac.md` §3.2.
+//
+// Slot tahsis politikası (oneof HekaDropFrame.payload):
+//   1..9   — boş (gelecek non-payload core fields için rezerv: correlation_id,
+//             trace_span vb.)
+//   10–14  — bu RFC paketinde sabitlenmiş (capabilities, chunk_tag,
+//             resume_hint, resume_reject, folder_mft)
+//   15..63 — gelecek v0.x minor eklemeler için rezerv
+//
+// `oneof` içinde proto3 `reserved` keyword'ü KULLANILMAZ — `reserved`
+// gelecek kullanımı yasaklar (capabilities.md §3.1). Slot management
+// dokümantasyon-driven.
+
+syntax = "proto3";
+package hekadrop.ext;
+
+// HekaDrop extension envelope.
+//
+// Wire layout: `[4-byte BE magic 0xA5DEB201][bu mesajın protobuf encoding'i]`
+// Magic protobuf field DEĞİL — dispatcher seviyesinde strip edilir.
+message HekaDropFrame {
+  uint32 version = 1;         // monoton; v0.8 = 1
+
+  oneof payload {
+    Capabilities    capabilities  = 10;  // RFC 0003 §3.2
+    ChunkIntegrity  chunk_tag     = 11;  // RFC 0003 §3.2 (ChunkIntegrity)
+    ResumeHint      resume_hint   = 12;  // RFC 0004 (placeholder, v0.8.1)
+    ResumeReject    resume_reject = 13;  // RFC 0004 (placeholder, v0.8.1)
+    FolderManifest  folder_mft    = 14;  // RFC 0005 (placeholder, v0.8.x)
+  }
+}
+
+// Peer-to-peer feature negotiation. Her iki uç PairedKeyEncryption
+// sonrası kendi `Capabilities`'ini gönderir; aktif feature set =
+// `my.features & peer.features`. 2 sn timeout → legacy mode (active=0).
+message Capabilities {
+  uint32 version  = 1;        // Capabilities şeması versiyonu; v0.8.0 = 1
+  uint64 features = 2;        // Bitmask, sabit bit konumları için
+                              // hekadrop-core::capabilities::features modülüne bkz.
+}
+
+// Per-chunk HMAC integrity tag (RFC 0003).
+//
+// Wire-byte-exact spec: `docs/protocol/chunk-hmac.md`.
+// Bu mesaj capabilities.CHUNK_HMAC_V1 (= 0x0001) bit'i her iki uçta
+// aktifse gönderilir; PayloadTransferFrame'den HEMEN sonra, aynı
+// SecureCtx stream'inde.
+message ChunkIntegrity {
+  int64  payload_id  = 1;     // PayloadHeader.id mirror (redundant integrity)
+  int64  chunk_index = 2;     // 0-based monoton per-payload counter
+  int64  offset      = 3;     // PayloadChunk.offset mirror
+  uint32 body_len    = 4;     // len(body) bu değere eşit olmalı
+  bytes  tag         = 5;     // HMAC-SHA256 = 32 bytes; başka uzunluk reject
+}
+
+// Transfer resume hint (RFC 0004 placeholder).
+//
+// Receiver, Introduction frame'inde tanıdığı bir payload_id görüp
+// `~/.hekadrop/partial/<session_id>_<payload_id>.meta` ile eşleşen
+// partial dosyası varsa bu mesajla sender'a "şuradan devam" ipucu verir.
+//
+// **v0.8.0'da boş placeholder.** Tam tanım v0.8.1 implementation'ında
+// `docs/protocol/resume.md` byte-exact spec'inden indirilecek.
+message ResumeHint {
+  int64  payload_id          = 1;
+  int64  offset              = 2;
+  bytes  partial_hash        = 3;   // SHA-256(bytes[0..offset])
+  bytes  last_chunk_tag      = 4;   // RFC-0003 fast-path (32 bytes)
+  uint32 capabilities_version = 5;  // peer Capabilities.version mirror
+}
+
+// Resume reject reasons (RFC 0004).
+message ResumeReject {
+  enum Reason {
+    UNKNOWN          = 0;
+    HASH_MISMATCH    = 1;
+    TTL_EXPIRED      = 2;
+    VERSION_MISMATCH = 3;
+    DISK_BUDGET      = 4;
+  }
+  int64  payload_id = 1;
+  Reason reason     = 2;
+}
+
+// Folder bundle manifest (RFC 0005 placeholder).
+//
+// **v0.8.0'da boş placeholder.** Tam tanım folder-payload.md
+// implementation'ında.
+message FolderManifest {
+  // Sealed during v0.8.x implementation; bu boş slot ABI'yi rezerv eder.
+}

--- a/crates/hekadrop-proto/src/lib.rs
+++ b/crates/hekadrop-proto/src/lib.rs
@@ -92,3 +92,26 @@ pub mod sharing {
         include!(concat!(env!("OUT_DIR"), "/sharing.nearby.rs"));
     }
 }
+
+/// HekaDrop-only protocol extension envelope (RFC-0003 §3.2).
+///
+/// Wire layout: 4-byte big-endian magic (`0xA5DEB201`) — protobuf-DIŞINDA,
+/// raw prefix — ardından `HekaDropFrame` protobuf encoding'i. Magic
+/// dispatcher seviyesinde strip edilir (`hekadrop-core::frame`).
+///
+/// Slot tahsisi: capabilities=10, chunk_tag=11, resume_hint=12,
+/// resume_reject=13, folder_mft=14. 1..9 ve 15..63 reserved.
+///
+/// Wire-byte-exact spec: `docs/protocol/capabilities.md`.
+#[allow(
+    clippy::all,
+    non_snake_case,
+    non_camel_case_types,
+    dead_code,
+    unused_qualifications,
+    rustdoc::invalid_html_tags,
+    rustdoc::broken_intra_doc_links
+)]
+pub mod hekadrop_ext {
+    include!(concat!(env!("OUT_DIR"), "/hekadrop.ext.rs"));
+}


### PR DESCRIPTION
## Özet

v0.8.0 chunk-HMAC (RFC-0003), transfer resume (RFC-0004) ve folder payload (RFC-0005) implementation'larının **zemin koşulu**: HekaDrop extension envelope altyapısı. Wire layout [\`docs/protocol/capabilities.md\`](docs/protocol/capabilities.md) byte-exact spec'inden birebir indirildi.

> Tek atomik PR — capabilities olmadan chunk-HMAC/resume/folder hiçbiri çalışamaz; bu commit zemini açar.

## Tür

- [x] Yeni özellik (protocol extension envelope)

## Değişiklikler

### Yeni proto file: \`crates/hekadrop-proto/proto/hekadrop_extensions.proto\`

\`HekaDropFrame\` envelope + 5 inner mesaj (Capabilities, ChunkIntegrity, ResumeHint, ResumeReject, FolderManifest):
- **Magic protobuf-DIŞINDA**, raw 4-byte BE prefix (\`0xA5DEB201\`) — Gemini PR-85 review sonrası kilit karar (proto3 \`fixed32 field=1\` tag-byte'lı encoding, magic prefix garantisi vermezdi)
- Oneof slot tahsisi: 10–14 sealed (capabilities=10, chunk_tag=11, resume_hint=12, resume_reject=13, folder_mft=14); 1–9 ve 15–63 reserved
- Proto3 \`reserved\` keyword **KULLANILMADI** (gelecek kullanımı yasaklayacaktı)
- \`hekadrop-proto/build.rs\` listesine eklendi → \`hekadrop_proto::hekadrop_ext\` Rust modülü

### Yeni Rust modülü: \`crates/hekadrop-core/src/capabilities.rs\`

Idiomatic API + capability negotiation:
\`\`\`rust
pub mod features {
    pub const CHUNK_HMAC_V1:    u64 = 0x0001;
    pub const RESUME_V1:        u64 = 0x0002;
    pub const FOLDER_STREAM_V1: u64 = 0x0004;
    pub const ALL_SUPPORTED:    u64 = CHUNK_HMAC_V1 | RESUME_V1 | FOLDER_STREAM_V1;
}

pub struct ActiveCapabilities { /* features: u64 */ }
impl ActiveCapabilities {
    pub const fn negotiate(my: u64, peer: u64) -> Self { /* my & peer */ }
    pub const fn legacy() -> Self;
    pub const fn has(&self, feature: u64) -> bool;
    pub const fn is_legacy(&self) -> bool;
}

pub fn build_self_capabilities() -> Capabilities;
pub fn build_capabilities_frame(caps: Capabilities) -> HekaDropFrame;
\`\`\`

8 unit test: legacy, intersection, forward-compat (peer'ın bilmediğimiz üst bit'leri silently elenir), protobuf roundtrip, envelope oneof slot 10 doğrulaması.

### Magic prefix dispatcher: \`crates/hekadrop-core/src/frame.rs\`

\`\`\`rust
pub const HEKADROP_MAGIC_BE: [u8; 4] = [0xA5, 0xDE, 0xB2, 0x01];

pub enum FrameKind<'a> {
    HekaDrop { inner: &'a [u8] },
    Offline { body: &'a [u8] },
}

pub fn dispatch_frame_body(body: &[u8]) -> FrameKind<'_>;
pub fn wrap_hekadrop_frame(protobuf_bytes: &[u8]) -> Bytes;
\`\`\`

10 dispatcher testi (boundary'ler dahil):
- \`dispatch_empty_body\` — boş body → Offline
- \`dispatch_offline_when_body_shorter_than_magic\` (3 byte) → Offline (OOB safe)
- \`dispatch_offline_when_first_three_match_but_fourth_differs\` → Offline
- \`dispatch_hekadrop_when_magic_present\` → HekaDrop, inner stripped
- \`wrap_then_dispatch_roundtrip\`
- **\`capabilities_kat_legacy_dispatch\`** — capabilities.md §8 KAT-CAP-1 wire'da doğrulandı (\`A5 DE B2 01 08 01 52 04 08 01 10 00\`)
- **\`capabilities_kat_all_features_dispatch\`** — KAT-CAP-2 (\`...10 07\`)

## Test

- [x] \`cargo build --workspace\` — yeşil (5 crate)
- [x] \`cargo test --workspace\` — **182 main test pass** (önceki 164'ten +18 yeni: 8 capabilities + 10 dispatcher); 0 fail
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — temiz
- [x] \`cargo fmt --check\` — temiz
- [x] \`cargo machete\` — 0 unused dep
- [x] KAT-CAP-1 ve KAT-CAP-2 wire byte sırası capabilities.md §8 ile birebir eşleşiyor

## İlgili

- RFC-0003 §3.2 (envelope tasarımı normative)
- \`docs/protocol/capabilities.md\` (byte-exact spec)
- \`docs/protocol/chunk-hmac.md\` (sıradaki implementation referansı)

## Sıradaki PR'lar (zemin üstüne)

1. **chunk-HMAC tag computation + verify** — \`hekadrop-core::chunk_hmac\` modülü, HKDF-SHA256 \`"hekadrop chunk-hmac v1"\` key derivation, HMAC input canonical encoding, ct_eq verify
2. **Capabilities exchange entegrasyonu** — sender/receiver state machine'inde PairedKeyEncryption sonrası HekaDropFrame{capabilities} swap (2 sn timeout → legacy mode)
3. **Resume hint state machine** (RFC-0004) — partial dosya yönetimi
4. **Folder bundle** (RFC-0005) — \`FolderManifest\` proto field'ları sealed olunca

🤖 Generated with [Claude Code](https://claude.com/claude-code)