### PR TITLE
chore(lint): uninlined_format_args enable + 110 site auto-fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ get_unwrap = "warn"
 redundant_clone = "warn"
 use_self = "warn"
 # Kalite — düşük volüm, anlık temizlik
+uninlined_format_args = "warn"  # PR #87 auto-fix sonrası 110 yeni site birikmişti; auto-fix tekrar uygulandı + lint enforce
 manual_let_else = "warn"
 ignored_unit_patterns = "warn"
 trivially_copy_pass_by_ref = "warn"

--- a/crates/hekadrop-app/src/i18n.rs
+++ b/crates/hekadrop-app/src/i18n.rs
@@ -771,8 +771,8 @@ mod tests {
             "onboarding.cta_dismiss",
         ];
         for k in &sample_keys {
-            assert!(lookup_tr(k).is_some(), "Türkçe çeviri eksik: {}", k);
-            assert!(lookup_en(k).is_some(), "English translation missing: {}", k);
+            assert!(lookup_tr(k).is_some(), "Türkçe çeviri eksik: {k}");
+            assert!(lookup_en(k).is_some(), "English translation missing: {k}");
         }
     }
 }

--- a/crates/hekadrop-app/src/main.rs
+++ b/crates/hekadrop-app/src/main.rs
@@ -184,7 +184,7 @@ fn main() {
                 Err(e) => {
                     ui::fatal_error_dialog(
                         "HekaDrop başlatılamıyor",
-                        &format!("tokio runtime kurulamadı: {}", e),
+                        &format!("tokio runtime kurulamadı: {e}"),
                     );
                     std::process::exit(1);
                 }
@@ -198,7 +198,7 @@ fn main() {
     if let Err(e) = spawn_result {
         ui::fatal_error_dialog(
             "HekaDrop başlatılamıyor",
-            &format!("async thread başlatılamadı: {}", e),
+            &format!("async thread başlatılamadı: {e}"),
         );
         std::process::exit(1);
     }
@@ -251,10 +251,7 @@ fn setup_logging(log_level: settings::LogLevel) {
             // Tracing subscriber henüz kurulmadı — eprintln! tek başvuru.
             #[allow(clippy::print_stderr)]
             {
-                eprintln!(
-                    "[HekaDrop] log appender kurulamadı ({}); stdout-only devam",
-                    e
-                );
+                eprintln!("[HekaDrop] log appender kurulamadı ({e}); stdout-only devam");
             }
             None
         }
@@ -384,7 +381,7 @@ fn run_app() -> ! {
         Err(e) => {
             ui::fatal_error_dialog(
                 "HekaDrop başlatılamıyor",
-                &format!("pencere oluşturulamadı: {}", e),
+                &format!("pencere oluşturulamadı: {e}"),
             );
             // Fatal startup; ?-propagation main()'e tanrı-Result zorlar — exit
             // burada anlamlı: kullanıcı hata gördü, RAII temizliğe gerek yok.
@@ -454,7 +451,7 @@ fn run_app() -> ! {
         Err(e) => {
             ui::fatal_error_dialog(
                 "HekaDrop başlatılamıyor",
-                &format!("webview oluşturulamadı: {}", e),
+                &format!("webview oluşturulamadı: {e}"),
             );
             // Fatal startup; bkz. yukarı.
             #[allow(clippy::exit)]
@@ -790,7 +787,7 @@ fn graceful_quit() -> ! {
     #[cfg(target_os = "macos")]
     {
         if let Ok(home) = std::env::var("HOME") {
-            let plist_path = format!("{}/Library/LaunchAgents/com.sourvice.hekadrop.plist", home);
+            let plist_path = format!("{home}/Library/LaunchAgents/com.sourvice.hekadrop.plist");
             if std::path::Path::new(&plist_path).exists() {
                 info!("launchd agent unload: {}", plist_path);
                 let _ = std::process::Command::new("launchctl")
@@ -872,7 +869,7 @@ fn handle_settings_save(json: &str) {
                 tracing::warn!("[ui] download_dir geçersiz: {}", e);
                 ui::notify(
                     i18n::t("notify.app_name"),
-                    &format!("download_dir geçersiz: {}", e),
+                    &format!("download_dir geçersiz: {e}"),
                 );
                 return;
             }
@@ -995,10 +992,7 @@ fn push_i18n_to_ui() {
     // fonksiyonu script block içinde tanımlı — bu push ondan sonra geldiğinde
     // doğrudan çağrılır; öncesinde geldiyse window.__I18N__ setlenir, script
     // tag'i load olunca boot path'i yakalar.
-    let js = format!(
-        "window.__I18N__ = {}; window.applyI18n && window.applyI18n();",
-        payload
-    );
+    let js = format!("window.__I18N__ = {payload}; window.applyI18n && window.applyI18n();");
     state::enqueue_js(js);
 }
 
@@ -1058,7 +1052,7 @@ fn push_settings_to_ui() {
         "disable_update_check": s.disable_update_check,
     });
     drop(s);
-    let js = format!("window.applySettings && window.applySettings({})", payload);
+    let js = format!("window.applySettings && window.applySettings({payload})");
     state::enqueue_js(js);
 }
 
@@ -1113,10 +1107,7 @@ fn push_stats_to_ui() {
         "top_rx": top_rx,
         "top_tx": top_tx,
     });
-    state::enqueue_js(format!(
-        "window.applyStats && window.applyStats({})",
-        payload
-    ));
+    state::enqueue_js(format!("window.applyStats && window.applyStats({payload})"));
 }
 
 fn st_settings_resolved_name() -> String {
@@ -1154,7 +1145,7 @@ fn push_trusted_to_ui() {
         .collect();
     drop(s);
     let payload = serde_json::Value::Array(items);
-    let js = format!("window.applyTrusted && window.applyTrusted({})", payload);
+    let js = format!("window.applyTrusted && window.applyTrusted({payload})");
     state::enqueue_js(js);
 }
 
@@ -1215,8 +1206,8 @@ fn progress_signature(p: &state::ProgressState) -> String {
             device,
             file,
             percent,
-        } => format!("recv:{}:{}:{}", device, file, percent),
-        state::ProgressState::Completed { file } => format!("done:{}", file),
+        } => format!("recv:{device}:{file}:{percent}"),
+        state::ProgressState::Completed { file } => format!("done:{file}"),
     }
 }
 
@@ -1225,7 +1216,7 @@ fn js_string(s: &str) -> String {
         .replace('\\', "\\\\")
         .replace('"', "\\\"")
         .replace('\n', "\\n");
-    format!("\"{}\"", escaped)
+    format!("\"{escaped}\"")
 }
 
 fn push_progress_to_ui(webview: &wry::WebView, p: &state::ProgressState) {
@@ -1240,11 +1231,11 @@ fn push_progress_to_ui(webview: &wry::WebView, p: &state::ProgressState) {
         } => format!(
             "window.updateProgress && window.updateProgress({}, {})",
             percent,
-            js_string(&format!("{} • {} ({}%)", device, file, percent))
+            js_string(&format!("{device} • {file} ({percent}%)"))
         ),
         state::ProgressState::Completed { file } => format!(
             "window.updateProgress && window.updateProgress(100, {}); setTimeout(() => window.updateProgress(-1, ''), 2500)",
-            js_string(&format!("✓ {}", file))
+            js_string(&format!("✓ {file}"))
         ),
     };
     let _ = webview.evaluate_script(&js);
@@ -1284,7 +1275,7 @@ async fn initiate_send_flow_with(files: Vec<std::path::PathBuf>) {
     let devices = match discovery::scan(Duration::from_secs(3), own_port).await {
         Ok(v) => v,
         Err(e) => {
-            ui::show_info(i18n::t("send.discovery_error"), &format!("{:#}", e));
+            ui::show_info(i18n::t("send.discovery_error"), &format!("{e:#}"));
             return;
         }
     };
@@ -1338,7 +1329,7 @@ async fn initiate_send_flow_with(files: Vec<std::path::PathBuf>) {
         }
         Err(e) => {
             tracing::warn!("send hatası: {:#}", e);
-            ui::show_info(i18n::t("send.send_error"), &format!("{:#}", e));
+            ui::show_info(i18n::t("send.send_error"), &format!("{e:#}"));
         }
     }
 }
@@ -1360,7 +1351,7 @@ async fn initiate_text_send_flow(text: String) {
     let devices = match discovery::scan(Duration::from_secs(3), own_port).await {
         Ok(v) => v,
         Err(e) => {
-            ui::show_info(i18n::t("send.discovery_error"), &format!("{:#}", e));
+            ui::show_info(i18n::t("send.discovery_error"), &format!("{e:#}"));
             return;
         }
     };
@@ -1411,7 +1402,7 @@ async fn initiate_text_send_flow(text: String) {
         }
         Err(e) => {
             tracing::warn!("send_text hatası: {:#}", e);
-            ui::show_info(i18n::t("send.send_error"), &format!("{:#}", e));
+            ui::show_info(i18n::t("send.send_error"), &format!("{e:#}"));
         }
     }
 }
@@ -1536,17 +1527,17 @@ async fn check_update_async() {
                 }
                 // Body'yi 200 char ile sınırla (char-safe, UTF-8 boundary sağlam).
                 let snippet: String = body.chars().take(200).collect();
-                return UpdateCheckOutcome::ApiError(format!("403: {}", snippet));
+                return UpdateCheckOutcome::ApiError(format!("403: {snippet}"));
             }
             "200" => {}
             other if !other.is_empty() => {
-                return UpdateCheckOutcome::ApiError(format!("HTTP {}", other));
+                return UpdateCheckOutcome::ApiError(format!("HTTP {other}"));
             }
             _ => return UpdateCheckOutcome::NetworkError,
         }
         let json: serde_json::Value = match serde_json::from_str(body) {
             Ok(j) => j,
-            Err(e) => return UpdateCheckOutcome::ApiError(format!("JSON: {}", e)),
+            Err(e) => return UpdateCheckOutcome::ApiError(format!("JSON: {e}")),
         };
         let tag = match json.get("tag_name").and_then(|v| v.as_str()) {
             Some(t) => t.to_string(),
@@ -1603,7 +1594,7 @@ fn render_update_outcome(outcome: UpdateCheckOutcome) {
             let msg = i18n::tf("update.status.new_version", &[&tag]);
             // URL'yi mesaja iliştiriyoruz — i18n string'i sürüm taglına odaklı,
             // link satır içi bilgi olarak kalıyor.
-            push_update_status(&format!("{} — {}", msg, url), "success");
+            push_update_status(&format!("{msg} — {url}"), "success");
         }
         UpdateCheckOutcome::NetworkError => {
             push_update_status(i18n::t("update.error.network"), "error");
@@ -1708,7 +1699,7 @@ fn human_size(bytes: i64) -> String {
         i += 1;
     }
     if i == 0 {
-        format!("{} B", bytes)
+        format!("{bytes} B")
     } else {
         format!("{:.1} {}", n, UNITS[i])
     }
@@ -1720,7 +1711,7 @@ fn toggle_login_item() {
         ui::notify("HekaDrop", "HOME bulunamadı");
         return;
     };
-    let plist_path = format!("{}/Library/LaunchAgents/com.sourvice.hekadrop.plist", home);
+    let plist_path = format!("{home}/Library/LaunchAgents/com.sourvice.hekadrop.plist");
     let plist_exists = std::path::Path::new(&plist_path).exists();
 
     if plist_exists {
@@ -1740,8 +1731,7 @@ fn toggle_login_item() {
         ui::show_info(
             "HekaDrop — otomatik başlatma",
             &format!(
-                "Önce HekaDrop.app'i {} dizinine kopyalayın.\n\nTerminal'den:  make install",
-                app_path
+                "Önce HekaDrop.app'i {app_path} dizinine kopyalayın.\n\nTerminal'den:  make install"
             ),
         );
         return;
@@ -1779,7 +1769,7 @@ fn toggle_login_item() {
     if let Err(e) = std::fs::write(&plist_path, plist_template) {
         ui::show_info(
             "HekaDrop",
-            &format!("plist yazılamadı: {}\nKonum: {}", e, plist_path),
+            &format!("plist yazılamadı: {e}\nKonum: {plist_path}"),
         );
         return;
     }

--- a/crates/hekadrop-app/src/ui.rs
+++ b/crates/hekadrop-app/src/ui.rs
@@ -53,7 +53,7 @@ pub async fn prompt_accept(
 
     task::spawn_blocking(move || prompt_accept_blocking(&device, &pin, &files, text_count))
         .await
-        .map_err(|e| anyhow::anyhow!("UI task join: {}", e))
+        .map_err(|e| anyhow::anyhow!("UI task join: {e}"))
 }
 
 /// Tek bir peer-kontrollü alan (cihaz adı, dosya adı, PIN) için sıkı
@@ -1039,7 +1039,7 @@ fn choose_device_blocking(labels: &[String]) -> Option<String> {
 /// notify kullanıyoruz.
 #[allow(dead_code)]
 pub fn send_progress_notify(device: &str, file: &str) {
-    notify("HekaDrop", &format!("Gönderiliyor: {} → {}", file, device));
+    notify("HekaDrop", &format!("Gönderiliyor: {file} → {device}"));
 }
 
 #[cfg(target_os = "macos")]

--- a/crates/hekadrop-app/tests/cancel_per_transfer.rs
+++ b/crates/hekadrop-app/tests/cancel_per_transfer.rs
@@ -146,7 +146,7 @@ async fn cancelling_root_cascades_to_all_children() {
     for (name, h) in [("a", ha), ("b", hb), ("c", hc)] {
         let r = tokio::time::timeout(CANCEL_OBSERVE_TIMEOUT, h)
             .await
-            .unwrap_or_else(|_| panic!("{} task timeout", name))
+            .unwrap_or_else(|_| panic!("{name} task timeout"))
             .unwrap();
         assert!(r, "{name} root cancel'dan tetiklenmeli");
     }

--- a/crates/hekadrop-app/tests/file_metadata_size_guard.rs
+++ b/crates/hekadrop-app/tests/file_metadata_size_guard.rs
@@ -95,6 +95,6 @@ fn ui_gosterilen_deger_dogrudan_accept_s_den_gelir() {
     // görmez. Bu testin kontratı: clamp kararında boyut 0 olur.
     match classify_file_size(-42) {
         FileSizeGuard::Clamped => { /* UI'a 0 yazılmalı — bkz. connection.rs */ }
-        other => panic!("negatif size Clamped beklenirdi, geldi: {:?}", other),
+        other => panic!("negatif size Clamped beklenirdi, geldi: {other:?}"),
     }
 }

--- a/crates/hekadrop-app/tests/frame_codec.rs
+++ b/crates/hekadrop-app/tests/frame_codec.rs
@@ -123,7 +123,7 @@ fn truncated_length_prefix_hata_doner() {
     let buf = [0x00u8, 0x00, 0x01]; // 4. byte eksik
     let mut cur = Cursor::new(&buf[..]);
     let err = read_frame(&mut cur).expect_err("truncated hata bekleniyor");
-    assert!(matches!(err, FrameError::Truncated), "err={:?}", err);
+    assert!(matches!(err, FrameError::Truncated), "err={err:?}");
 }
 
 #[test]
@@ -133,7 +133,7 @@ fn truncated_body_hata_doner() {
     buf.extend_from_slice(&[0xAA, 0xBB, 0xCC]);
     let mut cur = Cursor::new(&buf);
     let err = read_frame(&mut cur).expect_err("truncated body");
-    assert!(matches!(err, FrameError::Truncated), "err={:?}", err);
+    assert!(matches!(err, FrameError::Truncated), "err={err:?}");
 }
 
 #[test]
@@ -155,7 +155,7 @@ fn cok_buyuk_frame_reddedilir() {
     let err = read_frame(&mut cur).expect_err("TooLarge");
     match err {
         FrameError::TooLarge(n) => assert_eq!(n as u32, too_big),
-        _ => panic!("TooLarge beklendi, got: {:?}", err),
+        _ => panic!("TooLarge beklendi, got: {err:?}"),
     }
 }
 

--- a/crates/hekadrop-app/tests/frame_limits.rs
+++ b/crates/hekadrop-app/tests/frame_limits.rs
@@ -99,7 +99,7 @@ fn frame_too_large_reddedilir() {
         FrameError::TooLarge(n) => {
             assert_eq!(n, MAX_FRAME_SIZE + 1);
         }
-        other => panic!("TooLarge beklendi, aldı: {:?}", other),
+        other => panic!("TooLarge beklendi, aldı: {other:?}"),
     }
 
     // Tam sınır değer (16 MiB) kabul — bu davranışı da pin'le.
@@ -123,8 +123,7 @@ fn truncated_frame_eof_doner() {
     let err = read_frame(&mut cur).expect_err("truncated body EOF döndürmeli");
     assert!(
         matches!(err, FrameError::Eof),
-        "Eof bekleniyor, aldı: {:?}",
-        err
+        "Eof bekleniyor, aldı: {err:?}"
     );
 
     // Length-prefix bile tam gelmezse (2/4 bayt) yine EOF.
@@ -133,8 +132,7 @@ fn truncated_frame_eof_doner() {
     let err = read_frame(&mut cur).expect_err("prefix truncated");
     assert!(
         matches!(err, FrameError::Eof),
-        "Eof bekleniyor, aldı: {:?}",
-        err
+        "Eof bekleniyor, aldı: {err:?}"
     );
 }
 
@@ -166,8 +164,8 @@ fn huge_length_u32_max_reddedilir() {
         FrameError::TooLarge(n) => {
             // 32-bit: n == u32::MAX as usize. 64-bit: aynı. Her iki yönde de
             // MAX_FRAME_SIZE'ın çok üstündedir.
-            assert!(n > MAX_FRAME_SIZE, "absürt değer: {}", n);
+            assert!(n > MAX_FRAME_SIZE, "absürt değer: {n}");
         }
-        other => panic!("TooLarge beklendi, aldı: {:?}", other),
+        other => panic!("TooLarge beklendi, aldı: {other:?}"),
     }
 }

--- a/crates/hekadrop-app/tests/hmac_tag_length.rs
+++ b/crates/hekadrop-app/tests/hmac_tag_length.rs
@@ -88,11 +88,10 @@ fn decrypt_rejects_short_hmac_tag() {
     let err = b
         .decrypt(&short_bytes)
         .expect_err("31-bayt tag reddedilmeli");
-    let msg = format!("{}", err);
+    let msg = format!("{err}");
     assert!(
         msg.contains("HMAC tag") || msg.contains("tag uzunluğu"),
-        "uzunluk hatası beklenir, alınan: {}",
-        msg
+        "uzunluk hatası beklenir, alınan: {msg}"
     );
 
     // İstemci seq'i advance etmemeli — state bozulmamalı, retry desteklenebilir.

--- a/crates/hekadrop-app/tests/payload_corrupt.rs
+++ b/crates/hekadrop-app/tests/payload_corrupt.rs
@@ -90,7 +90,7 @@ fn frame(
 fn tmp(label: &str) -> std::path::PathBuf {
     let pid = std::process::id();
     let rnd: u64 = rand::random();
-    std::env::temp_dir().join(format!("hd-payload-corrupt-{}-{}-{}.bin", label, pid, rnd))
+    std::env::temp_dir().join(format!("hd-payload-corrupt-{label}-{pid}-{rnd}.bin"))
 }
 
 #[tokio::test]
@@ -166,8 +166,7 @@ async fn duplicate_payload_id_reddedilir() {
     let msg = err.to_string();
     assert!(
         msg.contains("duplicate") || msg.contains("777"),
-        "hata mesajı duplicate/ id belirtmeli, aldı: {}",
-        msg
+        "hata mesajı duplicate/ id belirtmeli, aldı: {msg}"
     );
 }
 
@@ -204,7 +203,7 @@ async fn out_of_order_chunks_dogru_konuma_yazilir() {
                 "arrival-order append: offset alanı yazım pozisyonu için değil"
             );
         }
-        other => panic!("File bekleniyor, {:?}", other),
+        other => panic!("File bekleniyor, {other:?}"),
     }
     let _ = std::fs::remove_file(&path);
 }
@@ -233,8 +232,7 @@ async fn total_size_overrun_reddedilir() {
     let msg = err.to_string();
     assert!(
         msg.contains("overrun"),
-        "overrun mesajı bekleniyor, aldı: {}",
-        msg
+        "overrun mesajı bekleniyor, aldı: {msg}"
     );
     let _ = std::fs::remove_file(&path);
 }

--- a/crates/hekadrop-app/tests/save_non_blocking.rs
+++ b/crates/hekadrop-app/tests/save_non_blocking.rs
@@ -100,7 +100,7 @@ struct Payload {
 impl Payload {
     fn new() -> Self {
         Self {
-            devices: (0..32).map(|i| format!("device-{}", i)).collect(),
+            devices: (0..32).map(|i| format!("device-{i}")).collect(),
             flags: vec![false; 64],
             counters: vec![0; 64],
         }
@@ -199,15 +199,12 @@ fn save_write_lock_not_held_during_disk_io() {
     // — her writer iterasyonu reader'ı tam blokladığı için max >= 5 ms.
     assert!(
         samples > 10,
-        "reader yeterince örnekleme yapamadı: {}",
-        samples
+        "reader yeterince örnekleme yapamadı: {samples}"
     );
     assert!(
         max_ms < 100.0,
-        "read() acquire max {:.3} ms — snapshot pattern regress olmuş olabilir \
-         (write guard disk I/O altında tutuluyor). Örnek sayısı: {}",
-        max_ms,
-        samples
+        "read() acquire max {max_ms:.3} ms — snapshot pattern regress olmuş olabilir \
+         (write guard disk I/O altında tutuluyor). Örnek sayısı: {samples}"
     );
 }
 
@@ -278,7 +275,6 @@ fn regressed_pattern_blocks_reader_self_check() {
     // Regressed pattern reader'ı en az save_slow süresi (5 ms) kadar bloklar.
     assert!(
         max_ms >= 3.0,
-        "regressed pattern reader'ı {:.3} ms bekletti — beklenen >=3 ms",
-        max_ms
+        "regressed pattern reader'ı {max_ms:.3} ms bekletti — beklenen >=3 ms"
     );
 }

--- a/crates/hekadrop-app/tests/secure_roundtrip.rs
+++ b/crates/hekadrop-app/tests/secure_roundtrip.rs
@@ -208,7 +208,7 @@ fn secure_roundtrip_ab_a_dan_b_ye() {
 fn sequence_counter_monoton_artar() {
     let (mut a, mut b) = make_pair();
     for i in 1..=5 {
-        let msg = format!("msg #{}", i);
+        let msg = format!("msg #{i}");
         let enc = a.encrypt(msg.as_bytes());
         let dec = b.decrypt(&enc).expect("decrypt");
         assert_eq!(dec, msg.as_bytes());
@@ -232,7 +232,7 @@ fn replay_saldirisi_ayni_seq_ikinci_kez_rejected() {
     assert!(replay.is_err(), "replay reddedilmeli");
     // Hata türü sequence ile ilgili olmalı
     let err = replay.unwrap_err();
-    assert!(err.contains("sequence"), "sequence error: got '{}'", err);
+    assert!(err.contains("sequence"), "sequence error: got '{err}'");
 }
 
 /// Out-of-order: seq atlanırsa reject. Göndericiden 3 mesaj geliyor ama
@@ -282,7 +282,7 @@ fn tampered_hmac_reddedilir() {
     let r = b.decrypt(&enc);
     assert!(r.is_err(), "HMAC bozulmuşken reddedilmeli");
     let e = r.unwrap_err();
-    assert!(e.contains("HMAC"), "HMAC error beklenir: '{}'", e);
+    assert!(e.contains("HMAC"), "HMAC error beklenir: '{e}'");
 }
 
 /// Ciphertext tampering (HMAC'i yeniden hesaplamadan ciphertext'i değiştir):

--- a/crates/hekadrop-app/tests/ukey2_handshake.rs
+++ b/crates/hekadrop-app/tests/ukey2_handshake.rs
@@ -182,7 +182,7 @@ fn pin_code_her_zaman_4_basamak() {
     for key_seed in [0u8, 1, 42, 0xFF, 0x80, 0x7F] {
         let key = [key_seed; 32];
         let pin = pin_code_from_auth_key(&key);
-        assert_eq!(pin.len(), 4, "PIN her zaman 4 karakter olmalı: '{}'", pin);
+        assert_eq!(pin.len(), 4, "PIN her zaman 4 karakter olmalı: '{pin}'");
         assert!(pin.chars().all(|c| c.is_ascii_digit()), "PIN sadece digit");
     }
 }

--- a/crates/hekadrop-core/src/connection.rs
+++ b/crates/hekadrop-core/src/connection.rs
@@ -65,7 +65,7 @@ pub async fn handle(
     // `TransferGuard::new()` içinde auto clear_cancel — bu bağlantıya özel
     // child token hem taze root'a hem de scope sonunda active_transfers
     // map'inden otomatik temizliğe (early-return yollarında bile) garanti verir.
-    let guard = state::TransferGuard::new(Arc::clone(&state), format!("in:{}", peer));
+    let guard = state::TransferGuard::new(Arc::clone(&state), format!("in:{peer}"));
     let cancel = guard.token.clone();
 
     // 1) plain ConnectionRequest
@@ -839,7 +839,7 @@ async fn handle_sharing_frame(
                 );
                 ui.notify(UiNotification::ToastRaw {
                     title: "HekaDrop".to_string(),
-                    body: format!("{} artık güvenilir cihaz", remote_name),
+                    body: format!("{remote_name} artık güvenilir cihaz"),
                 });
             }
 
@@ -877,7 +877,7 @@ async fn handle_sharing_frame(
                 info!("[{}] ✗ kullanıcı reddetti", peer);
                 ui.notify(UiNotification::ToastRaw {
                     title: "HekaDrop".to_string(),
-                    body: format!("{}: aktarım reddedildi", remote_name),
+                    body: format!("{remote_name}: aktarım reddedildi"),
                 });
                 return Ok(FlowOutcome::Disconnect);
             }
@@ -958,7 +958,7 @@ fn preview(s: &str, max: usize) -> String {
         s.to_string()
     } else {
         let truncated: String = s.chars().take(max).collect();
-        format!("{}…", truncated)
+        format!("{truncated}…")
     }
 }
 
@@ -987,7 +987,7 @@ fn human_size(bytes: i64) -> String {
         i += 1;
     }
     if i == 0 {
-        format!("{} B", bytes)
+        format!("{bytes} B")
     } else {
         format!("{:.1} {}", n, UNITS[i])
     }
@@ -1029,7 +1029,7 @@ fn unique_downloads_path(name: &str, state: &AppState) -> Result<PathBuf> {
     match try_reserve(&candidate) {
         Ok(()) => return Ok(candidate),
         Err(e) if e.kind() != std::io::ErrorKind::AlreadyExists => {
-            return Err(anyhow!("dosya rezerve edilemedi: {}", e));
+            return Err(anyhow!("dosya rezerve edilemedi: {e}"));
         }
         Err(_) => {}
     }
@@ -1038,15 +1038,15 @@ fn unique_downloads_path(name: &str, state: &AppState) -> Result<PathBuf> {
     let mut n = 1;
     loop {
         let filename = if ext.is_empty() {
-            format!("{} ({})", stem, n)
+            format!("{stem} ({n})")
         } else {
-            format!("{} ({}).{}", stem, n, ext)
+            format!("{stem} ({n}).{ext}")
         };
         let next = base.join(filename);
         match try_reserve(&next) {
             Ok(()) => return Ok(next),
             Err(e) if e.kind() != std::io::ErrorKind::AlreadyExists => {
-                return Err(anyhow!("dosya rezerve edilemedi: {}", e));
+                return Err(anyhow!("dosya rezerve edilemedi: {e}"));
             }
             Err(_) => {}
         }
@@ -1124,7 +1124,7 @@ fn sanitize_received_name(name: &str) -> String {
         .iter()
         .any(|r| stem_for_reserved.eq_ignore_ascii_case(r))
     {
-        format!("_{}", cleaned)
+        format!("_{cleaned}")
     } else {
         cleaned
     };

--- a/crates/hekadrop-core/src/identity.rs
+++ b/crates/hekadrop-core/src/identity.rs
@@ -299,8 +299,7 @@ mod tests {
         let mode = meta.permissions().mode() & 0o777;
         assert_eq!(
             mode, 0o600,
-            "identity.key 0o600 olmalı, bulunan: 0o{:o}",
-            mode
+            "identity.key 0o600 olmalı, bulunan: 0o{mode:o}"
         );
         let _ = std::fs::remove_dir_all(path.parent().unwrap());
     }
@@ -315,8 +314,7 @@ mod tests {
         let err = format!("{:#}", res.err().unwrap());
         assert!(
             err.contains("bozuk") || err.contains("32 bayt"),
-            "hata mesajı bozukluğu belirtmeli: {}",
-            err
+            "hata mesajı bozukluğu belirtmeli: {err}"
         );
         let _ = std::fs::remove_dir_all(path.parent().unwrap());
     }

--- a/crates/hekadrop-core/src/log_redact.rs
+++ b/crates/hekadrop-core/src/log_redact.rs
@@ -57,7 +57,7 @@ pub fn url_scheme_host(url: &str) -> String {
     if host_port.is_empty() {
         return "<unparsable>".to_string();
     }
-    format!("{}://{}", scheme, host_port)
+    format!("{scheme}://{host_port}")
 }
 
 #[cfg(test)]

--- a/crates/hekadrop-core/src/payload.rs
+++ b/crates/hekadrop-core/src/payload.rs
@@ -256,8 +256,7 @@ impl PayloadAssembler {
             PayloadType::Bytes => self.ingest_bytes(id, body, last_chunk),
             PayloadType::File => self.ingest_file(id, total_size, body, last_chunk).await,
             other => Err(HekaError::ProtocolState(format!(
-                "desteklenmeyen payload tipi: {:?}",
-                other
+                "desteklenmeyen payload tipi: {other:?}"
             ))
             .into()),
         }
@@ -322,7 +321,7 @@ impl PayloadAssembler {
             let dest = self
                 .pending_destinations
                 .remove(&id)
-                .ok_or_else(|| anyhow!("payload_id={} için destination kayıtlı değil", id))?;
+                .ok_or_else(|| anyhow!("payload_id={id} için destination kayıtlı değil"))?;
             // SECURITY: `total_size` negatif ya da absürt büyükse en başta reddet.
             // Aksi halde `(written*100)/total` integer aritmetiği taşar ve
             // saldırgan terabaytlık disk doldurma isteği UI/progress yoluyla
@@ -384,7 +383,7 @@ impl PayloadAssembler {
             let sink = self
                 .file_sinks
                 .get_mut(&id)
-                .ok_or_else(|| anyhow!("file_sink kayıp: id={}", id))?;
+                .ok_or_else(|| anyhow!("file_sink kayıp: id={id}"))?;
             // SECURITY: Cumulative overrun koruması — saldırgan `total_size=10`
             // deklare edip gigabaytlarca chunk yollayarak disk doldurabilir.
             // usize → i64: pratikte body 4 MiB ile sınırlı (CHUNK_SIZE),
@@ -397,7 +396,7 @@ impl PayloadAssembler {
             let new_written = sink
                 .written
                 .checked_add(body_len)
-                .ok_or_else(|| HekaError::PayloadIo(format!("yazım toplamı taştı (id={})", id)))?;
+                .ok_or_else(|| HekaError::PayloadIo(format!("yazım toplamı taştı (id={id})")))?;
             if new_written > sink.total_size {
                 return Err(HekaError::PayloadOverrun {
                     id,
@@ -421,7 +420,7 @@ impl PayloadAssembler {
             let mut sink = self
                 .file_sinks
                 .remove(&id)
-                .ok_or_else(|| anyhow!("son chunk ama sink yok: id={}", id))?;
+                .ok_or_else(|| anyhow!("son chunk ama sink yok: id={id}"))?;
             // SECURITY: Peer `last_chunk=true` gönderip yarım dosyayı tamamlanmış
             // gibi onaylatabilir (silent truncation). Toplam byte sayısı
             // bildirilen total_size ile eşleşmezse reddet.
@@ -541,7 +540,7 @@ mod tests {
                 assert_eq!(id, 42);
                 assert_eq!(data, b"hello");
             }
-            other => panic!("beklenen Bytes, {:?} geldi", other),
+            other => panic!("beklenen Bytes, {other:?} geldi"),
         }
         assert_eq!(a.partial_count(), 0, "tamamlanan bytes temizlenmeli");
     }
@@ -555,7 +554,7 @@ mod tests {
         let done = a.ingest(&f2).await.unwrap().expect("last chunk tamamlar");
         match done {
             CompletedPayload::Bytes { data, .. } => assert_eq!(data, b"foobar"),
-            other => panic!("{:?}", other),
+            other => panic!("{other:?}"),
         }
     }
 
@@ -656,7 +655,7 @@ mod tests {
     async fn cancel_removes_bytes_file_and_pending() {
         let pid = std::process::id();
         let rnd: u32 = rand::random();
-        let tmp = std::env::temp_dir().join(format!("hekadrop-cancel-test-{}-{}.part", pid, rnd));
+        let tmp = std::env::temp_dir().join(format!("hekadrop-cancel-test-{pid}-{rnd}.part"));
         let _ = std::fs::remove_file(&tmp);
         let mut a = PayloadAssembler::new();
 
@@ -671,8 +670,7 @@ mod tests {
             .unwrap();
         assert!(tmp.exists());
         // pending destination — review-18 MED: cancel artık placeholder'ı da silmeli.
-        let tmp2 =
-            std::env::temp_dir().join(format!("hekadrop-cancel-pending-{}-{}.part", pid, rnd));
+        let tmp2 = std::env::temp_dir().join(format!("hekadrop-cancel-pending-{pid}-{rnd}.part"));
         // Diskte sıfır bayt placeholder simulate et (unique_downloads_path davranışı).
         std::fs::write(&tmp2, b"").expect("placeholder yarat");
         a.register_file_destination(3, tmp2.clone()).unwrap();
@@ -699,8 +697,8 @@ mod tests {
         // reddetmelidir.
         let pid = std::process::id();
         let rnd: u32 = rand::random();
-        let real = std::env::temp_dir().join(format!("hekadrop-symlink-real-{}-{}.bin", pid, rnd));
-        let link = std::env::temp_dir().join(format!("hekadrop-symlink-link-{}-{}.bin", pid, rnd));
+        let real = std::env::temp_dir().join(format!("hekadrop-symlink-real-{pid}-{rnd}.bin"));
+        let link = std::env::temp_dir().join(format!("hekadrop-symlink-link-{pid}-{rnd}.bin"));
         let _ = std::fs::remove_file(&real);
         let _ = std::fs::remove_file(&link);
         std::fs::write(&real, b"").expect("real yarat");
@@ -714,8 +712,7 @@ mod tests {
             .expect_err("symlink hedef reddedilmeli");
         assert!(
             err.to_string().contains("symlink"),
-            "hata mesajı symlink belirtmeli, aldı: {}",
-            err
+            "hata mesajı symlink belirtmeli, aldı: {err}"
         );
 
         let _ = std::fs::remove_file(&link);
@@ -727,7 +724,7 @@ mod tests {
         // review-18: 1 TiB üstü bildirilen dosya başlamadan reddedilmeli.
         let pid = std::process::id();
         let rnd: u32 = rand::random();
-        let tmp = std::env::temp_dir().join(format!("hekadrop-absurd-{}-{}.bin", pid, rnd));
+        let tmp = std::env::temp_dir().join(format!("hekadrop-absurd-{pid}-{rnd}.bin"));
         let _ = std::fs::remove_file(&tmp);
         std::fs::write(&tmp, b"").expect("placeholder");
 
@@ -746,8 +743,7 @@ mod tests {
             .expect_err("absurd total_size reddedilmeli");
         assert!(
             err.to_string().contains("absürt") || err.to_string().contains("1 TiB"),
-            "hata mesajı limit belirtmeli, aldı: {}",
-            err
+            "hata mesajı limit belirtmeli, aldı: {err}"
         );
         let _ = std::fs::remove_file(&tmp);
     }
@@ -799,7 +795,7 @@ mod tests {
                 };
                 assert_eq!(sha256, expected);
             }
-            other => panic!("beklenen File, {:?} geldi", other),
+            other => panic!("beklenen File, {other:?} geldi"),
         }
         // Dosyayı oku ve içeriğini doğrula.
         let content = std::fs::read(&tmp).unwrap();

--- a/crates/hekadrop-core/src/secure.rs
+++ b/crates/hekadrop-core/src/secure.rs
@@ -126,7 +126,7 @@ impl SecureCtx {
         iv.copy_from_slice(&iv_vec);
 
         let plaintext = crypto::aes256_cbc_decrypt(&self.decrypt_key, &iv, &hb.body)
-            .map_err(|e| anyhow!("AES decrypt: {:?}", e))?;
+            .map_err(|e| anyhow!("AES decrypt: {e:?}"))?;
 
         let d2d = DeviceToDeviceMessage::decode(&plaintext[..])?;
         let seq = d2d
@@ -183,7 +183,7 @@ mod tests {
     fn sequence_number_artar() {
         let (mut a, mut b) = make_pair();
         for i in 1..=5 {
-            let msg = format!("mesaj {}", i);
+            let msg = format!("mesaj {i}");
             let enc = a.encrypt(msg.as_bytes()).unwrap();
             let dec = b.decrypt(&enc).expect("decrypt");
             assert_eq!(dec.as_ref(), msg.as_bytes());

--- a/crates/hekadrop-core/src/sender.rs
+++ b/crates/hekadrop-core/src/sender.rs
@@ -735,13 +735,13 @@ async fn send_text_bytes(
         let body = data[offset..end].to_vec();
         let last_flag = 0;
         let offset_i64 = i64::try_from(offset)
-            .with_context(|| format!("metin payload offset'i çok büyük: {}", offset))?;
+            .with_context(|| format!("metin payload offset'i çok büyük: {offset}"))?;
         let wrapped = wrap_bytes_payload_transfer(payload_id, total, offset_i64, last_flag, body);
         let enc = ctx.encrypt(&wrapped.encode_to_vec())?;
         frame::write_frame(socket, &enc).await?;
         offset = end;
         let offset_i64 = i64::try_from(offset)
-            .with_context(|| format!("metin payload offset'i çok büyük: {}", offset))?;
+            .with_context(|| format!("metin payload offset'i çok büyük: {offset}"))?;
         if let Some(percent) = compute_percent(0, offset_i64, total) {
             state.set_progress(ProgressState::Receiving {
                 device: peer_label.to_string(),

--- a/crates/hekadrop-core/src/settings.rs
+++ b/crates/hekadrop-core/src/settings.rs
@@ -162,7 +162,7 @@ mod hex_hash_opt {
             return Ok(None);
         };
         let bytes = hex::decode(&raw)
-            .map_err(|e| D::Error::custom(format!("secret_id_hash hex decode: {}", e)))?;
+            .map_err(|e| D::Error::custom(format!("secret_id_hash hex decode: {e}")))?;
         if bytes.len() != 6 {
             return Err(D::Error::custom(format!(
                 "secret_id_hash 6 bayt bekleniyor, bulunan {}",
@@ -624,7 +624,7 @@ static DEBOUNCE_TASK: parking_lot::Mutex<Option<tokio::task::JoinHandle<()>>> =
 pub fn validate_download_dir(path: &Path) -> Result<()> {
     let meta = std::fs::metadata(path).map_err(|e| HekaError::DownloadDirInvalid {
         path: path.display().to_string(),
-        reason: format!("okunamadı: {}", e),
+        reason: format!("okunamadı: {e}"),
     })?;
     if !meta.is_dir() {
         return Err(HekaError::DownloadDirInvalid {
@@ -641,7 +641,7 @@ pub fn validate_download_dir(path: &Path) -> Result<()> {
         }
         Err(e) => Err(HekaError::DownloadDirInvalid {
             path: path.display().to_string(),
-            reason: format!("yazılabilir değil: {}", e),
+            reason: format!("yazılabilir değil: {e}"),
         }
         .into()),
     }
@@ -782,7 +782,7 @@ pub(crate) fn atomic_write_mode(
     let (mut file, tmp_path) = loop {
         attempts += 1;
         let r = rand::thread_rng().next_u64();
-        let tmp = parent.join(format!(".{}.{}.{:016x}.tmp", file_name, pid, r));
+        let tmp = parent.join(format!(".{file_name}.{pid}.{r:016x}.tmp"));
         let mut opts = std::fs::OpenOptions::new();
         opts.write(true).create_new(true);
         #[cfg(unix)]
@@ -838,8 +838,7 @@ pub(crate) fn migrate_trusted_value(v: serde_json::Value) -> Result<Vec<TrustedD
         serde_json::Value::Array(a) => a,
         other => {
             return Err(format!(
-                "trusted_devices array bekleniyordu, geldi: {:?}",
-                other
+                "trusted_devices array bekleniyordu, geldi: {other:?}"
             ))
         }
     };
@@ -859,15 +858,14 @@ pub(crate) fn migrate_trusted_value(v: serde_json::Value) -> Result<Vec<TrustedD
             }
             serde_json::Value::Object(_) => {
                 let td: TrustedDevice = serde_json::from_value(item)
-                    .map_err(|e| format!("TrustedDevice parse: {}", e))?;
+                    .map_err(|e| format!("TrustedDevice parse: {e}"))?;
                 if !td.name.is_empty() {
                     out.push(td);
                 }
             }
             other => {
                 return Err(format!(
-                    "trusted_devices elemanı beklenmeyen tip: {:?}",
-                    other
+                    "trusted_devices elemanı beklenmeyen tip: {other:?}"
                 ))
             }
         }
@@ -1088,7 +1086,7 @@ mod tests {
         use std::thread;
         let mut s = Settings::default();
         for i in 0..50 {
-            s.add_trusted(&format!("dev-{}", i), &format!("id-{}", i));
+            s.add_trusted(&format!("dev-{i}"), &format!("id-{i}"));
         }
         let arc = Arc::new(s);
         let handles: Vec<_> = (0..8)
@@ -1320,8 +1318,7 @@ mod tests {
         // Hex string'in JSON'da göründüğünü doğrula.
         assert!(
             json.contains("\"deadbeef0042\""),
-            "beklenen hex yok: {}",
-            json
+            "beklenen hex yok: {json}"
         );
         let back: Settings = serde_json::from_str(&json).expect("parse");
         assert_eq!(back.trusted_devices[0].secret_id_hash, Some(hash));
@@ -1532,7 +1529,7 @@ mod tests {
             ..Settings::default()
         };
         let json = serde_json::to_string(&s).expect("serialize");
-        assert!(json.contains("\"warn\""), "lowercase beklenir: {}", json);
+        assert!(json.contains("\"warn\""), "lowercase beklenir: {json}");
     }
 
     #[test]
@@ -1669,8 +1666,7 @@ mod tests {
         assert!(
             owner_bits <= 0o600,
             "owner bitleri 0o600'den fazla olmamalı (mode(0o600) umask'i gevşetmez): \
-             0o{:o}",
-            owner_bits
+             0o{owner_bits:o}"
         );
         let _ = std::fs::remove_dir_all(&dir);
     }
@@ -1752,7 +1748,7 @@ mod tests {
             .map(|i| {
                 let t = Arc::clone(&target);
                 thread::spawn(move || {
-                    let payload = format!("thread-{}", i);
+                    let payload = format!("thread-{i}");
                     for _ in 0..16 {
                         atomic_write(&t, payload.as_bytes()).expect("atomic_write ok");
                     }

--- a/crates/hekadrop-core/src/ukey2.rs
+++ b/crates/hekadrop-core/src/ukey2.rs
@@ -138,7 +138,7 @@ pub async fn client_handshake(socket: &mut TcpStream) -> Result<DerivedKeys> {
     uncompressed.extend_from_slice(&peer_x);
     uncompressed.extend_from_slice(&peer_y);
     let encoded =
-        EncodedPoint::from_bytes(&uncompressed).map_err(|e| anyhow!("peer pubkey parse: {}", e))?;
+        EncodedPoint::from_bytes(&uncompressed).map_err(|e| anyhow!("peer pubkey parse: {e}"))?;
     let peer_pk = PublicKey::from_encoded_point(&encoded);
     let peer_pk = Option::<PublicKey>::from(peer_pk)
         .ok_or_else(|| anyhow!("peer pubkey geçersiz eğri noktası"))?;
@@ -249,8 +249,7 @@ pub fn process_client_init(client_init_frame: &[u8]) -> Result<ServerInitResult>
     // 2 = CLIENT_INIT
     if message_type != 2 {
         return Err(HekaError::ProtocolState(format!(
-            "beklenen CLIENT_INIT, alınan {}",
-            message_type
+            "beklenen CLIENT_INIT, alınan {message_type}"
         ))
         .into());
     }
@@ -271,7 +270,7 @@ pub fn process_client_init(client_init_frame: &[u8]) -> Result<ServerInitResult>
     let next_protocol = ci.next_protocol();
     if next_protocol != "AES_256_CBC-HMAC_SHA256" {
         return Err(
-            HekaError::Ukey2(format!("desteklenmeyen next_protocol: {}", next_protocol)).into(),
+            HekaError::Ukey2(format!("desteklenmeyen next_protocol: {next_protocol}")).into(),
         );
     }
 
@@ -389,8 +388,7 @@ pub fn process_client_finish(raw_frame: &[u8], state: &ServerInitResult) -> Resu
         .ok_or_else(|| HekaError::Protocol("mesaj verisi yok".into()))?;
     if message_type != 4 {
         return Err(HekaError::ProtocolState(format!(
-            "beklenen CLIENT_FINISH, alınan {}",
-            message_type
+            "beklenen CLIENT_FINISH, alınan {message_type}"
         ))
         .into());
     }
@@ -424,7 +422,7 @@ pub fn process_client_finish(raw_frame: &[u8], state: &ServerInitResult) -> Resu
     uncompressed.extend_from_slice(&peer_x);
     uncompressed.extend_from_slice(&peer_y);
     let encoded =
-        EncodedPoint::from_bytes(&uncompressed).map_err(|e| anyhow!("peer pubkey parse: {}", e))?;
+        EncodedPoint::from_bytes(&uncompressed).map_err(|e| anyhow!("peer pubkey parse: {e}"))?;
     let peer_pk = PublicKey::from_encoded_point(&encoded);
     let peer_pk = Option::<PublicKey>::from(peer_pk)
         .ok_or_else(|| anyhow!("peer pubkey geçersiz eğri noktası"))?;

--- a/crates/hekadrop-net/src/mdns.rs
+++ b/crates/hekadrop-net/src/mdns.rs
@@ -68,7 +68,7 @@ pub fn advertise(device_name: &str, port: u16) -> Result<Option<MdnsHandle>> {
     let info = ServiceInfo::new(
         &service_type,
         &instance,
-        &format!("{}.local.", instance),
+        &format!("{instance}.local."),
         &addrs[..],
         port,
         &[("n", endpoint_info_b64.as_str())][..],

--- a/crates/hekadrop-proto/build.rs
+++ b/crates/hekadrop-proto/build.rs
@@ -17,7 +17,7 @@ fn main() -> Result<()> {
     ];
 
     for p in &protos {
-        println!("cargo:rerun-if-changed={}", p);
+        println!("cargo:rerun-if-changed={p}");
     }
     println!("cargo:rerun-if-changed=build.rs");
 


### PR DESCRIPTION
## Özet

PR #87 deferred strictness sweep listesinden bir madde: \`clippy::uninlined_format_args\`. PR #87'de auto-fix uygulanmıştı ama lint **enable edilmemişti**, dolayısıyla v0.7 boyunca 110 yeni site birikmişti. Bu PR auto-fix'i tekrar uygular + workspace.lints'e ekler.

## Değişim

* \`cargo clippy --fix --workspace --all-targets --all-features -- -W clippy::uninlined_format_args\` → **110 site otomatik düzeltildi** (\`format!("{}", x)\` → \`format!("{x}")\`)
* Root \`Cargo.toml\` \`[workspace.lints.clippy]\`:
  \`\`\`toml
  uninlined_format_args = "warn"
  \`\`\`
* 23 dosya etkilendi (proto build.rs dahil), **109 eklemeler / 139 silme** — net küçülme, daha okunaklı format string'ler

## CLAUDE.md pre-commit invariant scan

| Kontrol | Sonuç |
|---|---|
| Standard checks (clippy/test/fmt/machete/typos) | ✓ |
| I-1 (core'da app modül) | değişiklik yok ✓ |
| I-2 (yeni allow) | yok ✓ |
| I-3 (map_err pattern) | değişmedi ✓ |
| 27 test suite davranış parity | ✓ |

## Test plan

- [x] cargo build/clippy/test --workspace
- [x] cargo fmt --all -- --check
- [x] cargo machete --with-metadata
- [x] typos
- [ ] CI matrix (mac/Linux/Windows + extra-lints)

## PR #87 deferred listesi durumu

| Lint | Hit | Durum |
|---|---|---|
| \`uninlined_format_args\` | 110 | ✓ **bu PR** |
| \`cast_possible_wrap\` | 36 | ✓ #101 (diğer AI) |
| \`unreachable_pub\` | 349 | sırada (sonraki PR) |
| \`clippy::pedantic\` umbrella | ~1,228 | modular yapılacak |
| \`clippy::doc_markdown\` | 445+792 | sonra |
| \`must_use_candidate\` | 71 | annotation pass |
| \`match_same_arms\`, \`items_after_statements\`, vb. | <100 each | sonra |

🤖 Generated with [Claude Code](https://claude.com/claude-code)