### PR TITLE
chore(lint): unreachable_pub cleanup (58 hit) + enforce

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,12 +20,14 @@ homepage = "https://github.com/YatogamiRaito/HekaDrop"
 # Kapsam dışı bırakılanlar (RED-tier — ayrı tracking issue'larla cleanup):
 #   * clippy::pedantic umbrella (~1,228 hit)        — issue #TBD
 #   * clippy::doc_markdown (445 hand + 792 gen)     — issue #TBD
-#   * unreachable_pub (349)                         — issue #TBD
-#   * clippy::uninlined_format_args (225)           — bu PR'da --fix uygulandı
 #   * clippy::must_use_candidate (71 hand)          — issue #TBD
 #   * clippy::match_same_arms (68)                  — issue #TBD
-#   * clippy::cast_possible_wrap (36, security)     — issue #TBD (audit gerekiyor)
 #   * unused_crate_dependencies                     — false-pos cascade, atlandı
+#
+# v0.7.x ile enforce edilenler (önceki "RED" listesinden):
+#   * clippy::cast_possible_wrap (36)               — PR #101 audit + enforce
+#   * clippy::uninlined_format_args (auto-fix +110) — PR #105 enforce
+#   * unreachable_pub (workspace refactor sonrası 58 hit) — bu PR cleanup + enforce
 #
 # Konsensus referans: Embark, uv, ruff. Top-tier (tokio/ripgrep/rustls/hyper)
 # minimal config tercih ediyor; biz crypto/protocol surface taşıyan bir desktop
@@ -37,6 +39,11 @@ trivial_numeric_casts = "warn"
 single_use_lifetimes = "warn"
 unused_lifetimes = "warn"
 unused_macro_rules = "warn"
+# Public API hijyeni — pub item bir tüketici tarafından erişilemiyorsa
+# pub(crate)'e dönmeli. Workspace refactor (Adım 5) sonrası app→core
+# split ile çoğu mu eski-pub items pub(crate) olabilir hâle geldi.
+# PR #87'de 349 hit'tən refactor sonrası 58'e düştü; cleanup + enforce.
+unreachable_pub = "warn"
 
 [workspace.lints.clippy]
 # Ship-blocker'lar — production'a sızmamalı

--- a/crates/hekadrop-app/src/i18n.rs
+++ b/crates/hekadrop-app/src/i18n.rs
@@ -27,7 +27,7 @@
 use std::sync::OnceLock;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Lang {
+pub(crate) enum Lang {
     Tr,
     En,
 }
@@ -35,7 +35,7 @@ pub enum Lang {
 static LANG: OnceLock<Lang> = OnceLock::new();
 
 /// Uygulamanın kullanacağı dili döner. İlk çağrıda detect edilir ve cache'lenir.
-pub fn current() -> Lang {
+pub(crate) fn current() -> Lang {
     *LANG.get_or_init(detect)
 }
 
@@ -70,7 +70,7 @@ fn parse_lang(raw: &str) -> Option<Lang> {
 /// `key` `&'static str` — çağrı siteleri literal olduğundan (`t("tray.xxx")`)
 /// bu kısıt sorun değil ve fallback olarak key'i dönmeyi güvenli kılar.
 /// Eksik çeviri varsa UI'da key string'i görünür, dev fark eder.
-pub fn t(key: &'static str) -> &'static str {
+pub(crate) fn t(key: &'static str) -> &'static str {
     let lang = current();
     match lang {
         Lang::Tr => lookup_tr(key).or_else(|| lookup_en(key)).unwrap_or(key),
@@ -88,7 +88,7 @@ pub fn t(key: &'static str) -> &'static str {
 ///
 /// Placeholder olmayan `{` karakterleri literal bırakılır (kullanıcıya
 /// gösterilen metinde `{X}` geçmesi tipik değil ama güvenli).
-pub fn tf(key: &'static str, args: &[&str]) -> String {
+pub(crate) fn tf(key: &'static str, args: &[&str]) -> String {
     apply_args(t(key), args)
 }
 

--- a/crates/hekadrop-app/src/paths.rs
+++ b/crates/hekadrop-app/src/paths.rs
@@ -14,6 +14,6 @@ pub(crate) fn stats_path() -> PathBuf {
     crate::platform::config_dir().join("stats.json")
 }
 
-pub fn config_path() -> PathBuf {
+pub(crate) fn config_path() -> PathBuf {
     crate::platform::config_dir().join("config.json")
 }

--- a/crates/hekadrop-app/src/platform.rs
+++ b/crates/hekadrop-app/src/platform.rs
@@ -37,7 +37,7 @@ fn home_dir() -> PathBuf {
 /// - macOS: `~/Library/Application Support/HekaDrop`
 /// - Linux: `$XDG_CONFIG_HOME/HekaDrop` → `~/.config/HekaDrop`
 /// - Windows: `FOLDERID_RoamingAppData\HekaDrop` (genelde `%APPDATA%\HekaDrop`)
-pub fn config_dir() -> PathBuf {
+pub(crate) fn config_dir() -> PathBuf {
     #[cfg(target_os = "macos")]
     {
         home_dir().join("Library/Application Support/HekaDrop")
@@ -62,7 +62,7 @@ pub fn config_dir() -> PathBuf {
 /// - macOS: `~/Library/Logs/HekaDrop`
 /// - Linux: `$XDG_STATE_HOME/HekaDrop/logs` → `~/.local/state/HekaDrop/logs`
 /// - Windows: `FOLDERID_LocalAppData\HekaDrop\logs` — log'lar roam etmesin.
-pub fn logs_dir() -> PathBuf {
+pub(crate) fn logs_dir() -> PathBuf {
     #[cfg(target_os = "macos")]
     {
         home_dir().join("Library/Logs/HekaDrop")
@@ -88,7 +88,7 @@ pub fn logs_dir() -> PathBuf {
 /// - macOS: `$HOME/Downloads`
 /// - Windows: `FOLDERID_Downloads` (kullanıcının özel konuma taşımış olması
 ///   durumunda da doğru yolu döner)
-pub fn default_download_dir() -> PathBuf {
+pub(crate) fn default_download_dir() -> PathBuf {
     #[cfg(target_os = "linux")]
     {
         if let Ok(out) = Command::new("xdg-user-dir").arg("DOWNLOAD").output() {
@@ -117,7 +117,7 @@ pub fn default_download_dir() -> PathBuf {
 /// - Linux: `/etc/hostname` → `hostname` komutu → fallback "HekaDrop Linux"
 /// - Windows: `GetComputerNameExW(ComputerNameDnsHostname)` → fallback
 ///   `%COMPUTERNAME%` → "HekaDrop PC"
-pub fn device_name() -> String {
+pub(crate) fn device_name() -> String {
     if let Ok(v) = std::env::var("HEKADROP_NAME") {
         if !v.is_empty() {
             return v;
@@ -175,7 +175,7 @@ pub fn device_name() -> String {
 }
 
 /// Verilen dosyayı/dizini işletim sisteminin varsayılan programıyla açar.
-pub fn open_path(path: &Path) {
+pub(crate) fn open_path(path: &Path) {
     #[cfg(target_os = "macos")]
     {
         let _ = Command::new("open").arg(path).spawn();
@@ -191,7 +191,7 @@ pub fn open_path(path: &Path) {
 }
 
 /// Dosyayı dosya yöneticisinde (Finder / Nautilus / Explorer) seçili olarak gösterir.
-pub fn reveal_path(path: &Path) {
+pub(crate) fn reveal_path(path: &Path) {
     #[cfg(target_os = "macos")]
     {
         let _ = Command::new("open").arg("-R").arg(path).spawn();
@@ -301,7 +301,7 @@ mod tests {
 }
 
 /// URL'i tarayıcıda açar.
-pub fn open_url(url: &str) {
+pub(crate) fn open_url(url: &str) {
     #[cfg(target_os = "macos")]
     {
         let _ = Command::new("open").arg(url).spawn();
@@ -321,7 +321,7 @@ pub fn open_url(url: &str) {
 /// - macOS: `pbpaste`
 /// - Linux: Wayland (`wl-paste`) → X11 (`xclip` → `xsel`) sırayla
 /// - Windows: `GetClipboardData(CF_UNICODETEXT)` — UTF-16 → UTF-8 lossy
-pub fn paste_from_clipboard() -> Option<String> {
+pub(crate) fn paste_from_clipboard() -> Option<String> {
     #[cfg(target_os = "windows")]
     {
         win::clipboard_get().ok().flatten()
@@ -364,7 +364,7 @@ pub fn paste_from_clipboard() -> Option<String> {
 /// - Linux: Wayland (`wl-copy`) → X11 (`xclip` → `xsel`) sırayla
 /// - Windows: `OpenClipboard` + `SetClipboardData(CF_UNICODETEXT)` — UTF-16 LE,
 ///   `clip.exe`'nin ANSI-yorumu yüzünden Türkçe/non-ASCII bozulmasın
-pub fn copy_to_clipboard(text: &str) {
+pub(crate) fn copy_to_clipboard(text: &str) {
     #[cfg(target_os = "windows")]
     {
         if win::clipboard_set(text).is_err() {

--- a/crates/hekadrop-app/src/state.rs
+++ b/crates/hekadrop-app/src/state.rs
@@ -17,7 +17,7 @@
 // kasıtlı API genişliği — bin'de doğrudan referans yok ama integration
 // test'leri ve gelecekteki UI tab'ları için açık tutuluyor.
 #[allow(unused_imports)]
-pub use hekadrop_core::state::{
+pub(crate) use hekadrop_core::state::{
     AppState, HistoryItem, ProgressState, RateLimiter, TransferGuard, DEFAULT_COMPLETED_IDLE_DELAY,
 };
 
@@ -26,7 +26,7 @@ use std::sync::{Arc, OnceLock};
 
 static STATE: OnceLock<Arc<AppState>> = OnceLock::new();
 
-pub fn init(settings: Settings) {
+pub(crate) fn init(settings: Settings) {
     // App-singleton katmanı path'leri ve platform default'larını inject
     // ediyor — `AppState::new` core'da global'siz çalışır. Path resolution
     // `crate::paths` (`crate::platform::config_dir()` üstünde) sorumluluğu;
@@ -42,7 +42,7 @@ pub fn init(settings: Settings) {
     ));
 }
 
-pub fn get() -> Arc<AppState> {
+pub(crate) fn get() -> Arc<AppState> {
     // INVARIANT: `init()` her zaman `main`'in ilk işlerinden — `get()`
     // öncesinde çağrılması garanti. Aksi durum programlama hatası, panik
     // yerine sessiz default state üretmek bug'ı maskeler.
@@ -59,51 +59,51 @@ pub fn get() -> Arc<AppState> {
 // (artık core'da) doğrudan `Arc<AppState>` parametresi alıyor — singleton
 // lookup yok.
 
-pub fn enqueue_js(js: String) {
+pub(crate) fn enqueue_js(js: String) {
     get().enqueue_js(js);
 }
 
-pub fn drain_js() -> Vec<String> {
+pub(crate) fn drain_js() -> Vec<String> {
     get().drain_js()
 }
 
-pub fn request_hide_window() {
+pub(crate) fn request_hide_window() {
     get().request_hide_window();
 }
 
-pub fn request_show_window() {
+pub(crate) fn request_show_window() {
     get().request_show_window();
 }
 
-pub fn consume_hide_window() -> bool {
+pub(crate) fn consume_hide_window() -> bool {
     get().consume_hide_window()
 }
 
-pub fn consume_show_window() -> bool {
+pub(crate) fn consume_show_window() -> bool {
     get().consume_show_window()
 }
 
-pub fn request_cancel(id: Option<&str>) {
+pub(crate) fn request_cancel(id: Option<&str>) {
     get().request_cancel(id);
 }
 
 /// Legacy kompat: tray menüsündeki "İptal" "hepsini iptal et" anlamındaydı.
-pub fn request_cancel_all() {
+pub(crate) fn request_cancel_all() {
     request_cancel(None);
 }
 
-pub fn set_listen_port(p: u16) {
+pub(crate) fn set_listen_port(p: u16) {
     get().set_listen_port(p);
 }
 
-pub fn listen_port() -> u16 {
+pub(crate) fn listen_port() -> u16 {
     get().listen_port()
 }
 
-pub fn read_history() -> Vec<HistoryItem> {
+pub(crate) fn read_history() -> Vec<HistoryItem> {
     get().read_history()
 }
 
-pub fn read_progress() -> ProgressState {
+pub(crate) fn read_progress() -> ProgressState {
     get().read_progress()
 }

--- a/crates/hekadrop-app/src/ui.rs
+++ b/crates/hekadrop-app/src/ui.rs
@@ -18,13 +18,13 @@ use tokio::task;
 #[allow(unused_imports)]
 use std::path::PathBuf;
 
-pub struct FileSummary {
+pub(crate) struct FileSummary {
     pub name: String,
     pub size: i64,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum AcceptResult {
+pub(crate) enum AcceptResult {
     Reject,
     Accept,
     AcceptAndTrust,
@@ -34,7 +34,7 @@ pub enum AcceptResult {
 ///   - Reddet
 ///   - Kabul et
 ///   - Kabul + güven (device_name ileride otomatik kabul edilir)
-pub async fn prompt_accept(
+pub(crate) async fn prompt_accept(
     device_name: &str,
     pin_code: &str,
     files: &[FileSummary],
@@ -348,7 +348,7 @@ fn prompt_accept_blocking(
 /// butona bastığında dosya `xdg-open` ile, klasör ise file-manager ile açılır.
 /// macOS'ta aksiyon butonu desteklenmez — düz bildirim + tıklanınca Finder'da
 /// açma için fallback uygulanır (bkz. `NotificationCenter` gelecek iş).
-pub fn notify_file_received(title: &str, body: &str, path: std::path::PathBuf) {
+pub(crate) fn notify_file_received(title: &str, body: &str, path: std::path::PathBuf) {
     #[cfg(target_os = "macos")]
     {
         let _ = path; // macOS'ta aksiyon butonlu notify henüz yok.
@@ -428,7 +428,7 @@ pub fn notify_file_received(title: &str, body: &str, path: std::path::PathBuf) {
 }
 
 /// Kısa bildirim. Başarı/hata mesajları için.
-pub fn notify(title: &str, body: &str) {
+pub(crate) fn notify(title: &str, body: &str) {
     #[cfg(target_os = "macos")]
     {
         let script = format!(
@@ -473,7 +473,7 @@ pub fn notify(title: &str, body: &str) {
 ///
 /// Dialog aracı yoksa (headless) sadece log'a yazılır — zaten log dosyası
 /// da açılamamış olabilir, ama `tracing` stdout layer'ı çalışmaya devam eder.
-pub fn fatal_error_dialog(title: &str, body: &str) {
+pub(crate) fn fatal_error_dialog(title: &str, body: &str) {
     tracing::error!("fatal: {} — {}", title, body);
     #[cfg(target_os = "macos")]
     {
@@ -537,7 +537,7 @@ pub fn fatal_error_dialog(title: &str, body: &str) {
 }
 
 /// Bilgi diyaloğu (blocking değil, fire-and-forget).
-pub fn show_info(title: &str, body: &str) {
+pub(crate) fn show_info(title: &str, body: &str) {
     #[cfg(target_os = "macos")]
     {
         let script = format!(
@@ -603,12 +603,12 @@ pub fn show_info(title: &str, body: &str) {
 
 /// `choose file` dialog → seçilen dosyanın tam yolu veya None (tek dosya).
 #[allow(dead_code)]
-pub async fn choose_file() -> Option<std::path::PathBuf> {
+pub(crate) async fn choose_file() -> Option<std::path::PathBuf> {
     choose_files().await.and_then(|mut v| v.pop())
 }
 
 /// Çoklu dosya seçim dialog'u → seçilen tüm path'lerin listesi.
-pub async fn choose_files() -> Option<Vec<std::path::PathBuf>> {
+pub(crate) async fn choose_files() -> Option<Vec<std::path::PathBuf>> {
     task::spawn_blocking(choose_files_blocking)
         .await
         .ok()
@@ -751,7 +751,7 @@ fn choose_files_blocking() -> Option<Vec<std::path::PathBuf>> {
 }
 
 /// `choose folder` dialog → seçilen klasörün path'i.
-pub async fn choose_folder() -> Option<std::path::PathBuf> {
+pub(crate) async fn choose_folder() -> Option<std::path::PathBuf> {
     task::spawn_blocking(choose_folder_blocking)
         .await
         .ok()
@@ -861,7 +861,7 @@ fn choose_folder_blocking() -> Option<std::path::PathBuf> {
 }
 
 /// Listeden cihaz seçim dialog'u. `labels` içindeki etiket indeks'i döner.
-pub async fn choose_device(labels: Vec<String>) -> Option<usize> {
+pub(crate) async fn choose_device(labels: Vec<String>) -> Option<usize> {
     if labels.is_empty() {
         return None;
     }
@@ -1038,7 +1038,7 @@ fn choose_device_blocking(labels: &[String]) -> Option<String> {
 /// Dosya keşif sırasında basit bir ilerleme/bildirim dialog'u olmadığı için
 /// notify kullanıyoruz.
 #[allow(dead_code)]
-pub fn send_progress_notify(device: &str, file: &str) {
+pub(crate) fn send_progress_notify(device: &str, file: &str) {
     notify("HekaDrop", &format!("Gönderiliyor: {} → {}", file, device));
 }
 

--- a/crates/hekadrop-app/src/ui_adapter.rs
+++ b/crates/hekadrop-app/src/ui_adapter.rs
@@ -20,10 +20,10 @@ use hekadrop_core::ui_port::{AcceptDecision, FileSummary, UiNotification, UiPort
 /// platform::open_url` / `crate::platform::copy_to_clipboard`'ı sarar.
 /// Connection core'a taşındıktan sonra `Arc<dyn PlatformOps>` olarak
 /// `accept_loop`'a geçirilir; core'da `crate::platform` referansı olmaz.
-pub struct PlatformAdapter;
+pub(crate) struct PlatformAdapter;
 
 impl PlatformAdapter {
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self
     }
 }
@@ -44,10 +44,10 @@ impl hekadrop_core::connection::PlatformOps for PlatformAdapter {
     }
 }
 
-pub struct UiAdapter;
+pub(crate) struct UiAdapter;
 
 impl UiAdapter {
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self
     }
 }

--- a/crates/hekadrop-app/tests/common/mod.rs
+++ b/crates/hekadrop-app/tests/common/mod.rs
@@ -21,7 +21,7 @@ use hmac::{Hmac, Mac};
 use sha2::Sha256;
 
 /// HKDF-SHA256 → HekaDrop `crypto::hkdf_sha256` ile birebir aynı davranış.
-pub fn hkdf_sha256(ikm: &[u8], salt: &[u8], info: &[u8], len: usize) -> Vec<u8> {
+pub(crate) fn hkdf_sha256(ikm: &[u8], salt: &[u8], info: &[u8], len: usize) -> Vec<u8> {
     let hk = hkdf::Hkdf::<Sha256>::new(Some(salt), ikm);
     let mut out = vec![0u8; len];
     hk.expand(info, &mut out).expect("HKDF expand");
@@ -29,7 +29,7 @@ pub fn hkdf_sha256(ikm: &[u8], salt: &[u8], info: &[u8], len: usize) -> Vec<u8> 
 }
 
 /// SHA256 tek seferlik.
-pub fn sha256(data: &[u8]) -> [u8; 32] {
+pub(crate) fn sha256(data: &[u8]) -> [u8; 32] {
     use sha2::Digest;
     let mut h = Sha256::new();
     h.update(data);
@@ -39,7 +39,7 @@ pub fn sha256(data: &[u8]) -> [u8; 32] {
     a
 }
 
-pub fn hmac_sha256(key: &[u8], data: &[u8]) -> [u8; 32] {
+pub(crate) fn hmac_sha256(key: &[u8], data: &[u8]) -> [u8; 32] {
     let mut mac = Hmac::<Sha256>::new_from_slice(key).expect("HMAC key");
     mac.update(data);
     let result = mac.finalize().into_bytes();
@@ -50,7 +50,7 @@ pub fn hmac_sha256(key: &[u8], data: &[u8]) -> [u8; 32] {
 
 /// Quick Share UKEY2 D2D sabit salt'ı — protokol sürümleri arası değişmez.
 /// `src/crypto.rs::D2D_SALT` ile birebir eşleşmeli.
-pub const D2D_SALT: [u8; 32] = [
+pub(crate) const D2D_SALT: [u8; 32] = [
     0x82, 0xAA, 0x55, 0xA0, 0xD3, 0x97, 0xF8, 0x83, 0x46, 0xCA, 0x1C, 0xEE, 0x8D, 0x39, 0x09, 0xB9,
     0x5F, 0x13, 0xFA, 0x7D, 0xEB, 0x1D, 0x4A, 0xB3, 0x83, 0x76, 0xB8, 0x25, 0x6D, 0xA8, 0x55, 0x10,
 ];
@@ -58,7 +58,7 @@ pub const D2D_SALT: [u8; 32] = [
 /// Quick Share 4-haneli PIN türetme — `src/crypto.rs::pin_code_from_auth_key`
 /// referans implementasyonunun birebir kopyası (NearDrop algoritması).
 /// Her bayt Java'daki `byte`-olarak (signed) yorumlanır.
-pub fn pin_code_from_auth_key(key: &[u8]) -> String {
+pub(crate) fn pin_code_from_auth_key(key: &[u8]) -> String {
     let mut hash: i64 = 0;
     let mut mult: i64 = 1;
     const MOD: i64 = 9973;
@@ -73,7 +73,7 @@ pub fn pin_code_from_auth_key(key: &[u8]) -> String {
 /// Java `BigInteger.toByteArray()` uyumlu signed-byte formatı.
 /// MSB ≥ 0x80 ise başa 0x00 eklenir (negatif yorumlanmaması için).
 /// `src/ukey2.rs::to_signed_bytes` ile aynı davranış — bağımsız implement.
-pub fn to_signed_bytes(v: &[u8]) -> Vec<u8> {
+pub(crate) fn to_signed_bytes(v: &[u8]) -> Vec<u8> {
     if !v.is_empty() && v[0] >= 0x80 {
         let mut out = Vec::with_capacity(v.len() + 1);
         out.push(0x00);

--- a/crates/hekadrop-core/src/settings.rs
+++ b/crates/hekadrop-core/src/settings.rs
@@ -147,7 +147,10 @@ mod hex_hash_opt {
 
     // serde signature kontratı `&Option<T>` ister — pass-by-value yapılamaz.
     #[allow(clippy::trivially_copy_pass_by_ref)]
-    pub fn serialize<S: Serializer>(value: &Option<[u8; 6]>, s: S) -> Result<S::Ok, S::Error> {
+    pub(super) fn serialize<S: Serializer>(
+        value: &Option<[u8; 6]>,
+        s: S,
+    ) -> Result<S::Ok, S::Error> {
         match value {
             Some(bytes) => s.serialize_str(&hex::encode(bytes)),
             // skip_serializing_if zaten None'u atlıyor — buraya düşülmez,
@@ -156,7 +159,9 @@ mod hex_hash_opt {
         }
     }
 
-    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Option<[u8; 6]>, D::Error> {
+    pub(super) fn deserialize<'de, D: Deserializer<'de>>(
+        d: D,
+    ) -> Result<Option<[u8; 6]>, D::Error> {
         let opt: Option<String> = Option::deserialize(d)?;
         let Some(raw) = opt else {
             return Ok(None);


### PR DESCRIPTION
## Özet

PR #87 deferred strictness sweep listesinden bir madde: \`unreachable_pub\`. PR #87'de 349 hit vardı; **RFC-0001 workspace refactor (Adım 1-8) sonrası core/app split + shim re-export pattern'i sayesinde 58'e düştü**. Bu PR onları temizler + lint enforce eder.

## Cleanup yöntemi

\`cargo clippy --fix --workspace --all-targets --all-features -- -W unreachable_pub\` → 5 dosyada 53 site otomatik:

| Dosya | Site | Niteliği |
|---|---|---|
| \`crates/hekadrop-app/src/state.rs\` | 15 | Singleton free-fn shim'ler — app-only |
| \`crates/hekadrop-app/src/ui.rs\` | 12 | UI helper fn'ler |
| \`crates/hekadrop-app/src/platform.rs\` | 9 | Platform shims |
| \`crates/hekadrop-app/src/i18n.rs\` | 4 | Translation helpers |
| \`crates/hekadrop-app/src/ui_adapter.rs\` | 4 | Adapter struct + impl helpers |
| \`crates/hekadrop-app/tests/common/mod.rs\` | 6 | Shared test helpers (pub(crate) yine her test crate'inden erişilebilir) |
| \`crates/hekadrop-app/src/paths.rs\` | 1 | identity_path/stats_path/config_path bir tanesi |
| \`crates/hekadrop-core/src/settings.rs\` | 2 | \`hex_hash_opt\` serde helper'lar — module-private |

53 sitenin tümü \`pub\` → \`pub(crate)\`. **Hiçbir external API kırılmadı** — core'un public surface'i (lib.rs \`pub use hekadrop_core::*\` ile re-export edilenler) zaten dikkatli tasarlanmıştı, bu PR onları DEĞİŞTİRMEDİ.

## Lint enforce

Root \`Cargo.toml\` \`[workspace.lints.rust]\`'a eklendi:

\`\`\`toml
unreachable_pub = "warn"
\`\`\`

Header yorumdaki "Kapsam dışı bırakılanlar" tablosu güncellendi — \`unreachable_pub\` artık enforce edilen liste tarafına geçti.

## CLAUDE.md pre-commit invariant scan

| Kontrol | Sonuç |
|---|---|
| \`cargo clippy -D warnings\` | ✓ |
| \`cargo test --workspace\` | ✓ 27 test suite (davranış parity) |
| \`cargo fmt --check\` | ✓ |
| \`cargo machete\` | ✓ |
| \`typos\` | ✓ |
| I-1 (core'da app modül) | değişmedi ✓ |
| I-2 (yeni allow) | yok ✓ |
| I-6 (yeni global state) | yok ✓ |

## Test plan

- [x] Lokal CI dry-run yeşil
- [ ] CI matrix (mac/Linux/Windows + extra-lints + cargo-deny + coverage)

## PR #87 deferred listesi durumu

| Lint | Hit | Durum |
|---|---|---|
| \`cast_possible_wrap\` | 36 | ✓ #101 (diğer AI) |
| \`uninlined_format_args\` | 110 | ✓ #105 |
| \`unreachable_pub\` | 58 (was 349) | ✓ **bu PR** |
| \`clippy::pedantic\` umbrella | ~1,228 | sırada — modular yapılacak |
| \`clippy::doc_markdown\` | 445+792 | sonra |
| \`must_use_candidate\` | 71 | annotation pass |
| \`match_same_arms\`, \`items_after_statements\`, vb. | <100 each | sonra |

🤖 Generated with [Claude Code](https://claude.com/claude-code)