### PR TITLE
chore(lint): deferred sweep batch — uninlined_format_args + unreachable_pub

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,6 +123,24 @@ typos
 
 Tüm yeşilse commit. Bir tanesi sarı/kırmızıysa fix öncesi commit yok.
 
+### Bilinen gap: platform-gated kod lokal lint kapsamında değil
+
+`cargo clippy --fix` veya manuel taramada lokal host platformu (genelde
+macOS) **hangi `#[cfg(target_os = "...")]` blokları derliyorsa onları
+görür** — diğer platform'ların gated kodu (Linux GTK / Windows Win32)
+kapsam dışıdır. Cross-compile setup pratik değildir (GTK system dep'leri).
+
+**Workaround:** Lint enforce eden bir PR push'unun ilk CI run'unda
+Linux + Windows fail edebilir; CI log'larındaki `--> path:line` listesini
+manuel fix + push iterasyonu. Bu pattern PR #93, #107 (uninlined_format_args)
+ve gelecekteki tüm cross-cutting lint enforce PR'larında **beklenmelidir**;
+1 ekstra CI iterasyonu kabul edilebilir maliyet.
+
+İleride elimine etmek için:
+- Cross-platform clippy CI matrix step'i + `cargo clippy --fix` koş
+  → fix önerisini patch olarak çıkar, lokal apply
+- VEYA cross-compile container kur (Docker/devcontainer)
+
 ## Pre-push adversarial review (önerilir)
 
 `git push` ÖNCESİ adversarial review agent çağır — özellikle non-trivial PR'larda:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ get_unwrap = "warn"
 redundant_clone = "warn"
 use_self = "warn"
 # Kalite — düşük volüm, anlık temizlik
+uninlined_format_args = "warn"  # PR #87 auto-fix sonrası 110 yeni site birikmişti; auto-fix tekrar uygulandı + lint enforce
 manual_let_else = "warn"
 ignored_unit_patterns = "warn"
 trivially_copy_pass_by_ref = "warn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,12 +20,14 @@ homepage = "https://github.com/YatogamiRaito/HekaDrop"
 # Kapsam dışı bırakılanlar (RED-tier — ayrı tracking issue'larla cleanup):
 #   * clippy::pedantic umbrella (~1,228 hit)        — issue #TBD
 #   * clippy::doc_markdown (445 hand + 792 gen)     — issue #TBD
-#   * unreachable_pub (349)                         — issue #TBD
-#   * clippy::uninlined_format_args (225)           — bu PR'da --fix uygulandı
 #   * clippy::must_use_candidate (71 hand)          — issue #TBD
 #   * clippy::match_same_arms (68)                  — issue #TBD
-#   * clippy::cast_possible_wrap (36, security)     — issue #TBD (audit gerekiyor)
 #   * unused_crate_dependencies                     — false-pos cascade, atlandı
+#
+# v0.7.x ile enforce edilenler (önceki "RED" listesinden):
+#   * clippy::cast_possible_wrap (36)               — PR #101 audit + enforce
+#   * clippy::uninlined_format_args (auto-fix +110) — PR #105 enforce
+#   * unreachable_pub (workspace refactor sonrası 58 hit) — bu PR cleanup + enforce
 #
 # Konsensus referans: Embark, uv, ruff. Top-tier (tokio/ripgrep/rustls/hyper)
 # minimal config tercih ediyor; biz crypto/protocol surface taşıyan bir desktop
@@ -37,6 +39,11 @@ trivial_numeric_casts = "warn"
 single_use_lifetimes = "warn"
 unused_lifetimes = "warn"
 unused_macro_rules = "warn"
+# Public API hijyeni — pub item bir tüketici tarafından erişilemiyorsa
+# pub(crate)'e dönmeli. Workspace refactor (Adım 5) sonrası app→core
+# split ile çoğu mu eski-pub items pub(crate) olabilir hâle geldi.
+# PR #87'de 349 hit'tən refactor sonrası 58'e düştü; cleanup + enforce.
+unreachable_pub = "warn"
 
 [workspace.lints.clippy]
 # Ship-blocker'lar — production'a sızmamalı

--- a/crates/hekadrop-app/src/i18n.rs
+++ b/crates/hekadrop-app/src/i18n.rs
@@ -27,7 +27,7 @@
 use std::sync::OnceLock;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Lang {
+pub(crate) enum Lang {
     Tr,
     En,
 }
@@ -35,7 +35,7 @@ pub enum Lang {
 static LANG: OnceLock<Lang> = OnceLock::new();
 
 /// Uygulamanın kullanacağı dili döner. İlk çağrıda detect edilir ve cache'lenir.
-pub fn current() -> Lang {
+pub(crate) fn current() -> Lang {
     *LANG.get_or_init(detect)
 }
 
@@ -70,7 +70,7 @@ fn parse_lang(raw: &str) -> Option<Lang> {
 /// `key` `&'static str` — çağrı siteleri literal olduğundan (`t("tray.xxx")`)
 /// bu kısıt sorun değil ve fallback olarak key'i dönmeyi güvenli kılar.
 /// Eksik çeviri varsa UI'da key string'i görünür, dev fark eder.
-pub fn t(key: &'static str) -> &'static str {
+pub(crate) fn t(key: &'static str) -> &'static str {
     let lang = current();
     match lang {
         Lang::Tr => lookup_tr(key).or_else(|| lookup_en(key)).unwrap_or(key),
@@ -88,7 +88,7 @@ pub fn t(key: &'static str) -> &'static str {
 ///
 /// Placeholder olmayan `{` karakterleri literal bırakılır (kullanıcıya
 /// gösterilen metinde `{X}` geçmesi tipik değil ama güvenli).
-pub fn tf(key: &'static str, args: &[&str]) -> String {
+pub(crate) fn tf(key: &'static str, args: &[&str]) -> String {
     apply_args(t(key), args)
 }
 

--- a/crates/hekadrop-app/src/i18n.rs
+++ b/crates/hekadrop-app/src/i18n.rs
@@ -771,8 +771,8 @@ mod tests {
             "onboarding.cta_dismiss",
         ];
         for k in &sample_keys {
-            assert!(lookup_tr(k).is_some(), "Türkçe çeviri eksik: {}", k);
-            assert!(lookup_en(k).is_some(), "English translation missing: {}", k);
+            assert!(lookup_tr(k).is_some(), "Türkçe çeviri eksik: {k}");
+            assert!(lookup_en(k).is_some(), "English translation missing: {k}");
         }
     }
 }

--- a/crates/hekadrop-app/src/lib.rs
+++ b/crates/hekadrop-app/src/lib.rs
@@ -67,4 +67,8 @@ pub use hekadrop_proto::{location, securegcm, securemessage, sharing};
 // alıyordu — Adım 3 öncesi yüzeyi korumak için aynı seviyede yeniden export.
 pub use hekadrop_core::{process_client_init, validate_server_init, DerivedKeys};
 
-pub mod platform;
+// `platform` modülü uygulamaya özgüdür (Win32 / macOS Cocoa / Linux GTK
+// shim'leri); core'a sızdırılmaz, tests/benches da bu modüle dokunmaz.
+// `pub(crate)` ile lib surface dışına çıkarıldı — PR #107 review (Copilot)
+// `pub mod` + iç items `pub(crate)` tutarsızlığını yakaladı.
+pub(crate) mod platform;

--- a/crates/hekadrop-app/src/main.rs
+++ b/crates/hekadrop-app/src/main.rs
@@ -437,7 +437,7 @@ fn run_app() -> ! {
             Err(e) => {
                 ui::fatal_error_dialog(
                     "HekaDrop başlatılamıyor",
-                    &format!("webview oluşturulamadı: {}", e),
+                    &format!("webview oluşturulamadı: {e}"),
                 );
                 // Fatal startup; bkz. yukarı.
                 #[allow(clippy::exit)]
@@ -1872,7 +1872,7 @@ fn toggle_login_item() {
                 } else {
                     ui::show_info(
                         "HekaDrop",
-                        &format!("Registry değeri silinemedi (err={:?})", del_rc),
+                        &format!("Registry değeri silinemedi (err={del_rc:?})"),
                     );
                 }
                 return;
@@ -1897,7 +1897,7 @@ fn toggle_login_item() {
         Err(e) => {
             ui::show_info(
                 "HekaDrop — otomatik başlatma",
-                &format!("current_exe alınamadı: {}", e),
+                &format!("current_exe alınamadı: {e}"),
             );
             return;
         }
@@ -1930,7 +1930,7 @@ fn toggle_login_item() {
         if rc != ERROR_SUCCESS {
             ui::show_info(
                 "HekaDrop",
-                &format!("Registry Run anahtarı açılamadı (err={:?})", rc),
+                &format!("Registry Run anahtarı açılamadı (err={rc:?})"),
             );
             return;
         }
@@ -1953,7 +1953,7 @@ fn toggle_login_item() {
         } else {
             ui::show_info(
                 "HekaDrop",
-                &format!("Registry değeri yazılamadı (err={:?})", set_rc),
+                &format!("Registry değeri yazılamadı (err={set_rc:?})"),
             );
         }
     }
@@ -1999,7 +1999,7 @@ fn toggle_login_item() {
         Err(e) => {
             ui::show_info(
                 "HekaDrop — otomatik başlatma",
-                &format!("current_exe alınamadı: {}", e),
+                &format!("current_exe alınamadı: {e}"),
             );
             return;
         }
@@ -2058,7 +2058,7 @@ fn toggle_login_item() {
                 String::from_utf8_lossy(&o.stderr).trim()
             ),
         ),
-        Err(e) => ui::show_info("HekaDrop", &format!("systemctl çalıştırılamadı: {}", e)),
+        Err(e) => ui::show_info("HekaDrop", &format!("systemctl çalıştırılamadı: {e}")),
     }
 }
 

--- a/crates/hekadrop-app/src/main.rs
+++ b/crates/hekadrop-app/src/main.rs
@@ -184,7 +184,7 @@ fn main() {
                 Err(e) => {
                     ui::fatal_error_dialog(
                         "HekaDrop başlatılamıyor",
-                        &format!("tokio runtime kurulamadı: {}", e),
+                        &format!("tokio runtime kurulamadı: {e}"),
                     );
                     std::process::exit(1);
                 }
@@ -198,7 +198,7 @@ fn main() {
     if let Err(e) = spawn_result {
         ui::fatal_error_dialog(
             "HekaDrop başlatılamıyor",
-            &format!("async thread başlatılamadı: {}", e),
+            &format!("async thread başlatılamadı: {e}"),
         );
         std::process::exit(1);
     }
@@ -251,10 +251,7 @@ fn setup_logging(log_level: settings::LogLevel) {
             // Tracing subscriber henüz kurulmadı — eprintln! tek başvuru.
             #[allow(clippy::print_stderr)]
             {
-                eprintln!(
-                    "[HekaDrop] log appender kurulamadı ({}); stdout-only devam",
-                    e
-                );
+                eprintln!("[HekaDrop] log appender kurulamadı ({e}); stdout-only devam");
             }
             None
         }
@@ -384,7 +381,7 @@ fn run_app() -> ! {
         Err(e) => {
             ui::fatal_error_dialog(
                 "HekaDrop başlatılamıyor",
-                &format!("pencere oluşturulamadı: {}", e),
+                &format!("pencere oluşturulamadı: {e}"),
             );
             // Fatal startup; ?-propagation main()'e tanrı-Result zorlar — exit
             // burada anlamlı: kullanıcı hata gördü, RAII temizliğe gerek yok.
@@ -454,7 +451,7 @@ fn run_app() -> ! {
         Err(e) => {
             ui::fatal_error_dialog(
                 "HekaDrop başlatılamıyor",
-                &format!("webview oluşturulamadı: {}", e),
+                &format!("webview oluşturulamadı: {e}"),
             );
             // Fatal startup; bkz. yukarı.
             #[allow(clippy::exit)]
@@ -790,7 +787,7 @@ fn graceful_quit() -> ! {
     #[cfg(target_os = "macos")]
     {
         if let Ok(home) = std::env::var("HOME") {
-            let plist_path = format!("{}/Library/LaunchAgents/com.sourvice.hekadrop.plist", home);
+            let plist_path = format!("{home}/Library/LaunchAgents/com.sourvice.hekadrop.plist");
             if std::path::Path::new(&plist_path).exists() {
                 info!("launchd agent unload: {}", plist_path);
                 let _ = std::process::Command::new("launchctl")
@@ -872,7 +869,7 @@ fn handle_settings_save(json: &str) {
                 tracing::warn!("[ui] download_dir geçersiz: {}", e);
                 ui::notify(
                     i18n::t("notify.app_name"),
-                    &format!("download_dir geçersiz: {}", e),
+                    &format!("download_dir geçersiz: {e}"),
                 );
                 return;
             }
@@ -995,10 +992,7 @@ fn push_i18n_to_ui() {
     // fonksiyonu script block içinde tanımlı — bu push ondan sonra geldiğinde
     // doğrudan çağrılır; öncesinde geldiyse window.__I18N__ setlenir, script
     // tag'i load olunca boot path'i yakalar.
-    let js = format!(
-        "window.__I18N__ = {}; window.applyI18n && window.applyI18n();",
-        payload
-    );
+    let js = format!("window.__I18N__ = {payload}; window.applyI18n && window.applyI18n();");
     state::enqueue_js(js);
 }
 
@@ -1058,7 +1052,7 @@ fn push_settings_to_ui() {
         "disable_update_check": s.disable_update_check,
     });
     drop(s);
-    let js = format!("window.applySettings && window.applySettings({})", payload);
+    let js = format!("window.applySettings && window.applySettings({payload})");
     state::enqueue_js(js);
 }
 
@@ -1113,10 +1107,7 @@ fn push_stats_to_ui() {
         "top_rx": top_rx,
         "top_tx": top_tx,
     });
-    state::enqueue_js(format!(
-        "window.applyStats && window.applyStats({})",
-        payload
-    ));
+    state::enqueue_js(format!("window.applyStats && window.applyStats({payload})"));
 }
 
 fn st_settings_resolved_name() -> String {
@@ -1154,7 +1145,7 @@ fn push_trusted_to_ui() {
         .collect();
     drop(s);
     let payload = serde_json::Value::Array(items);
-    let js = format!("window.applyTrusted && window.applyTrusted({})", payload);
+    let js = format!("window.applyTrusted && window.applyTrusted({payload})");
     state::enqueue_js(js);
 }
 
@@ -1215,8 +1206,8 @@ fn progress_signature(p: &state::ProgressState) -> String {
             device,
             file,
             percent,
-        } => format!("recv:{}:{}:{}", device, file, percent),
-        state::ProgressState::Completed { file } => format!("done:{}", file),
+        } => format!("recv:{device}:{file}:{percent}"),
+        state::ProgressState::Completed { file } => format!("done:{file}"),
     }
 }
 
@@ -1225,7 +1216,7 @@ fn js_string(s: &str) -> String {
         .replace('\\', "\\\\")
         .replace('"', "\\\"")
         .replace('\n', "\\n");
-    format!("\"{}\"", escaped)
+    format!("\"{escaped}\"")
 }
 
 fn push_progress_to_ui(webview: &wry::WebView, p: &state::ProgressState) {
@@ -1240,11 +1231,11 @@ fn push_progress_to_ui(webview: &wry::WebView, p: &state::ProgressState) {
         } => format!(
             "window.updateProgress && window.updateProgress({}, {})",
             percent,
-            js_string(&format!("{} • {} ({}%)", device, file, percent))
+            js_string(&format!("{device} • {file} ({percent}%)"))
         ),
         state::ProgressState::Completed { file } => format!(
             "window.updateProgress && window.updateProgress(100, {}); setTimeout(() => window.updateProgress(-1, ''), 2500)",
-            js_string(&format!("✓ {}", file))
+            js_string(&format!("✓ {file}"))
         ),
     };
     let _ = webview.evaluate_script(&js);
@@ -1284,7 +1275,7 @@ async fn initiate_send_flow_with(files: Vec<std::path::PathBuf>) {
     let devices = match discovery::scan(Duration::from_secs(3), own_port).await {
         Ok(v) => v,
         Err(e) => {
-            ui::show_info(i18n::t("send.discovery_error"), &format!("{:#}", e));
+            ui::show_info(i18n::t("send.discovery_error"), &format!("{e:#}"));
             return;
         }
     };
@@ -1338,7 +1329,7 @@ async fn initiate_send_flow_with(files: Vec<std::path::PathBuf>) {
         }
         Err(e) => {
             tracing::warn!("send hatası: {:#}", e);
-            ui::show_info(i18n::t("send.send_error"), &format!("{:#}", e));
+            ui::show_info(i18n::t("send.send_error"), &format!("{e:#}"));
         }
     }
 }
@@ -1360,7 +1351,7 @@ async fn initiate_text_send_flow(text: String) {
     let devices = match discovery::scan(Duration::from_secs(3), own_port).await {
         Ok(v) => v,
         Err(e) => {
-            ui::show_info(i18n::t("send.discovery_error"), &format!("{:#}", e));
+            ui::show_info(i18n::t("send.discovery_error"), &format!("{e:#}"));
             return;
         }
     };
@@ -1411,7 +1402,7 @@ async fn initiate_text_send_flow(text: String) {
         }
         Err(e) => {
             tracing::warn!("send_text hatası: {:#}", e);
-            ui::show_info(i18n::t("send.send_error"), &format!("{:#}", e));
+            ui::show_info(i18n::t("send.send_error"), &format!("{e:#}"));
         }
     }
 }
@@ -1536,17 +1527,17 @@ async fn check_update_async() {
                 }
                 // Body'yi 200 char ile sınırla (char-safe, UTF-8 boundary sağlam).
                 let snippet: String = body.chars().take(200).collect();
-                return UpdateCheckOutcome::ApiError(format!("403: {}", snippet));
+                return UpdateCheckOutcome::ApiError(format!("403: {snippet}"));
             }
             "200" => {}
             other if !other.is_empty() => {
-                return UpdateCheckOutcome::ApiError(format!("HTTP {}", other));
+                return UpdateCheckOutcome::ApiError(format!("HTTP {other}"));
             }
             _ => return UpdateCheckOutcome::NetworkError,
         }
         let json: serde_json::Value = match serde_json::from_str(body) {
             Ok(j) => j,
-            Err(e) => return UpdateCheckOutcome::ApiError(format!("JSON: {}", e)),
+            Err(e) => return UpdateCheckOutcome::ApiError(format!("JSON: {e}")),
         };
         let tag = match json.get("tag_name").and_then(|v| v.as_str()) {
             Some(t) => t.to_string(),
@@ -1603,7 +1594,7 @@ fn render_update_outcome(outcome: UpdateCheckOutcome) {
             let msg = i18n::tf("update.status.new_version", &[&tag]);
             // URL'yi mesaja iliştiriyoruz — i18n string'i sürüm taglına odaklı,
             // link satır içi bilgi olarak kalıyor.
-            push_update_status(&format!("{} — {}", msg, url), "success");
+            push_update_status(&format!("{msg} — {url}"), "success");
         }
         UpdateCheckOutcome::NetworkError => {
             push_update_status(i18n::t("update.error.network"), "error");
@@ -1708,7 +1699,7 @@ fn human_size(bytes: i64) -> String {
         i += 1;
     }
     if i == 0 {
-        format!("{} B", bytes)
+        format!("{bytes} B")
     } else {
         format!("{:.1} {}", n, UNITS[i])
     }
@@ -1720,7 +1711,7 @@ fn toggle_login_item() {
         ui::notify("HekaDrop", "HOME bulunamadı");
         return;
     };
-    let plist_path = format!("{}/Library/LaunchAgents/com.sourvice.hekadrop.plist", home);
+    let plist_path = format!("{home}/Library/LaunchAgents/com.sourvice.hekadrop.plist");
     let plist_exists = std::path::Path::new(&plist_path).exists();
 
     if plist_exists {
@@ -1740,8 +1731,7 @@ fn toggle_login_item() {
         ui::show_info(
             "HekaDrop — otomatik başlatma",
             &format!(
-                "Önce HekaDrop.app'i {} dizinine kopyalayın.\n\nTerminal'den:  make install",
-                app_path
+                "Önce HekaDrop.app'i {app_path} dizinine kopyalayın.\n\nTerminal'den:  make install"
             ),
         );
         return;
@@ -1779,7 +1769,7 @@ fn toggle_login_item() {
     if let Err(e) = std::fs::write(&plist_path, plist_template) {
         ui::show_info(
             "HekaDrop",
-            &format!("plist yazılamadı: {}\nKonum: {}", e, plist_path),
+            &format!("plist yazılamadı: {e}\nKonum: {plist_path}"),
         );
         return;
     }

--- a/crates/hekadrop-app/src/paths.rs
+++ b/crates/hekadrop-app/src/paths.rs
@@ -14,6 +14,6 @@ pub(crate) fn stats_path() -> PathBuf {
     crate::platform::config_dir().join("stats.json")
 }
 
-pub fn config_path() -> PathBuf {
+pub(crate) fn config_path() -> PathBuf {
     crate::platform::config_dir().join("config.json")
 }

--- a/crates/hekadrop-app/src/platform.rs
+++ b/crates/hekadrop-app/src/platform.rs
@@ -37,7 +37,7 @@ fn home_dir() -> PathBuf {
 /// - macOS: `~/Library/Application Support/HekaDrop`
 /// - Linux: `$XDG_CONFIG_HOME/HekaDrop` → `~/.config/HekaDrop`
 /// - Windows: `FOLDERID_RoamingAppData\HekaDrop` (genelde `%APPDATA%\HekaDrop`)
-pub fn config_dir() -> PathBuf {
+pub(crate) fn config_dir() -> PathBuf {
     #[cfg(target_os = "macos")]
     {
         home_dir().join("Library/Application Support/HekaDrop")
@@ -62,7 +62,7 @@ pub fn config_dir() -> PathBuf {
 /// - macOS: `~/Library/Logs/HekaDrop`
 /// - Linux: `$XDG_STATE_HOME/HekaDrop/logs` → `~/.local/state/HekaDrop/logs`
 /// - Windows: `FOLDERID_LocalAppData\HekaDrop\logs` — log'lar roam etmesin.
-pub fn logs_dir() -> PathBuf {
+pub(crate) fn logs_dir() -> PathBuf {
     #[cfg(target_os = "macos")]
     {
         home_dir().join("Library/Logs/HekaDrop")
@@ -88,7 +88,7 @@ pub fn logs_dir() -> PathBuf {
 /// - macOS: `$HOME/Downloads`
 /// - Windows: `FOLDERID_Downloads` (kullanıcının özel konuma taşımış olması
 ///   durumunda da doğru yolu döner)
-pub fn default_download_dir() -> PathBuf {
+pub(crate) fn default_download_dir() -> PathBuf {
     #[cfg(target_os = "linux")]
     {
         if let Ok(out) = Command::new("xdg-user-dir").arg("DOWNLOAD").output() {
@@ -117,7 +117,7 @@ pub fn default_download_dir() -> PathBuf {
 /// - Linux: `/etc/hostname` → `hostname` komutu → fallback "HekaDrop Linux"
 /// - Windows: `GetComputerNameExW(ComputerNameDnsHostname)` → fallback
 ///   `%COMPUTERNAME%` → "HekaDrop PC"
-pub fn device_name() -> String {
+pub(crate) fn device_name() -> String {
     if let Ok(v) = std::env::var("HEKADROP_NAME") {
         if !v.is_empty() {
             return v;
@@ -175,7 +175,7 @@ pub fn device_name() -> String {
 }
 
 /// Verilen dosyayı/dizini işletim sisteminin varsayılan programıyla açar.
-pub fn open_path(path: &Path) {
+pub(crate) fn open_path(path: &Path) {
     #[cfg(target_os = "macos")]
     {
         let _ = Command::new("open").arg(path).spawn();
@@ -191,7 +191,7 @@ pub fn open_path(path: &Path) {
 }
 
 /// Dosyayı dosya yöneticisinde (Finder / Nautilus / Explorer) seçili olarak gösterir.
-pub fn reveal_path(path: &Path) {
+pub(crate) fn reveal_path(path: &Path) {
     #[cfg(target_os = "macos")]
     {
         let _ = Command::new("open").arg("-R").arg(path).spawn();
@@ -301,7 +301,7 @@ mod tests {
 }
 
 /// URL'i tarayıcıda açar.
-pub fn open_url(url: &str) {
+pub(crate) fn open_url(url: &str) {
     #[cfg(target_os = "macos")]
     {
         let _ = Command::new("open").arg(url).spawn();
@@ -321,7 +321,7 @@ pub fn open_url(url: &str) {
 /// - macOS: `pbpaste`
 /// - Linux: Wayland (`wl-paste`) → X11 (`xclip` → `xsel`) sırayla
 /// - Windows: `GetClipboardData(CF_UNICODETEXT)` — UTF-16 → UTF-8 lossy
-pub fn paste_from_clipboard() -> Option<String> {
+pub(crate) fn paste_from_clipboard() -> Option<String> {
     #[cfg(target_os = "windows")]
     {
         win::clipboard_get().ok().flatten()
@@ -364,7 +364,7 @@ pub fn paste_from_clipboard() -> Option<String> {
 /// - Linux: Wayland (`wl-copy`) → X11 (`xclip` → `xsel`) sırayla
 /// - Windows: `OpenClipboard` + `SetClipboardData(CF_UNICODETEXT)` — UTF-16 LE,
 ///   `clip.exe`'nin ANSI-yorumu yüzünden Türkçe/non-ASCII bozulmasın
-pub fn copy_to_clipboard(text: &str) {
+pub(crate) fn copy_to_clipboard(text: &str) {
     #[cfg(target_os = "windows")]
     {
         if win::clipboard_set(text).is_err() {

--- a/crates/hekadrop-app/src/platform.rs
+++ b/crates/hekadrop-app/src/platform.rs
@@ -145,14 +145,14 @@ pub(crate) fn device_name() -> String {
         if let Ok(h) = std::fs::read_to_string("/etc/hostname") {
             let t = h.trim();
             if !t.is_empty() {
-                return format!("HekaDrop {}", t);
+                return format!("HekaDrop {t}");
             }
         }
         if let Ok(out) = Command::new("hostname").output() {
             if let Ok(s) = String::from_utf8(out.stdout) {
                 let t = s.trim();
                 if !t.is_empty() {
-                    return format!("HekaDrop {}", t);
+                    return format!("HekaDrop {t}");
                 }
             }
         }
@@ -162,12 +162,12 @@ pub(crate) fn device_name() -> String {
     #[cfg(target_os = "windows")]
     {
         if let Some(name) = win::computer_name() {
-            return format!("HekaDrop {}", name);
+            return format!("HekaDrop {name}");
         }
         if let Ok(v) = std::env::var("COMPUTERNAME") {
             let t = v.trim();
             if !t.is_empty() {
-                return format!("HekaDrop {}", t);
+                return format!("HekaDrop {t}");
             }
         }
         "HekaDrop PC".to_string()
@@ -210,7 +210,7 @@ pub(crate) fn reveal_path(path: &Path) {
                 "--type=method_call",
                 "/org/freedesktop/FileManager1",
                 "org.freedesktop.FileManager1.ShowItems",
-                &format!("array:string:{}", uri),
+                &format!("array:string:{uri}"),
                 "string:",
             ])
             .status();
@@ -249,7 +249,7 @@ fn path_to_file_uri(path: &Path) -> String {
         if unreserved {
             out.push(b as char);
         } else {
-            out.push_str(&format!("%{:02X}", b));
+            out.push_str(&format!("%{b:02X}"));
         }
     }
     out

--- a/crates/hekadrop-app/src/state.rs
+++ b/crates/hekadrop-app/src/state.rs
@@ -17,7 +17,7 @@
 // kasıtlı API genişliği — bin'de doğrudan referans yok ama integration
 // test'leri ve gelecekteki UI tab'ları için açık tutuluyor.
 #[allow(unused_imports)]
-pub use hekadrop_core::state::{
+pub(crate) use hekadrop_core::state::{
     AppState, HistoryItem, ProgressState, RateLimiter, TransferGuard, DEFAULT_COMPLETED_IDLE_DELAY,
 };
 
@@ -26,7 +26,7 @@ use std::sync::{Arc, OnceLock};
 
 static STATE: OnceLock<Arc<AppState>> = OnceLock::new();
 
-pub fn init(settings: Settings) {
+pub(crate) fn init(settings: Settings) {
     // App-singleton katmanı path'leri ve platform default'larını inject
     // ediyor — `AppState::new` core'da global'siz çalışır. Path resolution
     // `crate::paths` (`crate::platform::config_dir()` üstünde) sorumluluğu;
@@ -42,7 +42,7 @@ pub fn init(settings: Settings) {
     ));
 }
 
-pub fn get() -> Arc<AppState> {
+pub(crate) fn get() -> Arc<AppState> {
     // INVARIANT: `init()` her zaman `main`'in ilk işlerinden — `get()`
     // öncesinde çağrılması garanti. Aksi durum programlama hatası, panik
     // yerine sessiz default state üretmek bug'ı maskeler.
@@ -59,51 +59,51 @@ pub fn get() -> Arc<AppState> {
 // (artık core'da) doğrudan `Arc<AppState>` parametresi alıyor — singleton
 // lookup yok.
 
-pub fn enqueue_js(js: String) {
+pub(crate) fn enqueue_js(js: String) {
     get().enqueue_js(js);
 }
 
-pub fn drain_js() -> Vec<String> {
+pub(crate) fn drain_js() -> Vec<String> {
     get().drain_js()
 }
 
-pub fn request_hide_window() {
+pub(crate) fn request_hide_window() {
     get().request_hide_window();
 }
 
-pub fn request_show_window() {
+pub(crate) fn request_show_window() {
     get().request_show_window();
 }
 
-pub fn consume_hide_window() -> bool {
+pub(crate) fn consume_hide_window() -> bool {
     get().consume_hide_window()
 }
 
-pub fn consume_show_window() -> bool {
+pub(crate) fn consume_show_window() -> bool {
     get().consume_show_window()
 }
 
-pub fn request_cancel(id: Option<&str>) {
+pub(crate) fn request_cancel(id: Option<&str>) {
     get().request_cancel(id);
 }
 
 /// Legacy kompat: tray menüsündeki "İptal" "hepsini iptal et" anlamındaydı.
-pub fn request_cancel_all() {
+pub(crate) fn request_cancel_all() {
     request_cancel(None);
 }
 
-pub fn set_listen_port(p: u16) {
+pub(crate) fn set_listen_port(p: u16) {
     get().set_listen_port(p);
 }
 
-pub fn listen_port() -> u16 {
+pub(crate) fn listen_port() -> u16 {
     get().listen_port()
 }
 
-pub fn read_history() -> Vec<HistoryItem> {
+pub(crate) fn read_history() -> Vec<HistoryItem> {
     get().read_history()
 }
 
-pub fn read_progress() -> ProgressState {
+pub(crate) fn read_progress() -> ProgressState {
     get().read_progress()
 }

--- a/crates/hekadrop-app/src/state.rs
+++ b/crates/hekadrop-app/src/state.rs
@@ -12,10 +12,13 @@
 //! state YASAK).
 
 // API: app yüzeyini koru — `hekadrop::state::*` consumer'ları (lib.rs
-// re-export) `TransferGuard`, `RateLimiter`, `DEFAULT_COMPLETED_IDLE_DELAY`
-// sembollerini bekliyor. `cargo machete` style "kullanmayan ihaneti" yerine
-// kasıtlı API genişliği — bin'de doğrudan referans yok ama integration
-// test'leri ve gelecekteki UI tab'ları için açık tutuluyor.
+// `TransferGuard`, `RateLimiter`, `DEFAULT_COMPLETED_IDLE_DELAY` sembollerini
+// app içinden import etmek için bin-private use. PR #107'de `pub use` →
+// `pub(crate) use` indirildi (unreachable_pub cleanup); tests/benches
+// `hekadrop::state::*`'e dokunmadığı için external API daralması olmadı.
+// Gelecekte `Geçmiş` UI sekmesi `HistoryItem`/`RateLimiter`'ı bin
+// içinden referans verir; kullanım eklenince `#[allow(unused_imports)]`
+// kaldırılır.
 #[allow(unused_imports)]
 pub(crate) use hekadrop_core::state::{
     AppState, HistoryItem, ProgressState, RateLimiter, TransferGuard, DEFAULT_COMPLETED_IDLE_DELAY,

--- a/crates/hekadrop-app/src/ui.rs
+++ b/crates/hekadrop-app/src/ui.rs
@@ -188,7 +188,7 @@ fn prompt_accept_blocking(
         crate::i18n::t("accept.accept"),
         crate::i18n::t("accept.reject"),
     );
-    let message = sanitize_display_text(&format!("{}{}", body_main, hint));
+    let message = sanitize_display_text(&format!("{body_main}{hint}"));
     let title = crate::i18n::t("accept.title");
     let msg_w = to_wide(&message);
     let title_w = to_wide(title);
@@ -249,11 +249,11 @@ fn prompt_accept_blocking(
             let out = Command::new("zenity")
                 .args([
                     "--question",
-                    &format!("--title={}", title),
-                    &format!("--text={}", message),
-                    &format!("--ok-label={}", lbl_accept),
-                    &format!("--cancel-label={}", lbl_reject),
-                    &format!("--extra-button={}", lbl_trust),
+                    &format!("--title={title}"),
+                    &format!("--text={message}"),
+                    &format!("--ok-label={lbl_accept}"),
+                    &format!("--cancel-label={lbl_reject}"),
+                    &format!("--extra-button={lbl_trust}"),
                     "--width=420",
                 ])
                 .stderr(Stdio::null())
@@ -279,10 +279,10 @@ fn prompt_accept_blocking(
             let accept = Command::new("zenity")
                 .args([
                     "--question",
-                    &format!("--title={}", title),
-                    &format!("--text={}", message),
-                    &format!("--ok-label={}", lbl_accept),
-                    &format!("--cancel-label={}", lbl_reject),
+                    &format!("--title={title}"),
+                    &format!("--text={message}"),
+                    &format!("--ok-label={lbl_accept}"),
+                    &format!("--cancel-label={lbl_reject}"),
                     "--width=420",
                 ])
                 .stderr(Stdio::null())
@@ -293,7 +293,7 @@ fn prompt_accept_blocking(
             let trust = Command::new("zenity")
                 .args([
                     "--question",
-                    &format!("--title={}", title),
+                    &format!("--title={title}"),
                     &format!(
                         "--text={}",
                         sanitize_display_text(&crate::i18n::tf("accept.trust_prompt", &[device]))
@@ -322,7 +322,7 @@ fn prompt_accept_blocking(
                 "--title",
                 title,
                 "--yesnocancel",
-                &format!("{}\n\n({})", message, hint),
+                &format!("{message}\n\n({hint})"),
             ])
             .status();
         match out {
@@ -490,8 +490,8 @@ pub(crate) fn fatal_error_dialog(title: &str, body: &str) {
             let _ = Command::new("zenity")
                 .args([
                     "--error",
-                    &format!("--title={}", title),
-                    &format!("--text={}", body),
+                    &format!("--title={title}"),
+                    &format!("--text={body}"),
                     "--width=420",
                 ])
                 .stderr(Stdio::null())
@@ -506,7 +506,7 @@ pub(crate) fn fatal_error_dialog(title: &str, body: &str) {
             // henüz initialize olmamış olabilir (startup-fatal).
             #[allow(clippy::print_stderr)]
             {
-                eprintln!("[HekaDrop] {}: {}", title, body);
+                eprintln!("[HekaDrop] {title}: {body}");
             }
         }
     }
@@ -553,8 +553,8 @@ pub(crate) fn show_info(title: &str, body: &str) {
             let _ = Command::new("zenity")
                 .args([
                     "--info",
-                    &format!("--title={}", title),
-                    &format!("--text={}", body),
+                    &format!("--title={title}"),
+                    &format!("--text={body}"),
                     "--width=420",
                 ])
                 .stderr(Stdio::null())
@@ -697,7 +697,7 @@ fn choose_files_blocking() -> Option<Vec<std::path::PathBuf>> {
                 "--file-selection",
                 "--multiple",
                 "--separator=\n",
-                &format!("--title={}", title),
+                &format!("--title={title}"),
             ])
             .stderr(Stdio::null())
             .output()
@@ -827,7 +827,7 @@ fn choose_folder_blocking() -> Option<std::path::PathBuf> {
             .args([
                 "--file-selection",
                 "--directory",
-                &format!("--title={}", title),
+                &format!("--title={title}"),
             ])
             .stderr(Stdio::null())
             .output()
@@ -1096,7 +1096,7 @@ fn have(bin: &str) -> bool {
     }
     Command::new("sh")
         .arg("-c")
-        .arg(format!("command -v {} >/dev/null 2>&1", bin))
+        .arg(format!("command -v {bin} >/dev/null 2>&1"))
         .status()
         .map(|s| s.success())
         .unwrap_or(false)

--- a/crates/hekadrop-app/src/ui.rs
+++ b/crates/hekadrop-app/src/ui.rs
@@ -53,7 +53,7 @@ pub async fn prompt_accept(
 
     task::spawn_blocking(move || prompt_accept_blocking(&device, &pin, &files, text_count))
         .await
-        .map_err(|e| anyhow::anyhow!("UI task join: {}", e))
+        .map_err(|e| anyhow::anyhow!("UI task join: {e}"))
 }
 
 /// Tek bir peer-kontrollü alan (cihaz adı, dosya adı, PIN) için sıkı
@@ -1039,7 +1039,7 @@ fn choose_device_blocking(labels: &[String]) -> Option<String> {
 /// notify kullanıyoruz.
 #[allow(dead_code)]
 pub fn send_progress_notify(device: &str, file: &str) {
-    notify("HekaDrop", &format!("Gönderiliyor: {} → {}", file, device));
+    notify("HekaDrop", &format!("Gönderiliyor: {file} → {device}"));
 }
 
 #[cfg(target_os = "macos")]

--- a/crates/hekadrop-app/src/ui.rs
+++ b/crates/hekadrop-app/src/ui.rs
@@ -790,11 +790,10 @@ fn choose_folder_blocking() -> Option<std::path::PathBuf> {
 [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
 Add-Type -AssemblyName System.Windows.Forms | Out-Null
 $dlg = New-Object System.Windows.Forms.FolderBrowserDialog
-$dlg.Description = '{}'
+$dlg.Description = '{desc}'
 $dlg.ShowNewFolderButton = $true
 if ($dlg.ShowDialog() -eq 'OK') {{ $dlg.SelectedPath }}
-"#,
-        desc
+"#
     );
     let out = Command::new("powershell")
         .args([

--- a/crates/hekadrop-app/src/ui.rs
+++ b/crates/hekadrop-app/src/ui.rs
@@ -18,13 +18,13 @@ use tokio::task;
 #[allow(unused_imports)]
 use std::path::PathBuf;
 
-pub struct FileSummary {
+pub(crate) struct FileSummary {
     pub name: String,
     pub size: i64,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum AcceptResult {
+pub(crate) enum AcceptResult {
     Reject,
     Accept,
     AcceptAndTrust,
@@ -34,7 +34,7 @@ pub enum AcceptResult {
 ///   - Reddet
 ///   - Kabul et
 ///   - Kabul + güven (device_name ileride otomatik kabul edilir)
-pub async fn prompt_accept(
+pub(crate) async fn prompt_accept(
     device_name: &str,
     pin_code: &str,
     files: &[FileSummary],
@@ -348,7 +348,7 @@ fn prompt_accept_blocking(
 /// butona bastığında dosya `xdg-open` ile, klasör ise file-manager ile açılır.
 /// macOS'ta aksiyon butonu desteklenmez — düz bildirim + tıklanınca Finder'da
 /// açma için fallback uygulanır (bkz. `NotificationCenter` gelecek iş).
-pub fn notify_file_received(title: &str, body: &str, path: std::path::PathBuf) {
+pub(crate) fn notify_file_received(title: &str, body: &str, path: std::path::PathBuf) {
     #[cfg(target_os = "macos")]
     {
         let _ = path; // macOS'ta aksiyon butonlu notify henüz yok.
@@ -428,7 +428,7 @@ pub fn notify_file_received(title: &str, body: &str, path: std::path::PathBuf) {
 }
 
 /// Kısa bildirim. Başarı/hata mesajları için.
-pub fn notify(title: &str, body: &str) {
+pub(crate) fn notify(title: &str, body: &str) {
     #[cfg(target_os = "macos")]
     {
         let script = format!(
@@ -473,7 +473,7 @@ pub fn notify(title: &str, body: &str) {
 ///
 /// Dialog aracı yoksa (headless) sadece log'a yazılır — zaten log dosyası
 /// da açılamamış olabilir, ama `tracing` stdout layer'ı çalışmaya devam eder.
-pub fn fatal_error_dialog(title: &str, body: &str) {
+pub(crate) fn fatal_error_dialog(title: &str, body: &str) {
     tracing::error!("fatal: {} — {}", title, body);
     #[cfg(target_os = "macos")]
     {
@@ -537,7 +537,7 @@ pub fn fatal_error_dialog(title: &str, body: &str) {
 }
 
 /// Bilgi diyaloğu (blocking değil, fire-and-forget).
-pub fn show_info(title: &str, body: &str) {
+pub(crate) fn show_info(title: &str, body: &str) {
     #[cfg(target_os = "macos")]
     {
         let script = format!(
@@ -603,12 +603,12 @@ pub fn show_info(title: &str, body: &str) {
 
 /// `choose file` dialog → seçilen dosyanın tam yolu veya None (tek dosya).
 #[allow(dead_code)]
-pub async fn choose_file() -> Option<std::path::PathBuf> {
+pub(crate) async fn choose_file() -> Option<std::path::PathBuf> {
     choose_files().await.and_then(|mut v| v.pop())
 }
 
 /// Çoklu dosya seçim dialog'u → seçilen tüm path'lerin listesi.
-pub async fn choose_files() -> Option<Vec<std::path::PathBuf>> {
+pub(crate) async fn choose_files() -> Option<Vec<std::path::PathBuf>> {
     task::spawn_blocking(choose_files_blocking)
         .await
         .ok()
@@ -751,7 +751,7 @@ fn choose_files_blocking() -> Option<Vec<std::path::PathBuf>> {
 }
 
 /// `choose folder` dialog → seçilen klasörün path'i.
-pub async fn choose_folder() -> Option<std::path::PathBuf> {
+pub(crate) async fn choose_folder() -> Option<std::path::PathBuf> {
     task::spawn_blocking(choose_folder_blocking)
         .await
         .ok()
@@ -861,7 +861,7 @@ fn choose_folder_blocking() -> Option<std::path::PathBuf> {
 }
 
 /// Listeden cihaz seçim dialog'u. `labels` içindeki etiket indeks'i döner.
-pub async fn choose_device(labels: Vec<String>) -> Option<usize> {
+pub(crate) async fn choose_device(labels: Vec<String>) -> Option<usize> {
     if labels.is_empty() {
         return None;
     }
@@ -1038,7 +1038,7 @@ fn choose_device_blocking(labels: &[String]) -> Option<String> {
 /// Dosya keşif sırasında basit bir ilerleme/bildirim dialog'u olmadığı için
 /// notify kullanıyoruz.
 #[allow(dead_code)]
-pub fn send_progress_notify(device: &str, file: &str) {
+pub(crate) fn send_progress_notify(device: &str, file: &str) {
     notify("HekaDrop", &format!("Gönderiliyor: {file} → {device}"));
 }
 

--- a/crates/hekadrop-app/src/ui.rs
+++ b/crates/hekadrop-app/src/ui.rs
@@ -1019,7 +1019,7 @@ fn choose_device_blocking(labels: &[String]) -> Option<String> {
             crate::i18n::t("send.device_prompt").into(),
         ];
         for (i, l) in labels.iter().enumerate() {
-            args.push(format!("{}", i));
+            args.push(format!("{i}"));
             args.push(l.clone());
             args.push(if i == 0 { "on".into() } else { "off".into() });
         }

--- a/crates/hekadrop-app/src/ui_adapter.rs
+++ b/crates/hekadrop-app/src/ui_adapter.rs
@@ -20,10 +20,10 @@ use hekadrop_core::ui_port::{AcceptDecision, FileSummary, UiNotification, UiPort
 /// platform::open_url` / `crate::platform::copy_to_clipboard`'ı sarar.
 /// Connection core'a taşındıktan sonra `Arc<dyn PlatformOps>` olarak
 /// `accept_loop`'a geçirilir; core'da `crate::platform` referansı olmaz.
-pub struct PlatformAdapter;
+pub(crate) struct PlatformAdapter;
 
 impl PlatformAdapter {
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self
     }
 }
@@ -44,10 +44,10 @@ impl hekadrop_core::connection::PlatformOps for PlatformAdapter {
     }
 }
 
-pub struct UiAdapter;
+pub(crate) struct UiAdapter;
 
 impl UiAdapter {
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self
     }
 }

--- a/crates/hekadrop-app/src/ui_adapter.rs
+++ b/crates/hekadrop-app/src/ui_adapter.rs
@@ -16,10 +16,11 @@
 use async_trait::async_trait;
 use hekadrop_core::ui_port::{AcceptDecision, FileSummary, UiNotification, UiPort};
 
-/// `connection::PlatformOps` trait'inin app-side concrete impl'i — `crate::
-/// platform::open_url` / `crate::platform::copy_to_clipboard`'ı sarar.
-/// Connection core'a taşındıktan sonra `Arc<dyn PlatformOps>` olarak
-/// `accept_loop`'a geçirilir; core'da `crate::platform` referansı olmaz.
+/// `connection::PlatformOps` trait'inin app-side concrete impl'i —
+/// `crate::platform::open_url` / `crate::platform::copy_to_clipboard`'ı
+/// sarar. Connection core'a taşındıktan sonra `Arc<dyn PlatformOps>`
+/// olarak `accept_loop`'a geçirilir; core'da `crate::platform` referansı
+/// olmaz.
 pub(crate) struct PlatformAdapter;
 
 impl PlatformAdapter {

--- a/crates/hekadrop-app/tests/cancel_per_transfer.rs
+++ b/crates/hekadrop-app/tests/cancel_per_transfer.rs
@@ -146,7 +146,7 @@ async fn cancelling_root_cascades_to_all_children() {
     for (name, h) in [("a", ha), ("b", hb), ("c", hc)] {
         let r = tokio::time::timeout(CANCEL_OBSERVE_TIMEOUT, h)
             .await
-            .unwrap_or_else(|_| panic!("{} task timeout", name))
+            .unwrap_or_else(|_| panic!("{name} task timeout"))
             .unwrap();
         assert!(r, "{name} root cancel'dan tetiklenmeli");
     }

--- a/crates/hekadrop-app/tests/common/mod.rs
+++ b/crates/hekadrop-app/tests/common/mod.rs
@@ -21,7 +21,7 @@ use hmac::{Hmac, Mac};
 use sha2::Sha256;
 
 /// HKDF-SHA256 → HekaDrop `crypto::hkdf_sha256` ile birebir aynı davranış.
-pub fn hkdf_sha256(ikm: &[u8], salt: &[u8], info: &[u8], len: usize) -> Vec<u8> {
+pub(crate) fn hkdf_sha256(ikm: &[u8], salt: &[u8], info: &[u8], len: usize) -> Vec<u8> {
     let hk = hkdf::Hkdf::<Sha256>::new(Some(salt), ikm);
     let mut out = vec![0u8; len];
     hk.expand(info, &mut out).expect("HKDF expand");
@@ -29,7 +29,7 @@ pub fn hkdf_sha256(ikm: &[u8], salt: &[u8], info: &[u8], len: usize) -> Vec<u8> 
 }
 
 /// SHA256 tek seferlik.
-pub fn sha256(data: &[u8]) -> [u8; 32] {
+pub(crate) fn sha256(data: &[u8]) -> [u8; 32] {
     use sha2::Digest;
     let mut h = Sha256::new();
     h.update(data);
@@ -39,7 +39,7 @@ pub fn sha256(data: &[u8]) -> [u8; 32] {
     a
 }
 
-pub fn hmac_sha256(key: &[u8], data: &[u8]) -> [u8; 32] {
+pub(crate) fn hmac_sha256(key: &[u8], data: &[u8]) -> [u8; 32] {
     let mut mac = Hmac::<Sha256>::new_from_slice(key).expect("HMAC key");
     mac.update(data);
     let result = mac.finalize().into_bytes();
@@ -50,7 +50,7 @@ pub fn hmac_sha256(key: &[u8], data: &[u8]) -> [u8; 32] {
 
 /// Quick Share UKEY2 D2D sabit salt'ı — protokol sürümleri arası değişmez.
 /// `src/crypto.rs::D2D_SALT` ile birebir eşleşmeli.
-pub const D2D_SALT: [u8; 32] = [
+pub(crate) const D2D_SALT: [u8; 32] = [
     0x82, 0xAA, 0x55, 0xA0, 0xD3, 0x97, 0xF8, 0x83, 0x46, 0xCA, 0x1C, 0xEE, 0x8D, 0x39, 0x09, 0xB9,
     0x5F, 0x13, 0xFA, 0x7D, 0xEB, 0x1D, 0x4A, 0xB3, 0x83, 0x76, 0xB8, 0x25, 0x6D, 0xA8, 0x55, 0x10,
 ];
@@ -58,7 +58,7 @@ pub const D2D_SALT: [u8; 32] = [
 /// Quick Share 4-haneli PIN türetme — `src/crypto.rs::pin_code_from_auth_key`
 /// referans implementasyonunun birebir kopyası (NearDrop algoritması).
 /// Her bayt Java'daki `byte`-olarak (signed) yorumlanır.
-pub fn pin_code_from_auth_key(key: &[u8]) -> String {
+pub(crate) fn pin_code_from_auth_key(key: &[u8]) -> String {
     let mut hash: i64 = 0;
     let mut mult: i64 = 1;
     const MOD: i64 = 9973;
@@ -73,7 +73,7 @@ pub fn pin_code_from_auth_key(key: &[u8]) -> String {
 /// Java `BigInteger.toByteArray()` uyumlu signed-byte formatı.
 /// MSB ≥ 0x80 ise başa 0x00 eklenir (negatif yorumlanmaması için).
 /// `src/ukey2.rs::to_signed_bytes` ile aynı davranış — bağımsız implement.
-pub fn to_signed_bytes(v: &[u8]) -> Vec<u8> {
+pub(crate) fn to_signed_bytes(v: &[u8]) -> Vec<u8> {
     if !v.is_empty() && v[0] >= 0x80 {
         let mut out = Vec::with_capacity(v.len() + 1);
         out.push(0x00);

--- a/crates/hekadrop-app/tests/file_metadata_size_guard.rs
+++ b/crates/hekadrop-app/tests/file_metadata_size_guard.rs
@@ -95,6 +95,6 @@ fn ui_gosterilen_deger_dogrudan_accept_s_den_gelir() {
     // görmez. Bu testin kontratı: clamp kararında boyut 0 olur.
     match classify_file_size(-42) {
         FileSizeGuard::Clamped => { /* UI'a 0 yazılmalı — bkz. connection.rs */ }
-        other => panic!("negatif size Clamped beklenirdi, geldi: {:?}", other),
+        other => panic!("negatif size Clamped beklenirdi, geldi: {other:?}"),
     }
 }

--- a/crates/hekadrop-app/tests/frame_codec.rs
+++ b/crates/hekadrop-app/tests/frame_codec.rs
@@ -123,7 +123,7 @@ fn truncated_length_prefix_hata_doner() {
     let buf = [0x00u8, 0x00, 0x01]; // 4. byte eksik
     let mut cur = Cursor::new(&buf[..]);
     let err = read_frame(&mut cur).expect_err("truncated hata bekleniyor");
-    assert!(matches!(err, FrameError::Truncated), "err={:?}", err);
+    assert!(matches!(err, FrameError::Truncated), "err={err:?}");
 }
 
 #[test]
@@ -133,7 +133,7 @@ fn truncated_body_hata_doner() {
     buf.extend_from_slice(&[0xAA, 0xBB, 0xCC]);
     let mut cur = Cursor::new(&buf);
     let err = read_frame(&mut cur).expect_err("truncated body");
-    assert!(matches!(err, FrameError::Truncated), "err={:?}", err);
+    assert!(matches!(err, FrameError::Truncated), "err={err:?}");
 }
 
 #[test]
@@ -155,7 +155,7 @@ fn cok_buyuk_frame_reddedilir() {
     let err = read_frame(&mut cur).expect_err("TooLarge");
     match err {
         FrameError::TooLarge(n) => assert_eq!(n as u32, too_big),
-        _ => panic!("TooLarge beklendi, got: {:?}", err),
+        _ => panic!("TooLarge beklendi, got: {err:?}"),
     }
 }
 

--- a/crates/hekadrop-app/tests/frame_limits.rs
+++ b/crates/hekadrop-app/tests/frame_limits.rs
@@ -99,7 +99,7 @@ fn frame_too_large_reddedilir() {
         FrameError::TooLarge(n) => {
             assert_eq!(n, MAX_FRAME_SIZE + 1);
         }
-        other => panic!("TooLarge beklendi, aldı: {:?}", other),
+        other => panic!("TooLarge beklendi, aldı: {other:?}"),
     }
 
     // Tam sınır değer (16 MiB) kabul — bu davranışı da pin'le.
@@ -123,8 +123,7 @@ fn truncated_frame_eof_doner() {
     let err = read_frame(&mut cur).expect_err("truncated body EOF döndürmeli");
     assert!(
         matches!(err, FrameError::Eof),
-        "Eof bekleniyor, aldı: {:?}",
-        err
+        "Eof bekleniyor, aldı: {err:?}"
     );
 
     // Length-prefix bile tam gelmezse (2/4 bayt) yine EOF.
@@ -133,8 +132,7 @@ fn truncated_frame_eof_doner() {
     let err = read_frame(&mut cur).expect_err("prefix truncated");
     assert!(
         matches!(err, FrameError::Eof),
-        "Eof bekleniyor, aldı: {:?}",
-        err
+        "Eof bekleniyor, aldı: {err:?}"
     );
 }
 
@@ -166,8 +164,8 @@ fn huge_length_u32_max_reddedilir() {
         FrameError::TooLarge(n) => {
             // 32-bit: n == u32::MAX as usize. 64-bit: aynı. Her iki yönde de
             // MAX_FRAME_SIZE'ın çok üstündedir.
-            assert!(n > MAX_FRAME_SIZE, "absürt değer: {}", n);
+            assert!(n > MAX_FRAME_SIZE, "absürt değer: {n}");
         }
-        other => panic!("TooLarge beklendi, aldı: {:?}", other),
+        other => panic!("TooLarge beklendi, aldı: {other:?}"),
     }
 }

--- a/crates/hekadrop-app/tests/hmac_tag_length.rs
+++ b/crates/hekadrop-app/tests/hmac_tag_length.rs
@@ -88,11 +88,10 @@ fn decrypt_rejects_short_hmac_tag() {
     let err = b
         .decrypt(&short_bytes)
         .expect_err("31-bayt tag reddedilmeli");
-    let msg = format!("{}", err);
+    let msg = format!("{err}");
     assert!(
         msg.contains("HMAC tag") || msg.contains("tag uzunluğu"),
-        "uzunluk hatası beklenir, alınan: {}",
-        msg
+        "uzunluk hatası beklenir, alınan: {msg}"
     );
 
     // İstemci seq'i advance etmemeli — state bozulmamalı, retry desteklenebilir.

--- a/crates/hekadrop-app/tests/payload_corrupt.rs
+++ b/crates/hekadrop-app/tests/payload_corrupt.rs
@@ -90,7 +90,7 @@ fn frame(
 fn tmp(label: &str) -> std::path::PathBuf {
     let pid = std::process::id();
     let rnd: u64 = rand::random();
-    std::env::temp_dir().join(format!("hd-payload-corrupt-{}-{}-{}.bin", label, pid, rnd))
+    std::env::temp_dir().join(format!("hd-payload-corrupt-{label}-{pid}-{rnd}.bin"))
 }
 
 #[tokio::test]
@@ -166,8 +166,7 @@ async fn duplicate_payload_id_reddedilir() {
     let msg = err.to_string();
     assert!(
         msg.contains("duplicate") || msg.contains("777"),
-        "hata mesajı duplicate/ id belirtmeli, aldı: {}",
-        msg
+        "hata mesajı duplicate/ id belirtmeli, aldı: {msg}"
     );
 }
 
@@ -204,7 +203,7 @@ async fn out_of_order_chunks_dogru_konuma_yazilir() {
                 "arrival-order append: offset alanı yazım pozisyonu için değil"
             );
         }
-        other => panic!("File bekleniyor, {:?}", other),
+        other => panic!("File bekleniyor, {other:?}"),
     }
     let _ = std::fs::remove_file(&path);
 }
@@ -233,8 +232,7 @@ async fn total_size_overrun_reddedilir() {
     let msg = err.to_string();
     assert!(
         msg.contains("overrun"),
-        "overrun mesajı bekleniyor, aldı: {}",
-        msg
+        "overrun mesajı bekleniyor, aldı: {msg}"
     );
     let _ = std::fs::remove_file(&path);
 }

--- a/crates/hekadrop-app/tests/save_non_blocking.rs
+++ b/crates/hekadrop-app/tests/save_non_blocking.rs
@@ -100,7 +100,7 @@ struct Payload {
 impl Payload {
     fn new() -> Self {
         Self {
-            devices: (0..32).map(|i| format!("device-{}", i)).collect(),
+            devices: (0..32).map(|i| format!("device-{i}")).collect(),
             flags: vec![false; 64],
             counters: vec![0; 64],
         }
@@ -199,15 +199,12 @@ fn save_write_lock_not_held_during_disk_io() {
     // — her writer iterasyonu reader'ı tam blokladığı için max >= 5 ms.
     assert!(
         samples > 10,
-        "reader yeterince örnekleme yapamadı: {}",
-        samples
+        "reader yeterince örnekleme yapamadı: {samples}"
     );
     assert!(
         max_ms < 100.0,
-        "read() acquire max {:.3} ms — snapshot pattern regress olmuş olabilir \
-         (write guard disk I/O altında tutuluyor). Örnek sayısı: {}",
-        max_ms,
-        samples
+        "read() acquire max {max_ms:.3} ms — snapshot pattern regress olmuş olabilir \
+         (write guard disk I/O altında tutuluyor). Örnek sayısı: {samples}"
     );
 }
 
@@ -278,7 +275,6 @@ fn regressed_pattern_blocks_reader_self_check() {
     // Regressed pattern reader'ı en az save_slow süresi (5 ms) kadar bloklar.
     assert!(
         max_ms >= 3.0,
-        "regressed pattern reader'ı {:.3} ms bekletti — beklenen >=3 ms",
-        max_ms
+        "regressed pattern reader'ı {max_ms:.3} ms bekletti — beklenen >=3 ms"
     );
 }

--- a/crates/hekadrop-app/tests/secure_roundtrip.rs
+++ b/crates/hekadrop-app/tests/secure_roundtrip.rs
@@ -208,7 +208,7 @@ fn secure_roundtrip_ab_a_dan_b_ye() {
 fn sequence_counter_monoton_artar() {
     let (mut a, mut b) = make_pair();
     for i in 1..=5 {
-        let msg = format!("msg #{}", i);
+        let msg = format!("msg #{i}");
         let enc = a.encrypt(msg.as_bytes());
         let dec = b.decrypt(&enc).expect("decrypt");
         assert_eq!(dec, msg.as_bytes());
@@ -232,7 +232,7 @@ fn replay_saldirisi_ayni_seq_ikinci_kez_rejected() {
     assert!(replay.is_err(), "replay reddedilmeli");
     // Hata türü sequence ile ilgili olmalı
     let err = replay.unwrap_err();
-    assert!(err.contains("sequence"), "sequence error: got '{}'", err);
+    assert!(err.contains("sequence"), "sequence error: got '{err}'");
 }
 
 /// Out-of-order: seq atlanırsa reject. Göndericiden 3 mesaj geliyor ama
@@ -282,7 +282,7 @@ fn tampered_hmac_reddedilir() {
     let r = b.decrypt(&enc);
     assert!(r.is_err(), "HMAC bozulmuşken reddedilmeli");
     let e = r.unwrap_err();
-    assert!(e.contains("HMAC"), "HMAC error beklenir: '{}'", e);
+    assert!(e.contains("HMAC"), "HMAC error beklenir: '{e}'");
 }
 
 /// Ciphertext tampering (HMAC'i yeniden hesaplamadan ciphertext'i değiştir):

--- a/crates/hekadrop-app/tests/ukey2_handshake.rs
+++ b/crates/hekadrop-app/tests/ukey2_handshake.rs
@@ -182,7 +182,7 @@ fn pin_code_her_zaman_4_basamak() {
     for key_seed in [0u8, 1, 42, 0xFF, 0x80, 0x7F] {
         let key = [key_seed; 32];
         let pin = pin_code_from_auth_key(&key);
-        assert_eq!(pin.len(), 4, "PIN her zaman 4 karakter olmalı: '{}'", pin);
+        assert_eq!(pin.len(), 4, "PIN her zaman 4 karakter olmalı: '{pin}'");
         assert!(pin.chars().all(|c| c.is_ascii_digit()), "PIN sadece digit");
     }
 }

--- a/crates/hekadrop-core/src/connection.rs
+++ b/crates/hekadrop-core/src/connection.rs
@@ -65,7 +65,7 @@ pub async fn handle(
     // `TransferGuard::new()` içinde auto clear_cancel — bu bağlantıya özel
     // child token hem taze root'a hem de scope sonunda active_transfers
     // map'inden otomatik temizliğe (early-return yollarında bile) garanti verir.
-    let guard = state::TransferGuard::new(Arc::clone(&state), format!("in:{}", peer));
+    let guard = state::TransferGuard::new(Arc::clone(&state), format!("in:{peer}"));
     let cancel = guard.token.clone();
 
     // 1) plain ConnectionRequest
@@ -839,7 +839,7 @@ async fn handle_sharing_frame(
                 );
                 ui.notify(UiNotification::ToastRaw {
                     title: "HekaDrop".to_string(),
-                    body: format!("{} artık güvenilir cihaz", remote_name),
+                    body: format!("{remote_name} artık güvenilir cihaz"),
                 });
             }
 
@@ -877,7 +877,7 @@ async fn handle_sharing_frame(
                 info!("[{}] ✗ kullanıcı reddetti", peer);
                 ui.notify(UiNotification::ToastRaw {
                     title: "HekaDrop".to_string(),
-                    body: format!("{}: aktarım reddedildi", remote_name),
+                    body: format!("{remote_name}: aktarım reddedildi"),
                 });
                 return Ok(FlowOutcome::Disconnect);
             }
@@ -958,7 +958,7 @@ fn preview(s: &str, max: usize) -> String {
         s.to_string()
     } else {
         let truncated: String = s.chars().take(max).collect();
-        format!("{}…", truncated)
+        format!("{truncated}…")
     }
 }
 
@@ -987,7 +987,7 @@ fn human_size(bytes: i64) -> String {
         i += 1;
     }
     if i == 0 {
-        format!("{} B", bytes)
+        format!("{bytes} B")
     } else {
         format!("{:.1} {}", n, UNITS[i])
     }
@@ -1029,7 +1029,7 @@ fn unique_downloads_path(name: &str, state: &AppState) -> Result<PathBuf> {
     match try_reserve(&candidate) {
         Ok(()) => return Ok(candidate),
         Err(e) if e.kind() != std::io::ErrorKind::AlreadyExists => {
-            return Err(anyhow!("dosya rezerve edilemedi: {}", e));
+            return Err(anyhow!("dosya rezerve edilemedi: {e}"));
         }
         Err(_) => {}
     }
@@ -1038,15 +1038,15 @@ fn unique_downloads_path(name: &str, state: &AppState) -> Result<PathBuf> {
     let mut n = 1;
     loop {
         let filename = if ext.is_empty() {
-            format!("{} ({})", stem, n)
+            format!("{stem} ({n})")
         } else {
-            format!("{} ({}).{}", stem, n, ext)
+            format!("{stem} ({n}).{ext}")
         };
         let next = base.join(filename);
         match try_reserve(&next) {
             Ok(()) => return Ok(next),
             Err(e) if e.kind() != std::io::ErrorKind::AlreadyExists => {
-                return Err(anyhow!("dosya rezerve edilemedi: {}", e));
+                return Err(anyhow!("dosya rezerve edilemedi: {e}"));
             }
             Err(_) => {}
         }
@@ -1124,7 +1124,7 @@ fn sanitize_received_name(name: &str) -> String {
         .iter()
         .any(|r| stem_for_reserved.eq_ignore_ascii_case(r))
     {
-        format!("_{}", cleaned)
+        format!("_{cleaned}")
     } else {
         cleaned
     };

--- a/crates/hekadrop-core/src/identity.rs
+++ b/crates/hekadrop-core/src/identity.rs
@@ -299,8 +299,7 @@ mod tests {
         let mode = meta.permissions().mode() & 0o777;
         assert_eq!(
             mode, 0o600,
-            "identity.key 0o600 olmalı, bulunan: 0o{:o}",
-            mode
+            "identity.key 0o600 olmalı, bulunan: 0o{mode:o}"
         );
         let _ = std::fs::remove_dir_all(path.parent().unwrap());
     }
@@ -315,8 +314,7 @@ mod tests {
         let err = format!("{:#}", res.err().unwrap());
         assert!(
             err.contains("bozuk") || err.contains("32 bayt"),
-            "hata mesajı bozukluğu belirtmeli: {}",
-            err
+            "hata mesajı bozukluğu belirtmeli: {err}"
         );
         let _ = std::fs::remove_dir_all(path.parent().unwrap());
     }

--- a/crates/hekadrop-core/src/log_redact.rs
+++ b/crates/hekadrop-core/src/log_redact.rs
@@ -57,7 +57,7 @@ pub fn url_scheme_host(url: &str) -> String {
     if host_port.is_empty() {
         return "<unparsable>".to_string();
     }
-    format!("{}://{}", scheme, host_port)
+    format!("{scheme}://{host_port}")
 }
 
 #[cfg(test)]

--- a/crates/hekadrop-core/src/payload.rs
+++ b/crates/hekadrop-core/src/payload.rs
@@ -256,8 +256,7 @@ impl PayloadAssembler {
             PayloadType::Bytes => self.ingest_bytes(id, body, last_chunk),
             PayloadType::File => self.ingest_file(id, total_size, body, last_chunk).await,
             other => Err(HekaError::ProtocolState(format!(
-                "desteklenmeyen payload tipi: {:?}",
-                other
+                "desteklenmeyen payload tipi: {other:?}"
             ))
             .into()),
         }
@@ -322,7 +321,7 @@ impl PayloadAssembler {
             let dest = self
                 .pending_destinations
                 .remove(&id)
-                .ok_or_else(|| anyhow!("payload_id={} için destination kayıtlı değil", id))?;
+                .ok_or_else(|| anyhow!("payload_id={id} için destination kayıtlı değil"))?;
             // SECURITY: `total_size` negatif ya da absürt büyükse en başta reddet.
             // Aksi halde `(written*100)/total` integer aritmetiği taşar ve
             // saldırgan terabaytlık disk doldurma isteği UI/progress yoluyla
@@ -384,7 +383,7 @@ impl PayloadAssembler {
             let sink = self
                 .file_sinks
                 .get_mut(&id)
-                .ok_or_else(|| anyhow!("file_sink kayıp: id={}", id))?;
+                .ok_or_else(|| anyhow!("file_sink kayıp: id={id}"))?;
             // SECURITY: Cumulative overrun koruması — saldırgan `total_size=10`
             // deklare edip gigabaytlarca chunk yollayarak disk doldurabilir.
             // usize → i64: pratikte body 4 MiB ile sınırlı (CHUNK_SIZE),
@@ -397,7 +396,7 @@ impl PayloadAssembler {
             let new_written = sink
                 .written
                 .checked_add(body_len)
-                .ok_or_else(|| HekaError::PayloadIo(format!("yazım toplamı taştı (id={})", id)))?;
+                .ok_or_else(|| HekaError::PayloadIo(format!("yazım toplamı taştı (id={id})")))?;
             if new_written > sink.total_size {
                 return Err(HekaError::PayloadOverrun {
                     id,
@@ -421,7 +420,7 @@ impl PayloadAssembler {
             let mut sink = self
                 .file_sinks
                 .remove(&id)
-                .ok_or_else(|| anyhow!("son chunk ama sink yok: id={}", id))?;
+                .ok_or_else(|| anyhow!("son chunk ama sink yok: id={id}"))?;
             // SECURITY: Peer `last_chunk=true` gönderip yarım dosyayı tamamlanmış
             // gibi onaylatabilir (silent truncation). Toplam byte sayısı
             // bildirilen total_size ile eşleşmezse reddet.
@@ -541,7 +540,7 @@ mod tests {
                 assert_eq!(id, 42);
                 assert_eq!(data, b"hello");
             }
-            other => panic!("beklenen Bytes, {:?} geldi", other),
+            other => panic!("beklenen Bytes, {other:?} geldi"),
         }
         assert_eq!(a.partial_count(), 0, "tamamlanan bytes temizlenmeli");
     }
@@ -555,7 +554,7 @@ mod tests {
         let done = a.ingest(&f2).await.unwrap().expect("last chunk tamamlar");
         match done {
             CompletedPayload::Bytes { data, .. } => assert_eq!(data, b"foobar"),
-            other => panic!("{:?}", other),
+            other => panic!("{other:?}"),
         }
     }
 
@@ -656,7 +655,7 @@ mod tests {
     async fn cancel_removes_bytes_file_and_pending() {
         let pid = std::process::id();
         let rnd: u32 = rand::random();
-        let tmp = std::env::temp_dir().join(format!("hekadrop-cancel-test-{}-{}.part", pid, rnd));
+        let tmp = std::env::temp_dir().join(format!("hekadrop-cancel-test-{pid}-{rnd}.part"));
         let _ = std::fs::remove_file(&tmp);
         let mut a = PayloadAssembler::new();
 
@@ -671,8 +670,7 @@ mod tests {
             .unwrap();
         assert!(tmp.exists());
         // pending destination — review-18 MED: cancel artık placeholder'ı da silmeli.
-        let tmp2 =
-            std::env::temp_dir().join(format!("hekadrop-cancel-pending-{}-{}.part", pid, rnd));
+        let tmp2 = std::env::temp_dir().join(format!("hekadrop-cancel-pending-{pid}-{rnd}.part"));
         // Diskte sıfır bayt placeholder simulate et (unique_downloads_path davranışı).
         std::fs::write(&tmp2, b"").expect("placeholder yarat");
         a.register_file_destination(3, tmp2.clone()).unwrap();
@@ -699,8 +697,8 @@ mod tests {
         // reddetmelidir.
         let pid = std::process::id();
         let rnd: u32 = rand::random();
-        let real = std::env::temp_dir().join(format!("hekadrop-symlink-real-{}-{}.bin", pid, rnd));
-        let link = std::env::temp_dir().join(format!("hekadrop-symlink-link-{}-{}.bin", pid, rnd));
+        let real = std::env::temp_dir().join(format!("hekadrop-symlink-real-{pid}-{rnd}.bin"));
+        let link = std::env::temp_dir().join(format!("hekadrop-symlink-link-{pid}-{rnd}.bin"));
         let _ = std::fs::remove_file(&real);
         let _ = std::fs::remove_file(&link);
         std::fs::write(&real, b"").expect("real yarat");
@@ -714,8 +712,7 @@ mod tests {
             .expect_err("symlink hedef reddedilmeli");
         assert!(
             err.to_string().contains("symlink"),
-            "hata mesajı symlink belirtmeli, aldı: {}",
-            err
+            "hata mesajı symlink belirtmeli, aldı: {err}"
         );
 
         let _ = std::fs::remove_file(&link);
@@ -727,7 +724,7 @@ mod tests {
         // review-18: 1 TiB üstü bildirilen dosya başlamadan reddedilmeli.
         let pid = std::process::id();
         let rnd: u32 = rand::random();
-        let tmp = std::env::temp_dir().join(format!("hekadrop-absurd-{}-{}.bin", pid, rnd));
+        let tmp = std::env::temp_dir().join(format!("hekadrop-absurd-{pid}-{rnd}.bin"));
         let _ = std::fs::remove_file(&tmp);
         std::fs::write(&tmp, b"").expect("placeholder");
 
@@ -746,8 +743,7 @@ mod tests {
             .expect_err("absurd total_size reddedilmeli");
         assert!(
             err.to_string().contains("absürt") || err.to_string().contains("1 TiB"),
-            "hata mesajı limit belirtmeli, aldı: {}",
-            err
+            "hata mesajı limit belirtmeli, aldı: {err}"
         );
         let _ = std::fs::remove_file(&tmp);
     }
@@ -799,7 +795,7 @@ mod tests {
                 };
                 assert_eq!(sha256, expected);
             }
-            other => panic!("beklenen File, {:?} geldi", other),
+            other => panic!("beklenen File, {other:?} geldi"),
         }
         // Dosyayı oku ve içeriğini doğrula.
         let content = std::fs::read(&tmp).unwrap();

--- a/crates/hekadrop-core/src/secure.rs
+++ b/crates/hekadrop-core/src/secure.rs
@@ -126,7 +126,7 @@ impl SecureCtx {
         iv.copy_from_slice(&iv_vec);
 
         let plaintext = crypto::aes256_cbc_decrypt(&self.decrypt_key, &iv, &hb.body)
-            .map_err(|e| anyhow!("AES decrypt: {:?}", e))?;
+            .map_err(|e| anyhow!("AES decrypt: {e:?}"))?;
 
         let d2d = DeviceToDeviceMessage::decode(&plaintext[..])?;
         let seq = d2d
@@ -183,7 +183,7 @@ mod tests {
     fn sequence_number_artar() {
         let (mut a, mut b) = make_pair();
         for i in 1..=5 {
-            let msg = format!("mesaj {}", i);
+            let msg = format!("mesaj {i}");
             let enc = a.encrypt(msg.as_bytes()).unwrap();
             let dec = b.decrypt(&enc).expect("decrypt");
             assert_eq!(dec.as_ref(), msg.as_bytes());

--- a/crates/hekadrop-core/src/sender.rs
+++ b/crates/hekadrop-core/src/sender.rs
@@ -735,13 +735,13 @@ async fn send_text_bytes(
         let body = data[offset..end].to_vec();
         let last_flag = 0;
         let offset_i64 = i64::try_from(offset)
-            .with_context(|| format!("metin payload offset'i çok büyük: {}", offset))?;
+            .with_context(|| format!("metin payload offset'i çok büyük: {offset}"))?;
         let wrapped = wrap_bytes_payload_transfer(payload_id, total, offset_i64, last_flag, body);
         let enc = ctx.encrypt(&wrapped.encode_to_vec())?;
         frame::write_frame(socket, &enc).await?;
         offset = end;
         let offset_i64 = i64::try_from(offset)
-            .with_context(|| format!("metin payload offset'i çok büyük: {}", offset))?;
+            .with_context(|| format!("metin payload offset'i çok büyük: {offset}"))?;
         if let Some(percent) = compute_percent(0, offset_i64, total) {
             state.set_progress(ProgressState::Receiving {
                 device: peer_label.to_string(),

--- a/crates/hekadrop-core/src/settings.rs
+++ b/crates/hekadrop-core/src/settings.rs
@@ -147,7 +147,10 @@ mod hex_hash_opt {
 
     // serde signature kontratı `&Option<T>` ister — pass-by-value yapılamaz.
     #[allow(clippy::trivially_copy_pass_by_ref)]
-    pub fn serialize<S: Serializer>(value: &Option<[u8; 6]>, s: S) -> Result<S::Ok, S::Error> {
+    pub(super) fn serialize<S: Serializer>(
+        value: &Option<[u8; 6]>,
+        s: S,
+    ) -> Result<S::Ok, S::Error> {
         match value {
             Some(bytes) => s.serialize_str(&hex::encode(bytes)),
             // skip_serializing_if zaten None'u atlıyor — buraya düşülmez,
@@ -156,7 +159,9 @@ mod hex_hash_opt {
         }
     }
 
-    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Option<[u8; 6]>, D::Error> {
+    pub(super) fn deserialize<'de, D: Deserializer<'de>>(
+        d: D,
+    ) -> Result<Option<[u8; 6]>, D::Error> {
         let opt: Option<String> = Option::deserialize(d)?;
         let Some(raw) = opt else {
             return Ok(None);

--- a/crates/hekadrop-core/src/settings.rs
+++ b/crates/hekadrop-core/src/settings.rs
@@ -162,7 +162,7 @@ mod hex_hash_opt {
             return Ok(None);
         };
         let bytes = hex::decode(&raw)
-            .map_err(|e| D::Error::custom(format!("secret_id_hash hex decode: {}", e)))?;
+            .map_err(|e| D::Error::custom(format!("secret_id_hash hex decode: {e}")))?;
         if bytes.len() != 6 {
             return Err(D::Error::custom(format!(
                 "secret_id_hash 6 bayt bekleniyor, bulunan {}",
@@ -624,7 +624,7 @@ static DEBOUNCE_TASK: parking_lot::Mutex<Option<tokio::task::JoinHandle<()>>> =
 pub fn validate_download_dir(path: &Path) -> Result<()> {
     let meta = std::fs::metadata(path).map_err(|e| HekaError::DownloadDirInvalid {
         path: path.display().to_string(),
-        reason: format!("okunamadı: {}", e),
+        reason: format!("okunamadı: {e}"),
     })?;
     if !meta.is_dir() {
         return Err(HekaError::DownloadDirInvalid {
@@ -641,7 +641,7 @@ pub fn validate_download_dir(path: &Path) -> Result<()> {
         }
         Err(e) => Err(HekaError::DownloadDirInvalid {
             path: path.display().to_string(),
-            reason: format!("yazılabilir değil: {}", e),
+            reason: format!("yazılabilir değil: {e}"),
         }
         .into()),
     }
@@ -782,7 +782,7 @@ pub(crate) fn atomic_write_mode(
     let (mut file, tmp_path) = loop {
         attempts += 1;
         let r = rand::thread_rng().next_u64();
-        let tmp = parent.join(format!(".{}.{}.{:016x}.tmp", file_name, pid, r));
+        let tmp = parent.join(format!(".{file_name}.{pid}.{r:016x}.tmp"));
         let mut opts = std::fs::OpenOptions::new();
         opts.write(true).create_new(true);
         #[cfg(unix)]
@@ -838,8 +838,7 @@ pub(crate) fn migrate_trusted_value(v: serde_json::Value) -> Result<Vec<TrustedD
         serde_json::Value::Array(a) => a,
         other => {
             return Err(format!(
-                "trusted_devices array bekleniyordu, geldi: {:?}",
-                other
+                "trusted_devices array bekleniyordu, geldi: {other:?}"
             ))
         }
     };
@@ -859,15 +858,14 @@ pub(crate) fn migrate_trusted_value(v: serde_json::Value) -> Result<Vec<TrustedD
             }
             serde_json::Value::Object(_) => {
                 let td: TrustedDevice = serde_json::from_value(item)
-                    .map_err(|e| format!("TrustedDevice parse: {}", e))?;
+                    .map_err(|e| format!("TrustedDevice parse: {e}"))?;
                 if !td.name.is_empty() {
                     out.push(td);
                 }
             }
             other => {
                 return Err(format!(
-                    "trusted_devices elemanı beklenmeyen tip: {:?}",
-                    other
+                    "trusted_devices elemanı beklenmeyen tip: {other:?}"
                 ))
             }
         }
@@ -1088,7 +1086,7 @@ mod tests {
         use std::thread;
         let mut s = Settings::default();
         for i in 0..50 {
-            s.add_trusted(&format!("dev-{}", i), &format!("id-{}", i));
+            s.add_trusted(&format!("dev-{i}"), &format!("id-{i}"));
         }
         let arc = Arc::new(s);
         let handles: Vec<_> = (0..8)
@@ -1320,8 +1318,7 @@ mod tests {
         // Hex string'in JSON'da göründüğünü doğrula.
         assert!(
             json.contains("\"deadbeef0042\""),
-            "beklenen hex yok: {}",
-            json
+            "beklenen hex yok: {json}"
         );
         let back: Settings = serde_json::from_str(&json).expect("parse");
         assert_eq!(back.trusted_devices[0].secret_id_hash, Some(hash));
@@ -1532,7 +1529,7 @@ mod tests {
             ..Settings::default()
         };
         let json = serde_json::to_string(&s).expect("serialize");
-        assert!(json.contains("\"warn\""), "lowercase beklenir: {}", json);
+        assert!(json.contains("\"warn\""), "lowercase beklenir: {json}");
     }
 
     #[test]
@@ -1669,8 +1666,7 @@ mod tests {
         assert!(
             owner_bits <= 0o600,
             "owner bitleri 0o600'den fazla olmamalı (mode(0o600) umask'i gevşetmez): \
-             0o{:o}",
-            owner_bits
+             0o{owner_bits:o}"
         );
         let _ = std::fs::remove_dir_all(&dir);
     }
@@ -1752,7 +1748,7 @@ mod tests {
             .map(|i| {
                 let t = Arc::clone(&target);
                 thread::spawn(move || {
-                    let payload = format!("thread-{}", i);
+                    let payload = format!("thread-{i}");
                     for _ in 0..16 {
                         atomic_write(&t, payload.as_bytes()).expect("atomic_write ok");
                     }

--- a/crates/hekadrop-core/src/ukey2.rs
+++ b/crates/hekadrop-core/src/ukey2.rs
@@ -138,7 +138,7 @@ pub async fn client_handshake(socket: &mut TcpStream) -> Result<DerivedKeys> {
     uncompressed.extend_from_slice(&peer_x);
     uncompressed.extend_from_slice(&peer_y);
     let encoded =
-        EncodedPoint::from_bytes(&uncompressed).map_err(|e| anyhow!("peer pubkey parse: {}", e))?;
+        EncodedPoint::from_bytes(&uncompressed).map_err(|e| anyhow!("peer pubkey parse: {e}"))?;
     let peer_pk = PublicKey::from_encoded_point(&encoded);
     let peer_pk = Option::<PublicKey>::from(peer_pk)
         .ok_or_else(|| anyhow!("peer pubkey geçersiz eğri noktası"))?;
@@ -249,8 +249,7 @@ pub fn process_client_init(client_init_frame: &[u8]) -> Result<ServerInitResult>
     // 2 = CLIENT_INIT
     if message_type != 2 {
         return Err(HekaError::ProtocolState(format!(
-            "beklenen CLIENT_INIT, alınan {}",
-            message_type
+            "beklenen CLIENT_INIT, alınan {message_type}"
         ))
         .into());
     }
@@ -271,7 +270,7 @@ pub fn process_client_init(client_init_frame: &[u8]) -> Result<ServerInitResult>
     let next_protocol = ci.next_protocol();
     if next_protocol != "AES_256_CBC-HMAC_SHA256" {
         return Err(
-            HekaError::Ukey2(format!("desteklenmeyen next_protocol: {}", next_protocol)).into(),
+            HekaError::Ukey2(format!("desteklenmeyen next_protocol: {next_protocol}")).into(),
         );
     }
 
@@ -389,8 +388,7 @@ pub fn process_client_finish(raw_frame: &[u8], state: &ServerInitResult) -> Resu
         .ok_or_else(|| HekaError::Protocol("mesaj verisi yok".into()))?;
     if message_type != 4 {
         return Err(HekaError::ProtocolState(format!(
-            "beklenen CLIENT_FINISH, alınan {}",
-            message_type
+            "beklenen CLIENT_FINISH, alınan {message_type}"
         ))
         .into());
     }
@@ -424,7 +422,7 @@ pub fn process_client_finish(raw_frame: &[u8], state: &ServerInitResult) -> Resu
     uncompressed.extend_from_slice(&peer_x);
     uncompressed.extend_from_slice(&peer_y);
     let encoded =
-        EncodedPoint::from_bytes(&uncompressed).map_err(|e| anyhow!("peer pubkey parse: {}", e))?;
+        EncodedPoint::from_bytes(&uncompressed).map_err(|e| anyhow!("peer pubkey parse: {e}"))?;
     let peer_pk = PublicKey::from_encoded_point(&encoded);
     let peer_pk = Option::<PublicKey>::from(peer_pk)
         .ok_or_else(|| anyhow!("peer pubkey geçersiz eğri noktası"))?;

--- a/crates/hekadrop-net/src/mdns.rs
+++ b/crates/hekadrop-net/src/mdns.rs
@@ -68,7 +68,7 @@ pub fn advertise(device_name: &str, port: u16) -> Result<Option<MdnsHandle>> {
     let info = ServiceInfo::new(
         &service_type,
         &instance,
-        &format!("{}.local.", instance),
+        &format!("{instance}.local."),
         &addrs[..],
         port,
         &[("n", endpoint_info_b64.as_str())][..],

--- a/crates/hekadrop-proto/build.rs
+++ b/crates/hekadrop-proto/build.rs
@@ -17,7 +17,7 @@ fn main() -> Result<()> {
     ];
 
     for p in &protos {
-        println!("cargo:rerun-if-changed={}", p);
+        println!("cargo:rerun-if-changed={p}");
     }
     println!("cargo:rerun-if-changed=build.rs");
 


### PR DESCRIPTION
## Özet

PR #87 deferred strictness sweep listesinden **2 madde tek PR'da** (önceden #105 + #106 olarak ayrı açılmıştı, mekanik auto-fix sweep'leri olduğu için birleştirildi — tek CI run, tek review siklusu).

## Madde 1 — `clippy::uninlined_format_args` (110 site)

PR #87'de auto-fix uygulanmıştı ama lint **enable edilmemişti**, dolayısıyla v0.7 boyunca 110 yeni site birikmişti. Bu PR auto-fix'i tekrar uygular + workspace.lints'e ekler.

* \`cargo clippy --fix --workspace --all-targets --all-features -- -W clippy::uninlined_format_args\` → 110 site otomatik (\`format!("{}", x)\` → \`format!("{x}")\`)
* 23 dosya (proto build.rs dahil), 109 ekleme / 139 silme — net küçülme

## Madde 2 — `unreachable_pub` (58 hit, was 349)

PR #87'de 349 hit vardı; **RFC-0001 workspace refactor (Adım 1-8) sonrası** core/app split + shim re-export pattern'i sayesinde 58'e düştü. Çoğu app crate'inin "ex-monolith" pub items.

* \`cargo clippy --fix --workspace --all-targets --all-features -- -W unreachable_pub\` → 53 site \`pub\` → \`pub(crate)\`
* Etkilenen: \`state.rs\` (15), \`ui.rs\` (12), \`platform.rs\` (9), \`tests/common/mod.rs\` (6), \`i18n.rs\` (4), \`ui_adapter.rs\` (4), \`paths.rs\` (1), \`core/settings.rs\` (2 serde helper)
* **Hiçbir external API kırılmadı** — core public surface (lib.rs \`pub use hekadrop_core::*\` ile re-export edilenler) DEĞİŞMEDİ

## Lint config (root Cargo.toml)

\`\`\`toml
[workspace.lints.rust]
unreachable_pub = "warn"  # workspace refactor sonrası 58 hit cleanup + enforce

[workspace.lints.clippy]
uninlined_format_args = "warn"  # PR #87 auto-fix sonrası 110 site birikmişti
\`\`\`

Header yorumdaki "Kapsam dışı" tablosu güncellendi — her ikisi enforce listesine geçti.

## CLAUDE.md pre-commit invariant scan

| Kontrol | Sonuç |
|---|---|
| \`cargo clippy -D warnings\` | ✓ |
| \`cargo test --workspace\` | ✓ 27 test suite (davranış parity) |
| \`cargo fmt --check\` | ✓ |
| \`cargo machete\` | ✓ |
| \`typos\` | ✓ |
| I-1 (core'da app modül) | değişmedi ✓ |
| I-2 (yeni allow) | yok ✓ |

## Test plan

- [x] Lokal CI dry-run yeşil (her 2 madde için)
- [ ] CI matrix (mac/Linux/Windows + extra-lints + cargo-deny + coverage)

## Sıradaki

PR #87 deferred listesi durumu:

| Lint | Hit | Durum |
|---|---|---|
| \`cast_possible_wrap\` | 36 | ✓ #101 |
| \`uninlined_format_args\` | 110 | ✓ **bu PR** |
| \`unreachable_pub\` | 58 | ✓ **bu PR** |
| \`clippy::pedantic\` umbrella | ~1,228 | sırada — modular yapılacak |
| \`clippy::doc_markdown\` | 445+792 | sonra |
| \`must_use_candidate\` | 71 | annotation pass |
| \`match_same_arms\`, \`items_after_statements\`, vb. | <100 each | sonra |

Closes #105, #106 (aynı işin ayrı PR'larıydı; mekanik sweep'ler tek PR'da daha iyi).

🤖 Generated with [Claude Code](https://claude.com/claude-code)