### PR TITLE
chore(lint): match_same_arms enforce — 3 scoped allow + lint enable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ homepage = "https://github.com/YatogamiRaito/HekaDrop"
 #   * clippy::pedantic umbrella (~1,228 hit)        — issue #TBD
 #   * clippy::doc_markdown (445 hand + 792 gen)     — issue #TBD
 #   * clippy::must_use_candidate (71 hand)          — issue #TBD
-#   * clippy::match_same_arms (68)                  — issue #TBD
 #   * unused_crate_dependencies                     — false-pos cascade, atlandı
 #
 # v0.7.x ile enforce edilenler (önceki "RED" listesinden):
@@ -76,6 +75,7 @@ redundant_clone = "warn"
 use_self = "warn"
 # Kalite — düşük volüm, anlık temizlik
 uninlined_format_args = "warn"  # PR #87 auto-fix sonrası 110 yeni site birikmişti; auto-fix tekrar uygulandı + lint enforce
+match_same_arms = "warn"        # i18n table + 2 dokümantasyon arm scoped allow ile (PR #87 deferred)
 manual_let_else = "warn"
 ignored_unit_patterns = "warn"
 trivially_copy_pass_by_ref = "warn"

--- a/crates/hekadrop-app/src/i18n.rs
+++ b/crates/hekadrop-app/src/i18n.rs
@@ -136,6 +136,12 @@ pub(crate) fn apply_args(template: &str, args: &[&str]) -> String {
 // ---------------------------------------------------------------------------
 // Türkçe çeviriler (default)
 // ---------------------------------------------------------------------------
+// i18n key→string lookup: farklı key'lerin aynı çeviriye düşmesi doğal
+// (ör. "app.title" ve "tray.tooltip_format" için aynı kısaltma); semantik
+// olarak ayrı tutulmaları gerek — match arm'larını birleştirmek key'lerin
+// anlamını yok eder. PR #87 deferred listesinden match_same_arms enforce
+// edilirken bu fn istisna.
+#[allow(clippy::match_same_arms)]
 fn lookup_tr(key: &str) -> Option<&'static str> {
     Some(match key {
         // Tray / menü
@@ -341,6 +347,8 @@ fn lookup_tr(key: &str) -> Option<&'static str> {
 // ---------------------------------------------------------------------------
 // English translations
 // ---------------------------------------------------------------------------
+// Bkz. lookup_tr — i18n table'da farklı key'lerin aynı çeviriye düşmesi doğal.
+#[allow(clippy::match_same_arms)]
 fn lookup_en(key: &str) -> Option<&'static str> {
     Some(match key {
         // Tray / menu

--- a/crates/hekadrop-app/src/i18n.rs
+++ b/crates/hekadrop-app/src/i18n.rs
@@ -136,7 +136,7 @@ pub(crate) fn apply_args(template: &str, args: &[&str]) -> String {
 // ---------------------------------------------------------------------------
 // Türkçe çeviriler (default)
 // ---------------------------------------------------------------------------
-// i18n key→string lookup: farklı key'lerin aynı çeviriye düşmesi doğal
+// API: i18n key→string lookup; farklı key'lerin aynı çeviriye düşmesi doğal
 // (ör. "app.title" ve "tray.tooltip_format" için aynı kısaltma); semantik
 // olarak ayrı tutulmaları gerek — match arm'larını birleştirmek key'lerin
 // anlamını yok eder. PR #87 deferred listesinden match_same_arms enforce
@@ -347,7 +347,7 @@ fn lookup_tr(key: &str) -> Option<&'static str> {
 // ---------------------------------------------------------------------------
 // English translations
 // ---------------------------------------------------------------------------
-// Bkz. lookup_tr — i18n table'da farklı key'lerin aynı çeviriye düşmesi doğal.
+// API: Bkz. lookup_tr — i18n table'da farklı key'lerin aynı çeviriye düşmesi doğal.
 #[allow(clippy::match_same_arms)]
 fn lookup_en(key: &str) -> Option<&'static str> {
     Some(match key {

--- a/crates/hekadrop-core/src/connection.rs
+++ b/crates/hekadrop-core/src/connection.rs
@@ -587,10 +587,11 @@ async fn handle_sharing_frame(
             send_sharing_frame(socket, ctx, &build_paired_key_result()).await?;
             *sent_paired_result = true;
         }
-        // Explicit no-op (catch-all'a düşmesin diye yazılı): biz `build_paired_key_result()`
-        // gönderdik, peer'ın aynısını geri yollayışı protokol gereği — dokümante edilmiş
-        // expected frame, action yok. Match arm clippy::match_same_arms `_ => {}`'ye
-        // birleştir önerirse anlam kaybı; allow ile koruyoruz.
+        // PROTO: Explicit no-op (catch-all'a düşmesin diye yazılı): biz
+        // `build_paired_key_result()` gönderdik, peer'ın aynısını geri yollayışı
+        // protokol gereği — dokümante edilmiş expected frame, action yok. Match
+        // arm clippy::match_same_arms `_ => {}`'ye birleştir önerirse anlam
+        // kaybı; allow ile koruyoruz.
         #[allow(clippy::match_same_arms)]
         Some(sh_v1::FrameType::PairedKeyResult) => {}
         Some(sh_v1::FrameType::Introduction) => {
@@ -1336,11 +1337,12 @@ pub(crate) fn build_connection_response_accept() -> OfflineFrame {
 fn classify_handshake_error(e: &anyhow::Error) -> &'static str {
     fn map_io_error(io: &std::io::Error) -> &'static str {
         use std::io::ErrorKind::*;
-        // Explicit liste DOKÜMANTASYON: tanıdığımız peer-disconnect semantikli
-        // io error variants. Wildcard ile aynı body'ye düşse de bilinen kindleri
-        // ayrı listelemek "şu hatalar = peer disconnect" anlamını taşır;
-        // gelecekte ayrı i18n key ayrımı (network vs. abort) kolaylaşır.
-        // clippy::match_same_arms `_ => ...`'a indirmeyi öneriyor — anlam kaybı.
+        // API: Explicit liste DOKÜMANTASYON: tanıdığımız peer-disconnect
+        // semantikli io error variants. Wildcard ile aynı body'ye düşse de
+        // bilinen kindleri ayrı listelemek "şu hatalar = peer disconnect"
+        // anlamını taşır; gelecekte ayrı i18n key ayrımı (network vs. abort)
+        // kolaylaşır. clippy::match_same_arms `_ => ...`'a indirmeyi öneriyor —
+        // anlam kaybı.
         #[allow(clippy::match_same_arms)]
         match io.kind() {
             TimedOut => "err.peer_timeout",

--- a/crates/hekadrop-core/src/connection.rs
+++ b/crates/hekadrop-core/src/connection.rs
@@ -587,6 +587,11 @@ async fn handle_sharing_frame(
             send_sharing_frame(socket, ctx, &build_paired_key_result()).await?;
             *sent_paired_result = true;
         }
+        // Explicit no-op (catch-all'a düşmesin diye yazılı): biz `build_paired_key_result()`
+        // gönderdik, peer'ın aynısını geri yollayışı protokol gereği — dokümante edilmiş
+        // expected frame, action yok. Match arm clippy::match_same_arms `_ => {}`'ye
+        // birleştir önerirse anlam kaybı; allow ile koruyoruz.
+        #[allow(clippy::match_same_arms)]
         Some(sh_v1::FrameType::PairedKeyResult) => {}
         Some(sh_v1::FrameType::Introduction) => {
             let intro = v1
@@ -1331,6 +1336,12 @@ pub(crate) fn build_connection_response_accept() -> OfflineFrame {
 fn classify_handshake_error(e: &anyhow::Error) -> &'static str {
     fn map_io_error(io: &std::io::Error) -> &'static str {
         use std::io::ErrorKind::*;
+        // Explicit liste DOKÜMANTASYON: tanıdığımız peer-disconnect semantikli
+        // io error variants. Wildcard ile aynı body'ye düşse de bilinen kindleri
+        // ayrı listelemek "şu hatalar = peer disconnect" anlamını taşır;
+        // gelecekte ayrı i18n key ayrımı (network vs. abort) kolaylaşır.
+        // clippy::match_same_arms `_ => ...`'a indirmeyi öneriyor — anlam kaybı.
+        #[allow(clippy::match_same_arms)]
         match io.kind() {
             TimedOut => "err.peer_timeout",
             ConnectionReset | ConnectionAborted | BrokenPipe | UnexpectedEof | NotConnected => {


### PR DESCRIPTION
## Özet

PR #87 deferred strictness sweep listesinden bir madde: \`clippy::match_same_arms\`. PR #87'de 68 hit vardı; **workspace refactor sonrası 16'ya düştü**. Tümü "farklı semantic, aynı body" pattern'i — birleştirme anlam kaybı yaratacağından **3 scoped allow ile korunuyor**, lint enforce ediliyor.

(Not: orijinal plan \`must_use_candidate\` ile birlikte tek PR'dı; o lint **208 hit'e çıktı** (was 71) ve annotation pass + caller-side discard fix gerektiriyor — bu PR'a sığmıyor, ayrı PR.)

## Scoped allow site'ları

| Site | Sebep |
|---|---|
| \`i18n.rs::lookup_tr\` (14 hit) ve \`lookup_en\` | i18n key→string lookup; farklı key'lerin aynı çeviriye düşmesi doğal (\`app.title\` ve \`tray.tooltip_format\` ortak format string vb.). Match arm birleştirme key semantiğini yok eder. |
| \`connection.rs::handle_sharing_frame\` \`PairedKeyResult => {}\` | Explicit no-op arm: peer'dan beklenen frame, biz \`build_paired_key_result()\` gönderiyoruz, geri yollayışı protokol gereği. \`_ => {}\` wildcard'a birleştirmek "tanıdığımız ve kasıtlı yok saydığımız frame" anlamını silmiş olur. |
| \`connection.rs::map_io_error\` | io kind liste arm + \`_\` aynı \`"err.peer_disconnected"\`. Explicit liste DOKÜMANTASYON: tanıdığımız peer-disconnect kindleri ayrı yazmak gelecekte ayrı i18n key (network vs. abort) ayrımını kolaylaştırır. |

## Lint config

\`Cargo.toml\` \`[workspace.lints.clippy]\`:

\`\`\`toml
match_same_arms = "warn"
\`\`\`

Header yorumdaki "Kapsam dışı" tablosundan kaldırıldı.

## CLAUDE.md pre-commit invariant scan

| Kontrol | Sonuç |
|---|---|
| \`cargo clippy -D warnings\` | ✓ |
| \`cargo test --workspace\` | ✓ 27 test (davranış parity) |
| \`cargo fmt --check\` | ✓ |
| I-2 (allow disiplini) | 3 yeni allow scoped + gerekçeli yorum ✓ |

## PR #87 deferred listesi durumu (5/10 enforce)

| Lint | Hit | Durum |
|---|---|---|
| \`cast_possible_wrap\` | 36 | ✓ #101 |
| \`uninlined_format_args\` | 110 | ✓ #107 |
| \`unreachable_pub\` | 58 | ✓ #107 |
| \`match_same_arms\` | 16 | ✓ **bu PR** |
| \`clippy::pedantic\` umbrella | ~1,228 | sırada — modular |
| \`clippy::doc_markdown\` | 445+792 | sonra |
| \`must_use_candidate\` | 208 (was 71) | sırada — ayrı PR (annotation + caller fix) |
| \`items_after_statements\`, vb. | <100 each | sonra |

🤖 Generated with [Claude Code](https://claude.com/claude-code)