### PR TITLE
feat(net): RFC-0003 §3.3 peer-detection — mDNS TXT 'ext=1' flag

### DIFF
--- a/crates/hekadrop-core/src/discovery_types.rs
+++ b/crates/hekadrop-core/src/discovery_types.rs
@@ -41,6 +41,14 @@ pub struct DiscoveredDevice {
     pub port: u16,
     pub device_type: u8,
     pub fullname: String,
+    /// `true` ise peer mDNS TXT record'unda `ext=1` flag'i göndermiş —
+    /// HekaDrop extension protocol (capabilities envelope, chunk-HMAC,
+    /// resume, folder) destekli. `false` (eski Quick Share peer):
+    /// HekaDropFrame yollanmamalı; legacy mode kullanılır.
+    ///
+    /// RFC-0003 §3.3 peer-detection signal. Eski Quick Share peer'larında
+    /// `ext` alanı yok → parser default `false` set eder.
+    pub extension_supported: bool,
 }
 
 impl DiscoveredDevice {

--- a/crates/hekadrop-net/src/discovery.rs
+++ b/crates/hekadrop-net/src/discovery.rs
@@ -103,11 +103,58 @@ fn parse(info: &ResolvedService) -> Option<DiscoveredDevice> {
             .to_string()
     });
 
+    let extension_supported = parse_extension_flag(info.get_property_val_str("ext"));
+
     Some(DiscoveredDevice {
         name,
         addr,
         port,
         device_type,
         fullname: info.get_fullname().to_string(),
+        extension_supported,
     })
+}
+
+/// RFC-0003 §3.3 peer-detection — TXT record'undaki `ext` alanından HekaDrop
+/// extension destek flag'ini parse et.
+///
+/// Eski Quick Share peer'larında (Pixel/Samsung/NearDrop/rquickshare) `ext`
+/// alanı yoktur → `None` → `false` (legacy mode).
+/// HekaDrop peer'ları `ext=1` yollar → `Some("1")` → `true`.
+/// Beklenmeyen değerler (`"0"`, `"true"`, vb.) → `false` (defensive — yalnız
+/// "1" tam pozitif sinyal sayılır).
+#[must_use]
+pub(crate) fn parse_extension_flag(prop_value: Option<&str>) -> bool {
+    prop_value == Some("1")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Eski Quick Share peer (Pixel/Samsung/NearDrop) — `ext` alanı yok.
+    #[test]
+    fn missing_ext_property_legacy() {
+        assert!(!parse_extension_flag(None));
+    }
+
+    /// HekaDrop peer — `ext=1` spec değeri.
+    #[test]
+    fn ext_one_signals_extension_support() {
+        assert!(parse_extension_flag(Some("1")));
+    }
+
+    /// Defensive: "1" dışı hiçbir değer pozitif sinyal sayılmaz.
+    /// Saldırgan veya yanlışlıkla farklı flag yollayan peer extension
+    /// destekliyor sayılmamalı (false-positive → connection drop riski).
+    #[test]
+    fn unexpected_values_default_to_legacy() {
+        assert!(!parse_extension_flag(Some("0")));
+        assert!(!parse_extension_flag(Some("true")));
+        assert!(!parse_extension_flag(Some("yes")));
+        assert!(!parse_extension_flag(Some("")));
+        assert!(!parse_extension_flag(Some(" 1")));
+        assert!(!parse_extension_flag(Some("1 ")));
+        assert!(!parse_extension_flag(Some("2")));
+    }
 }

--- a/crates/hekadrop-net/src/mdns.rs
+++ b/crates/hekadrop-net/src/mdns.rs
@@ -65,13 +65,19 @@ pub fn advertise(device_name: &str, port: u16) -> Result<Option<MdnsHandle>> {
         return Ok(None);
     }
 
+    // RFC-0003 §3.3 peer-detection signal:
+    //   `ext=1` flag → bu instance HekaDrop extension protocol (capabilities
+    //   envelope, chunk-HMAC, resume, folder) destekli. Eski Quick Share
+    //   peer'ları bu alanı görmezden gelir (sadece "n" endpoint info'yu
+    //   parse ederler). HekaDrop discovery `extension_supported` field'ını
+    //   bu flag'in varlığına göre set eder.
     let info = ServiceInfo::new(
         &service_type,
         &instance,
         &format!("{instance}.local."),
         &addrs[..],
         port,
-        &[("n", endpoint_info_b64.as_str())][..],
+        &[("n", endpoint_info_b64.as_str()), ("ext", "1")][..],
     )?;
 
     let fullname = info.get_fullname().to_string();


### PR DESCRIPTION
## Özet

Capabilities exchange ana akış entegrasyonu için zemin: mDNS TXT record'unda HekaDrop extension flag'i. **State machine'e dokunulmadı** — bu PR yalnız discovery katmanında flag advertise/parse mekanizması ekler. Sender + receiver akışlarına entegrasyon ayrı bir sonraki PR.

## Tür

- [x] Yeni özellik (peer-detection signal)

## Wire değişikliği

\`\`\`
TXT record (eski):    n=<base64-endpoint-info>
TXT record (yeni):    n=<base64-endpoint-info>; ext=1
\`\`\`

Eski Quick Share peer'ları (Pixel/Samsung/NearDrop/rquickshare) **ext alanını görmezden gelir** — onlar sadece "n"yi parse eder. HekaDrop ↔ HekaDrop senaryosunda ek alan capabilities exchange'in güvenli olduğunu signaller.

## Domain tipi

\`\`\`rust
pub struct DiscoveredDevice {
    pub name: String,
    pub addr: IpAddr,
    pub port: u16,
    pub device_type: u8,
    pub fullname: String,
    pub extension_supported: bool,  // ← yeni: ext=1 ise true
}
\`\`\`

Sender flow `device.extension_supported` true ise `negotiate_capabilities()` çağırır (sonraki PR'ın işi).

## Defensive parsing

\`\`\`rust
pub(crate) fn parse_extension_flag(prop_value: Option<&str>) -> bool {
    prop_value == Some("1")  // strict equality
}
\`\`\`

**Sadece \`"1"\`** pozitif sinyal. \`"0"\`, \`"true"\`, \`"yes"\`, \`""\`, \` "1"\` (leading space), \`"2"\` hepsi \`false\`. Saldırgan veya yanlışlıkla farklı flag yollayan peer extension destekliyor sayılmamalı — false-positive HekaDropFrame'in eski peer'a yollanmasına neden olur, peer connection drop riski.

## 3 Unit Test

| Test | Senaryo |
|---|---|
| \`missing_ext_property_legacy\` | Eski peer (\`ext\` alanı yok) → false |
| \`ext_one_signals_extension_support\` | HekaDrop peer (\`ext=1\`) → true |
| \`unexpected_values_default_to_legacy\` | "0", "true", " 1", "2", boş — hepsi false |

## Test

- [x] \`cargo build --workspace\` — yeşil (5 crate)
- [x] \`cargo test --workspace\` — 213 main + 3 net + integration'lar pass; 0 fail
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — temiz
- [x] \`cargo fmt --check\` — temiz
- [x] \`cargo machete\` — 0 unused dep

## İlgili

- RFC-0003 §3.3 (peer-detection logic)
- PR #110 (\`negotiate_capabilities\` helper, merged) — bu PR onun callable'ı için zemin
- \`docs/protocol/capabilities.md\` (capabilities envelope spec)

## Sıradaki PR'lar

1. **Capabilities exchange ana akış entegrasyonu** — \`sender.rs\` + \`connection.rs\`'de \`device.extension_supported\` true ise PairedKeyResult sonrası \`negotiate_capabilities()\` çağrısı
2. **chunk-HMAC sender/receiver entegrasyonu** — \`active_caps.has(CHUNK_HMAC_V1)\` → her chunk sonrası ChunkIntegrity emit + verify
3. Resume hint state machine (RFC-0004)
4. Folder bundle (RFC-0005)

🤖 Generated with [Claude Code](https://claude.com/claude-code)