### PR TITLE
feat(sender): RFC-0003 §3.3 — capabilities exchange ana akış entegrasyonu

### DIFF
--- a/crates/hekadrop-core/src/sender.rs
+++ b/crates/hekadrop-core/src/sender.rs
@@ -195,6 +195,9 @@ pub async fn send(req: SendRequest, state: Arc<AppState>) -> Result<()> {
     // 7-11) Loop — peer sharing frame'lerini işle, duruma göre sıradaki adımı tetikle
     let mut introduction_sent = false;
     let mut sent_paired_result = false;
+    // RFC-0003 §3.3 — capabilities exchange tek seferlik, PairedKeyResult
+    // arm'ında tetiklenir. Peer `extension_supported = false` ise atlanır.
+    let mut capabilities_exchanged = false;
     let peer_label = req.device.name.clone();
     let transfer_id = format!("out:{}:{}", req.device.addr, req.device.port);
     let _guard = state::TransferGuard::new(Arc::clone(&state), &transfer_id);
@@ -261,6 +264,33 @@ pub async fn send(req: SendRequest, state: Arc<AppState>) -> Result<()> {
                     }
                     Some(sh_v1::FrameType::PairedKeyResult) => {
                         info!("[sender] peer PairedKeyResult aldı");
+
+                        // RFC-0003 §3.3 capabilities exchange — peer mDNS
+                        // TXT'te `ext=1` flag'i göndermişse (yani HekaDrop
+                        // extension destekli), Introduction'dan ÖNCE
+                        // capabilities swap yap. Eski Quick Share peer'ları
+                        // (extension_supported=false) için exchange atlanır
+                        // → mevcut Quick Share legacy akışı korunur.
+                        if req.device.extension_supported && !capabilities_exchanged {
+                            let active = crate::negotiation::negotiate_capabilities(
+                                &mut socket,
+                                &mut ctx,
+                                crate::negotiation::DEFAULT_CAPABILITIES_TIMEOUT,
+                            )
+                            .await;
+                            info!(
+                                "[sender] active capabilities: 0x{:04x} (chunk_hmac={}, resume={}, folder={})",
+                                active.raw(),
+                                active.has(crate::capabilities::features::CHUNK_HMAC_V1),
+                                active.has(crate::capabilities::features::RESUME_V1),
+                                active.has(crate::capabilities::features::FOLDER_STREAM_V1),
+                            );
+                            capabilities_exchanged = true;
+                            // NOT: `active` per-bağlantı state'e (chunk-HMAC
+                            // entegrasyonu sıradaki PR'ında kullanılacak)
+                            // taşınmadı; şimdilik log + observability.
+                        }
+
                         if !introduction_sent {
                             let intro = build_introduction_multi(&plans);
                             connection::send_sharing_frame(&mut socket, &mut ctx, &intro).await?;


### PR DESCRIPTION
## Özet

PR #110 (helper) + PR #111 (peer-detection) zemini üstüne **sender state machine'ine capabilities exchange hook'u**. Yalnız sender tarafı — receiver entegrasyonu sıradaki PR'da gelecek.

## Akış değişikliği

\`sender.rs\`'de \`PairedKeyResult\` arm'ında, Introduction'dan ÖNCE:

\`\`\`rust
if req.device.extension_supported && !capabilities_exchanged {
    let active = negotiation::negotiate_capabilities(
        &mut socket, &mut ctx, DEFAULT_CAPABILITIES_TIMEOUT
    ).await;
    info!("[sender] active capabilities: 0x{:04x} ...", active.raw());
    capabilities_exchanged = true;
}
```

## Güvenlik garantisi

`req.device.extension_supported` peer-detection signal'i (PR #111). Eski Quick Share peer'ları (Pixel/Samsung/NearDrop/rquickshare) mDNS TXT'te `ext=1` flag'i yollamaz:

| Peer | extension_supported | Davranış |
|---|---|---|
| HekaDrop | true | capabilities exchange yapılır, active_caps elde edilir |
| Eski Quick Share | false | Exchange ATLANIR, legacy akış korunur |

**HekaDropFrame yalnız HekaDrop ↔ HekaDrop senaryosunda gönderilir** — eski peer'a connection drop riski sıfır.

## Diff scope

- 4 satır gerçek akış değişikliği (PairedKeyResult arm)
- 1 yeni state field (`capabilities_exchanged: bool`)
- Yorum + log ifadesi

## Test

- [x] `cargo build --workspace` — yeşil (5 crate)
- [x] `cargo test --workspace` — 213 main + 3 net + integration'lar pass; 0 fail
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — temiz
- [x] `cargo fmt --check` — temiz
- [x] `cargo machete` — 0 unused dep

**Test stratejisi notu:** Sender state machine integration test'i mevcut `tests/` paketine yeni loopback dosyası ister (HekaDrop ↔ HekaDrop UKEY2 + PairedKey + capabilities setup). Bu PR'da kapsam sade (4 satır gerçek akış, peer-detection guard'lı); `negotiate_capabilities` helper'ının integration test'i (#110'da loopback) doğruluğu zaten doğruluyor.

## İlgili

- RFC-0003 §3.3
- PR #110 (helper, merged)
- PR #111 (peer-detection, merged)

## Sıradaki PR'lar

1. **Receiver (`connection.rs`) entegrasyonu** — mirror flow: peer ext=1 ise PairedKeyResult sonrası `negotiate_capabilities()` çağrısı
2. **chunk-HMAC sender/receiver hot path** — `active.has(CHUNK_HMAC_V1)` → her chunk sonrası ChunkIntegrity emit + verify
3. Resume hint state machine (RFC-0004)
4. Folder bundle (RFC-0005)

🤖 Generated with [Claude Code](https://claude.com/claude-code)