### PR TITLE
chore(lint): doc_markdown enforce — 242 auto-fix + 406 proto allow

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ homepage = "https://github.com/YatogamiRaito/HekaDrop"
 #
 # Kapsam dışı bırakılanlar (RED-tier — ayrı tracking issue'larla cleanup):
 #   * clippy::pedantic umbrella (~1,228 hit)        — issue #TBD
-#   * clippy::doc_markdown (445 hand + 792 gen)     — issue #TBD
 #   * clippy::must_use_candidate (71 hand)          — issue #TBD
 #   * unused_crate_dependencies                     — false-pos cascade, atlandı
 #
@@ -74,6 +73,7 @@ get_unwrap = "warn"
 redundant_clone = "warn"
 use_self = "warn"
 # Kalite — düşük volüm, anlık temizlik
+doc_markdown = "warn"           # PR #110: 648 hit, 242 auto-fix + 406 generated proto module-level allow
 uninlined_format_args = "warn"  # PR #87 auto-fix sonrası 110 yeni site birikmişti; auto-fix tekrar uygulandı + lint enforce
 match_same_arms = "warn"        # i18n table + 2 dokümantasyon arm scoped allow ile (PR #87 deferred)
 manual_let_else = "warn"

--- a/crates/hekadrop-app/benches/crypto.rs
+++ b/crates/hekadrop-app/benches/crypto.rs
@@ -22,7 +22,7 @@
 )]
 
 //! Criterion benchmark — kripto sıcak yolu (AES-CBC, HMAC, HKDF,
-//! session_fingerprint). 64 KiB tipik chunk boyutunu temsil ediyor.
+//! `session_fingerprint`). 64 KiB tipik chunk boyutunu temsil ediyor.
 //!
 //! Çalıştırma: `cargo bench --bench crypto`
 //! Derleme kontrolü (CI/pre-commit): `cargo bench --no-run`

--- a/crates/hekadrop-app/src/i18n.rs
+++ b/crates/hekadrop-app/src/i18n.rs
@@ -93,7 +93,7 @@ pub(crate) fn tf(key: &'static str, args: &[&str]) -> String {
 }
 
 /// Template stringinde `{N}` yer tutucularını args ile doldurur (single-pass).
-/// Public `tf()`'nin test edilebilir yan yüzü — `current()` OnceLock'una
+/// Public `tf()`'nin test edilebilir yan yüzü — `current()` `OnceLock`'una
 /// bağımlı değil, saf deterministik fonksiyon.
 pub(crate) fn apply_args(template: &str, args: &[&str]) -> String {
     let bytes = template.as_bytes();

--- a/crates/hekadrop-app/src/lib.rs
+++ b/crates/hekadrop-app/src/lib.rs
@@ -1,10 +1,10 @@
-//! HekaDrop library surface — yalnız benchmarklar ve harici entegrasyon testleri
+//! `HekaDrop` library surface — yalnız benchmarklar ve harici entegrasyon testleri
 //! için public re-export katmanı.
 //!
 //! Binary `src/main.rs` bu lib'e bağımlı değildir; modül ağacı ikisinde de
 //! bağımsızca derlenir (Cargo lib+bin hibrit projeyi bu şekilde ele alır).
 //! Buradaki amaç `benches/crypto.rs` ve `tests/*.rs` gibi harici consumer'lara
-//! dar bir yüzey (crypto + file_size_guard + UKEY2 downgrade validator
+//! dar bir yüzey (crypto + `file_size_guard` + UKEY2 downgrade validator
 //! + H#4 privacy controls için settings) açmaktır.
 
 #![allow(dead_code)]

--- a/crates/hekadrop-app/src/main.rs
+++ b/crates/hekadrop-app/src/main.rs
@@ -1968,7 +1968,7 @@ fn toggle_login_item() {
 }
 
 /// Windows: `HKCU\Software\Microsoft\Windows\CurrentVersion\Run` Registry
-/// anahtarına "HekaDrop" değerini yazar ya da kaldırır. Binary yolu
+/// anahtarına `"HekaDrop"` değerini yazar ya da kaldırır. Binary yolu
 /// `current_exe()` ile alınır (tırnak içine alınarak; Program Files gibi
 /// boşluklu yollara dayanıklı).
 #[cfg(target_os = "windows")]

--- a/crates/hekadrop-app/src/main.rs
+++ b/crates/hekadrop-app/src/main.rs
@@ -62,7 +62,7 @@ use hekadrop_core::{config, connection, log_redact, sender, server, settings, st
 
 /// `DeviceKind` → kullanıcıya gösterilen Türkçe etiket (emoji ile). Core
 /// UI/i18n-agnostic kalsın diye bu mapping app crate'inde — PR #93 review
-/// (Copilot) sonrası kind_label() core'dan çıkartıldı.
+/// (Copilot) sonrası `kind_label()` core'dan çıkartıldı.
 fn device_kind_label(kind: DeviceKind) -> &'static str {
     match kind {
         DeviceKind::Phone => "📱 Telefon",
@@ -295,7 +295,7 @@ fn main() {
 ///
 /// `log_level` Settings'ten gelir (H#4 privacy control). `RUST_LOG` env var
 /// set ise o öncelikli — geliştirici kaçış vanası; aksi halde verilen
-/// LogLevel `hekadrop=<seviye>` direktifine dönüşür.
+/// `LogLevel` `hekadrop=<seviye>` direktifine dönüşür.
 fn setup_logging(log_level: settings::LogLevel) {
     use tracing_appender::rolling::{RollingFileAppender, Rotation};
     use tracing_subscriber::{fmt, prelude::*, EnvFilter};
@@ -1100,7 +1100,7 @@ fn push_i18n_to_ui() {
     state::enqueue_js(js);
 }
 
-/// İlk açılışta (veya upgrade eden kullanıcının ilk sürüm sonrasında) WebView
+/// İlk açılışta (veya upgrade eden kullanıcının ilk sürüm sonrasında) `WebView`
 /// yüklenir yüklenmez onboarding modal'ını gösterir. `first_launch_completed`
 /// zaten true ise no-op. `act('onboarding_done')` IPC'si flag'i true'ya çekip
 /// diske yazar → bir sonraki boot'ta modal tekrar gelmez.
@@ -1631,7 +1631,7 @@ enum UpdateCheckOutcome {
 }
 
 /// UI'a update status push et. `kind` CSS class adıdır: `info` / `success` /
-/// `error`. Window açık değilse JS sessizce yutulur (enqueue_js buffer'lanır,
+/// `error`. Window açık değilse JS sessizce yutulur (`enqueue_js` buffer'lanır,
 /// sonraki eval bunu drain eder).
 fn push_update_status(msg: &str, kind: &str) {
     state::enqueue_js(format!(
@@ -1799,7 +1799,7 @@ fn semver_less(current: &str, latest: &str) -> bool {
 ///   - Dizin → içindeki tüm dosyalar (recursive)
 ///   - Symlink dizin → takip ETMEZ (döngü koruması; o path atlanır)
 ///
-/// Okuma hatası olan alt dizinler sessizce atlanır (tracing::warn log'u ile).
+/// Okuma hatası olan alt dizinler sessizce atlanır (`tracing::warn` log'u ile).
 /// Stack-based BFS; rekürsif çağrı yok, derin ağaçlarda stack overflow yok.
 fn expand_folder_drops(dropped: Vec<std::path::PathBuf>) -> Vec<std::path::PathBuf> {
     let mut out = Vec::new();

--- a/crates/hekadrop-app/src/platform.rs
+++ b/crates/hekadrop-app/src/platform.rs
@@ -435,7 +435,7 @@ pub(crate) mod win {
     use windows::Win32::UI::WindowsAndMessaging::SW_SHOWNORMAL;
 
     /// UTF-16 LE null-terminated vektör üretir.
-    /// `pub(crate)` — ui.rs (MessageBoxW) ve main.rs (Registry) de kullanır.
+    /// `pub(crate)` — ui.rs (`MessageBoxW`) ve main.rs (Registry) de kullanır.
     pub(crate) fn to_wide(s: &str) -> Vec<u16> {
         let mut v: Vec<u16> = s.encode_utf16().collect();
         v.push(0);
@@ -451,7 +451,7 @@ pub(crate) mod win {
         v
     }
 
-    /// `SHGetKnownFolderPath` → PathBuf. Çıktı bellek `CoTaskMemFree` ile serbest
+    /// `SHGetKnownFolderPath` → `PathBuf`. Çıktı bellek `CoTaskMemFree` ile serbest
     /// bırakılır (aksi halde leak). Bellek tahsisi başarısızsa `None`.
     pub(super) fn known_folder(folder: &GUID) -> Option<PathBuf> {
         // SAFETY: `folder` is a valid GUID reference from the caller.
@@ -609,10 +609,10 @@ pub(crate) mod win {
 
     /// Clipboard'a UTF-16 metin koyar.
     ///
-    /// Akış: OpenClipboard → EmptyClipboard → GlobalAlloc+Lock → copy →
-    /// Unlock → SetClipboardData(CF_UNICODETEXT) → CloseClipboard.
+    /// Akış: `OpenClipboard` → `EmptyClipboard` → `GlobalAlloc`+Lock → copy →
+    /// Unlock → `SetClipboardData(CF_UNICODETEXT)` → `CloseClipboard`.
     ///
-    /// SetClipboardData başarılıysa hafızanın sahipliği clipboard'a geçer —
+    /// `SetClipboardData` başarılıysa hafızanın sahipliği clipboard'a geçer —
     /// biz free ETMEYİZ. Her hata yolunda `GlobalFree` ile kaynak serbest
     /// bırakılır; `OpenClipboard` başarısız olursa da alloc'u temizleriz.
     pub(super) fn clipboard_set(text: &str) -> Result<()> {
@@ -690,12 +690,12 @@ pub(crate) mod win {
     /// ile çevirir.
     ///
     /// Dönüş semantiği:
-    ///   - `Ok(Some(s))`: Clipboard'da CF_UNICODETEXT formatı var ve başarıyla okundu.
+    ///   - `Ok(Some(s))`: Clipboard'da `CF_UNICODETEXT` formatı var ve başarıyla okundu.
     ///   - `Ok(None)`: Pano metin formatı içermiyor (`GetClipboardData` başarısız).
     ///   - `Err(_)`: `OpenClipboard`/`GlobalLock`/`GlobalSize` gibi Win32 API
     ///     hataları — caller handle'layabilsin.
     ///
-    /// SECURITY: CF_UNICODETEXT MSDN spec'i gereği NUL-terminated, ama yine
+    /// SECURITY: `CF_UNICODETEXT` MSDN spec'i gereği NUL-terminated, ama yine
     /// de `GlobalSize` ile hafıza blokunun gerçek üst sınırını alıp okumayı
     /// buraya clamp ediyoruz (malformed/oob handle'da buffer over-read yok).
     pub(super) fn clipboard_get() -> Result<Option<String>> {

--- a/crates/hekadrop-app/src/platform.rs
+++ b/crates/hekadrop-app/src/platform.rs
@@ -114,9 +114,9 @@ pub(crate) fn default_download_dir() -> PathBuf {
 /// mDNS / UI için gösterilecek cihaz adı.
 ///
 /// - macOS: `scutil --get ComputerName`
-/// - Linux: `/etc/hostname` → `hostname` komutu → fallback "HekaDrop Linux"
+/// - Linux: `/etc/hostname` → `hostname` komutu → fallback "`HekaDrop` Linux"
 /// - Windows: `GetComputerNameExW(ComputerNameDnsHostname)` → fallback
-///   `%COMPUTERNAME%` → "HekaDrop PC"
+///   `%COMPUTERNAME%` → "`HekaDrop` PC"
 pub(crate) fn device_name() -> String {
     if let Ok(v) = std::env::var("HEKADROP_NAME") {
         if !v.is_empty() {

--- a/crates/hekadrop-app/src/ui.rs
+++ b/crates/hekadrop-app/src/ui.rs
@@ -1,9 +1,9 @@
 //! Kullanıcı arayüzü yardımcıları — cross-platform dialog ve bildirimler.
 //!
-//! - macOS: `osascript` (AppKit dialog)
+//! - macOS: `osascript` (`AppKit` dialog)
 //! - Linux: `zenity` (yoksa `kdialog`)
 //! - Windows: native `MessageBoxW` / `windows-rs`, file/folder dialog'u için
-//!   PowerShell (`System.Windows.Forms`) fallback
+//!   `PowerShell` (`System.Windows.Forms`) fallback
 //!
 //! Dialog aracı yoksa veya headless ortamsa `Reject`/`None` döner; uygulama
 //! çökmek yerine güvenli default davranışa geçer.
@@ -33,7 +33,7 @@ pub(crate) enum AcceptResult {
 /// Kullanıcıya PIN + dosya listesi gösterir. 3 seçenek döner:
 ///   - Reddet
 ///   - Kabul et
-///   - Kabul + güven (device_name ileride otomatik kabul edilir)
+///   - Kabul + güven (`device_name` ileride otomatik kabul edilir)
 pub(crate) async fn prompt_accept(
     device_name: &str,
     pin_code: &str,
@@ -467,7 +467,7 @@ pub(crate) fn notify(title: &str, body: &str) {
 
 /// Fatal (ölümcül) hata diyaloğu — **blocking**. Uygulama başlatılamıyor ve
 /// process yakında `exit(1)` çağıracağında kullanıcıya görsel bir açıklama
-/// vermek için kullanılır; show_info fire-and-forget olduğundan o hata
+/// vermek için kullanılır; `show_info` fire-and-forget olduğundan o hata
 /// mesajı okunamadan uygulama kapanırdı. Burada `status()` kullanıyoruz →
 /// osascript/zenity/MessageBox kapanana kadar thread bloke olur.
 ///

--- a/crates/hekadrop-app/src/ui.rs
+++ b/crates/hekadrop-app/src/ui.rs
@@ -1077,7 +1077,7 @@ fn zenity_supports_extra_button() -> bool {
 }
 
 /// Bir ikili (binary) PATH'te mevcut mu? Linux-only helper (zenity/kdialog
-/// varlık kontrolü). Windows'ta kullanılmaz — MessageBoxW her zaman var.
+/// varlık kontrolü). Windows'ta kullanılmaz — `MessageBoxW` her zaman var.
 ///
 /// GÜVENLİK: `sh -c` kullanımı şu an sadece bu dosya içinden sabit
 /// binary isimleri ile çağrılıyor ("zenity", "kdialog") — peer-kontrollü

--- a/crates/hekadrop-app/src/ui_adapter.rs
+++ b/crates/hekadrop-app/src/ui_adapter.rs
@@ -1,4 +1,4 @@
-//! UiPort trait'inin app-side concrete implementation'ı. `connection.rs`
+//! `UiPort` trait'inin app-side concrete implementation'ı. `connection.rs`
 //! ve sonraki adımlarda `sender.rs`, `server.rs` bu adapter'ı `Arc<dyn
 //! UiPort>` olarak alır.
 //!

--- a/crates/hekadrop-app/tests/cancel_per_transfer.rs
+++ b/crates/hekadrop-app/tests/cancel_per_transfer.rs
@@ -23,7 +23,7 @@
 
 //! H#1 — Per-transfer `CancellationToken` semantiği.
 //!
-//! HekaDrop binary-only (sadece `crypto` lib'de export edilir); `state`
+//! `HekaDrop` binary-only (sadece `crypto` lib'de export edilir); `state`
 //! modülünü test için dışarı açmıyoruz. Refactor'ın çekirdek davranışı
 //! `tokio_util::sync::CancellationToken`'ın "root → child" ağacına dayanıyor —
 //! regresyonu önlemek için testimiz aynı primitif üzerinde aynı ağacı kurup

--- a/crates/hekadrop-app/tests/common/mod.rs
+++ b/crates/hekadrop-app/tests/common/mod.rs
@@ -1,6 +1,6 @@
 //! Ortak test yardımcıları — protokol-seviyesi entegrasyon testlerinde paylaşılır.
 //!
-//! HekaDrop binary-only bir crate (lib.rs yok). Bu yüzden `tests/` altındaki
+//! `HekaDrop` binary-only bir crate (lib.rs yok). Bu yüzden `tests/` altındaki
 //! entegrasyon testleri `hekadrop::...` erişemez; bunun yerine aynı dış crate'leri
 //! (p256, aes, cbc, hmac, sha2, hkdf, prost) kullanarak protokol uyumluluğunu
 //! bağımsızca doğrularız. Bu yaklaşımın bir yan faydası var: implement ve test
@@ -8,7 +8,7 @@
 //! kaçırılmaz.
 //!
 //! Her test binary'si bu modülü `mod common;` ile include eder, ama kendi özel
-//! fonksiyonlarını kullanır — kullanılmayan helper'lar dead_code warning'e yol
+//! fonksiyonlarını kullanır — kullanılmayan helper'lar `dead_code` warning'e yol
 //! açabilir. `#[allow(dead_code)]` her yardımcıyı bireysel olarak bu beklenen
 //! durumdan muaf tutar.
 
@@ -20,7 +20,7 @@
 use hmac::{Hmac, Mac};
 use sha2::Sha256;
 
-/// HKDF-SHA256 → HekaDrop `crypto::hkdf_sha256` ile birebir aynı davranış.
+/// HKDF-SHA256 → `HekaDrop` `crypto::hkdf_sha256` ile birebir aynı davranış.
 pub(crate) fn hkdf_sha256(ikm: &[u8], salt: &[u8], info: &[u8], len: usize) -> Vec<u8> {
     let hk = hkdf::Hkdf::<Sha256>::new(Some(salt), ikm);
     let mut out = vec![0u8; len];
@@ -56,7 +56,7 @@ pub(crate) const D2D_SALT: [u8; 32] = [
 ];
 
 /// Quick Share 4-haneli PIN türetme — `src/crypto.rs::pin_code_from_auth_key`
-/// referans implementasyonunun birebir kopyası (NearDrop algoritması).
+/// referans implementasyonunun birebir kopyası (`NearDrop` algoritması).
 /// Her bayt Java'daki `byte`-olarak (signed) yorumlanır.
 pub(crate) fn pin_code_from_auth_key(key: &[u8]) -> String {
     let mut hash: i64 = 0;

--- a/crates/hekadrop-app/tests/frame_codec.rs
+++ b/crates/hekadrop-app/tests/frame_codec.rs
@@ -23,7 +23,7 @@
 
 //! Frame codec: big-endian u32 length-prefix + protobuf body.
 //!
-//! HekaDrop `src/frame.rs` bu kontratı TcpStream üstünde uygular. Burada stream
+//! `HekaDrop` `src/frame.rs` bu kontratı `TcpStream` üstünde uygular. Burada stream
 //! yerine in-memory cursor kullanarak `read_frame`/`write_frame` davranışını
 //! simüle eder; uzunluk overflow, truncation, protobuf uyumluluğu (prost)
 //! senaryoları kapsanır.

--- a/crates/hekadrop-app/tests/frame_limits.rs
+++ b/crates/hekadrop-app/tests/frame_limits.rs
@@ -30,16 +30,16 @@
 //!
 //! Pin'lenen davranışlar:
 //!   * `frame_too_large_reddedilir` — 16 MiB üstü length-prefix reddedilmeli
-//!     (MAX_FRAME_SIZE). Tam sınır değer kabul, +1 reddedilir.
+//!     (`MAX_FRAME_SIZE`). Tam sınır değer kabul, +1 reddedilir.
 //!   * `truncated_frame_eof_doner` — Length-prefix N bayt deklare edip socket
-//!     N-k baytta kapanırsa read_exact EOF hatası döner (peer bağlantıyı
+//!     N-k baytta kapanırsa `read_exact` EOF hatası döner (peer bağlantıyı
 //!     yarıda kesti / slow-loris frame pompalama).
 //!   * `zero_length_frame_davranisi` — **Kabul edilir** (mevcut davranış);
 //!     üst katman boş payload'ı boş Vec olarak görür. Bu pin, ileride "zero
 //!     reject" politikası eklenirse test'i güncellemeyi zorunlu kılar.
 //!   * `huge_length_u32_max_reddedilir` — 32-bit platform'da `u32::MAX` gibi
-//!     bir length cast'i usize'a genişler ama MAX_FRAME_SIZE check'i absürt
-//!     değeri reddeder (DoS: 4 GiB alloc'u engeller).
+//!     bir length cast'i usize'a genişler ama `MAX_FRAME_SIZE` check'i absürt
+//!     değeri reddeder (`DoS`: 4 GiB alloc'u engeller).
 
 use std::io::{Cursor, Read, Write};
 

--- a/crates/hekadrop-app/tests/legacy_ttl.rs
+++ b/crates/hekadrop-app/tests/legacy_ttl.rs
@@ -23,7 +23,7 @@
 
 //! Legacy TTL soft-sunset — Issue #17 (Seçenek D).
 //!
-//! v0.6 prune_expired eskiden legacy kayıtlara (`secret_id_hash == None`)
+//! v0.6 `prune_expired` eskiden legacy kayıtlara (`secret_id_hash == None`)
 //! hiç dokunmazdı — sınırsız yaşarlardı. Bu, hash-suppress saldırısıyla
 //! birleştiğinde saldırgana "kurban 90 gün önce trust ettiği ama artık
 //! hash-upgrade olmamış legacy kaydı yoluyla muafiyet kazanma" şansı
@@ -46,7 +46,7 @@ fn now_epoch() -> u64 {
         .unwrap_or(0)
 }
 
-/// Legacy kayıt (`hash = None`) 90 günden eski ise prune_expired silmeli.
+/// Legacy kayıt (`hash = None`) 90 günden eski ise `prune_expired` silmeli.
 /// Saldırı yüzeyini sınırlar: "yıllar önce trust edilmiş ama hash-upgrade
 /// olmamış" peer'lar sonsuza kadar legacy fallback sunmaz.
 #[test]

--- a/crates/hekadrop-app/tests/mdns_discovery.rs
+++ b/crates/hekadrop-app/tests/mdns_discovery.rs
@@ -22,9 +22,9 @@
 )]
 
 //! mDNS keşif katmanı — Quick Share'in `_FC9F5ED42C8A._tcp.local.` servis tipi,
-//! 10-byte instance name ve EndpointInfo encoding'i protokol uyumluluğu.
+//! 10-byte instance name ve `EndpointInfo` encoding'i protokol uyumluluğu.
 //!
-//! Bu testler HekaDrop `src/config.rs` çıktılarıyla birebir uyumlu olmalı —
+//! Bu testler `HekaDrop` `src/config.rs` çıktılarıyla birebir uyumlu olmalı —
 //! her biri bağımsız implement edilmiştir, böylece kaynak değişirse regression
 //! yakalanır.
 
@@ -53,7 +53,7 @@ fn instance_name(endpoint_id: &[u8; 4]) -> String {
     URL_SAFE_NO_PAD.encode(bytes)
 }
 
-/// EndpointInfo yapısı — `n=` TXT record'un base64 öncesi:
+/// `EndpointInfo` yapısı — `n=` TXT record'un base64 öncesi:
 ///   [0]      bitmap (cihaz tipi << 1)
 ///   [1..17]  16 bayt rastgele
 ///   [17]     ad uzunluğu (u8)
@@ -119,7 +119,7 @@ fn instance_name_farkli_id_farkli_name() {
     assert_ne!(a, b);
 }
 
-/// EndpointInfo encoding'i: [bitmap, 16 random, name_len, utf8 name]
+/// `EndpointInfo` encoding'i: [bitmap, 16 random, `name_len`, utf8 name]
 #[test]
 fn endpoint_info_yerlesim_standart() {
     let random = [0xAAu8; 16];

--- a/crates/hekadrop-app/tests/payload_corrupt.rs
+++ b/crates/hekadrop-app/tests/payload_corrupt.rs
@@ -27,7 +27,7 @@
 //! Bu entegrasyon testi `hekadrop::payload::PayloadAssembler` public API'sini
 //! doğrudan kullanır (lib.rs'te `pub mod payload` olarak re-export edilmiştir).
 //! Secure/network katmanlarına dokunmaz — payload reassembly semantiği
-//! (chunk birleşimi, total_size validasyonu, duplicate id koruması, SHA-256
+//! (chunk birleşimi, `total_size` validasyonu, duplicate id koruması, SHA-256
 //! hesabı) platform-agnostik olduğu için bu seviyede izole edilebilir.
 //!
 //! Kapsanan invariant'lar (her test adı iddiayı pin'ler):
@@ -35,7 +35,7 @@
 //!     yerel olarak hesaplanan SHA-256'dan farklı olmalı; `CompletedPayload::
 //!     File.sha256` alanı streaming hasher üzerinden üretilir, dışarıdan
 //!     beklenen hash ile kıyaslanır.
-//!   * `duplicate_payload_id_reddedilir` — Introduction'da aynı payload_id
+//!   * `duplicate_payload_id_reddedilir` — Introduction'da aynı `payload_id`
 //!     ile iki destination register edilirse ikincisi silent-overwrite yerine
 //!     hata dönmeli (review-18 MED: path-swap saldırısı).
 //!   * `out_of_order_chunks_dogru_konuma_yazilir` — `PayloadChunk.offset`

--- a/crates/hekadrop-app/tests/privacy_controls.rs
+++ b/crates/hekadrop-app/tests/privacy_controls.rs
@@ -23,14 +23,14 @@
 
 //! H#4 — Privacy controls integration tests.
 //!
-//! Settings struct'a eklenen 4 alanın (advertise / log_level / keep_stats /
-//! disable_update_check) davranışsal semantiğini doğrular. Gerçek tcp/mdns
+//! Settings struct'a eklenen 4 alanın (advertise / `log_level` / `keep_stats` /
+//! `disable_update_check`) davranışsal semantiğini doğrular. Gerçek tcp/mdns
 //! soket simülasyonu yerine **doğrudan API seviyesinde** kontrat testleri —
 //! main.rs / connection.rs / sender.rs integration noktaları state + settings
 //! üzerinden bu değerleri okuyor; bu test'ler o okuma path'inin canlı
 //! olduğunu ve default'ların v0.5 davranışını koruduğunu garantiler.
 //!
-//! Gerçek mdns bypass integration testi için mdns_discovery.rs'teki canlı
+//! Gerçek mdns bypass integration testi için `mdns_discovery.rs`'teki canlı
 //! test yeterli — burada Settings kontratını izole ediyoruz.
 //!
 //! Bu binary crate içinde `pub mod settings` (src/lib.rs) public API olarak

--- a/crates/hekadrop-app/tests/rate_limiter.rs
+++ b/crates/hekadrop-app/tests/rate_limiter.rs
@@ -35,7 +35,7 @@ use std::collections::{HashMap, VecDeque};
 use std::net::{IpAddr, Ipv4Addr};
 use std::time::{Duration, Instant};
 
-/// HekaDrop `RateLimiter` ile birebir davranış — Instant tabanlı sliding window.
+/// `HekaDrop` `RateLimiter` ile birebir davranış — Instant tabanlı sliding window.
 struct RateLimiter {
     windows: RwLock<HashMap<IpAddr, VecDeque<Instant>>>,
     window: Duration,
@@ -178,7 +178,7 @@ fn sliding_window_kaydirimi_yari_window() {
 /// peer muafiyeti yalnız hash doğrulandıktan sonra `forget_most_recent` ile
 /// geriye-dönük verilir. Bu test güncel kontratı pin'liyor.
 ///
-/// Eski test ("gate'de trusted bypass, check_and_record hiç çağrılmaz")
+/// Eski test ("gate'de trusted bypass, `check_and_record` hiç çağrılmaz")
 /// Issue #17 öncesi davranıştı — peer-controlled (name, id) spoof'a izin
 /// verdiği için kaldırıldı.
 #[test]

--- a/crates/hekadrop-app/tests/save_non_blocking.rs
+++ b/crates/hekadrop-app/tests/save_non_blocking.rs
@@ -67,17 +67,17 @@
 //!   korele olur → assertion patlar.
 //!
 //! ## Referans call-site'lar (pattern uygulanmış yerler)
-//!   * `src/connection.rs:302-313` (stats.record_received)
-//!   * `src/connection.rs:578-586` (touch_trusted_by_hash)
-//!   * `src/connection.rs:622-629` (add_trusted_with_hash upgrade)
-//!   * `src/connection.rs:638-660` (AcceptAndTrust kayıt)
-//!   * `src/sender.rs:285-295` (stats.record_sent)
-//!   * `src/main.rs:425-432` (auto_accept toggle)
-//!   * `src/main.rs:464-471` (trust_remove)
-//!   * `src/main.rs:497-503` (stats_reset)
-//!   * `src/main.rs:515-522` (trusted_clear)
-//!   * `src/main.rs:565-574` (handle_settings_save)
-//!   * `src/main.rs:801-806` (open_config_file — H#2'de düzeltildi)
+//!   * `src/connection.rs:302-313` (`stats.record_received`)
+//!   * `src/connection.rs:578-586` (`touch_trusted_by_hash`)
+//!   * `src/connection.rs:622-629` (`add_trusted_with_hash` upgrade)
+//!   * `src/connection.rs:638-660` (`AcceptAndTrust` kayıt)
+//!   * `src/sender.rs:285-295` (`stats.record_sent`)
+//!   * `src/main.rs:425-432` (`auto_accept` toggle)
+//!   * `src/main.rs:464-471` (`trust_remove`)
+//!   * `src/main.rs:497-503` (`stats_reset`)
+//!   * `src/main.rs:515-522` (`trusted_clear`)
+//!   * `src/main.rs:565-574` (`handle_settings_save`)
+//!   * `src/main.rs:801-806` (`open_config_file` — H#2'de düzeltildi)
 
 use parking_lot::RwLock;
 use std::sync::atomic::{AtomicBool, Ordering};

--- a/crates/hekadrop-app/tests/secure_roundtrip.rs
+++ b/crates/hekadrop-app/tests/secure_roundtrip.rs
@@ -23,7 +23,7 @@
 
 //! Secure message (AES-256-CBC + HMAC-SHA256 + sequence counter) uyumluluğu.
 //!
-//! HekaDrop `src/secure.rs` davranışının bağımsız bir protokol-uyumlu implementasyonu
+//! `HekaDrop` `src/secure.rs` davranışının bağımsız bir protokol-uyumlu implementasyonu
 //! üzerinden roundtrip, replay, HMAC tampering ve out-of-order senaryoları doğrulanır.
 
 mod common;
@@ -73,7 +73,7 @@ fn decode_sm(buf: &[u8]) -> Option<(Vec<u8>, [u8; 16], [u8; 32])> {
     Some((ct, iv, tag))
 }
 
-/// Secure context — HekaDrop `SecureCtx` karşılığı. Sequence counter monoton artar;
+/// Secure context — `HekaDrop` `SecureCtx` karşılığı. Sequence counter monoton artar;
 /// eksik ya da geri giden sequence reddedilir.
 struct SecureCtx {
     encrypt_key: [u8; 32],
@@ -218,7 +218,7 @@ fn sequence_counter_monoton_artar() {
 }
 
 /// Replay attack: aynı ciphertext ikinci kez gönderilirse reject.
-/// HekaDrop `SecureCtx::decrypt` fonksiyonu `client_seq`'i advance ettikten sonra
+/// `HekaDrop` `SecureCtx::decrypt` fonksiyonu `client_seq`'i advance ettikten sonra
 /// aynı frame'i yine almaya çalışırsak sequence "beklenen" ile uyuşmaz.
 #[test]
 fn replay_saldirisi_ayni_seq_ikinci_kez_rejected() {
@@ -270,7 +270,7 @@ fn basarisiz_decrypt_sonrasi_state_bozulmaz() {
 }
 
 /// HMAC tampering: cipher text'in son byte'ı değiştirilirse HMAC patlamalı.
-/// Bu testin var oluş sebebi: HekaDrop secure layer subtle::ConstantTimeEq
+/// Bu testin var oluş sebebi: `HekaDrop` secure layer `subtle::ConstantTimeEq`
 /// kullanıyor, bu doğrulanırken constant-time olsa bile yanlış tag *reddedilmeli*.
 #[test]
 fn tampered_hmac_reddedilir() {
@@ -298,7 +298,7 @@ fn tampered_ciphertext_hmac_ile_yakalanir() {
     assert!(r.is_err());
 }
 
-/// 2 yönlü (A↔B) çift yönlü trafik. A'nın send_seq'i ile B'nin send_seq'i
+/// 2 yönlü (A↔B) çift yönlü trafik. A'nın `send_seq`'i ile B'nin `send_seq`'i
 /// bağımsız — her yön kendi sayacını yönetmeli.
 #[test]
 fn cift_yonlu_trafik_seq_bagimsiz() {

--- a/crates/hekadrop-app/tests/server_rate_limiter.rs
+++ b/crates/hekadrop-app/tests/server_rate_limiter.rs
@@ -39,7 +39,7 @@
 //!     `forget_most_recent` ile kayıt geri alınır. Gate peer-controlled
 //!     string'lere güvenmez.
 //!   * `farkli_ip_bagimsiz_pencere` — Farklı IP'ler birbirinin limit
-//!     penceresini etkilememeli (HashMap key=IpAddr).
+//!     penceresini etkilememeli (`HashMap` key=IpAddr).
 //!   * `spoofed_legacy_name_id_rate_limit_bypass_yapmamali` —
 //!     Issue #17: gate'de legacy (name, id) muafiyeti YOK.
 //!   * `hash_dogrulanmadan_muafiyet_verilmez` — Hash yoksa queue intact.
@@ -130,8 +130,8 @@ fn trusted_ip_rate_limit_bypass() {
         fn is_trusted_by_hash(&self, h: &[u8; 6]) -> bool {
             self.trusted_hashes.contains(h)
         }
-        /// Production ile aynı sıralama: gate'de check_and_record, sonra
-        /// PairedKeyEncryption frame'i sonrası hash doğrulanırsa forget.
+        /// Production ile aynı sıralama: gate'de `check_and_record`, sonra
+        /// `PairedKeyEncryption` frame'i sonrası hash doğrulanırsa forget.
         fn accept_flow(&self, peer_hash: Option<[u8; 6]>) -> bool {
             // 1) Gate: herkes rate-limit'e tabi.
             self.rate_limiter_calls

--- a/crates/hekadrop-app/tests/settings_migration.rs
+++ b/crates/hekadrop-app/tests/settings_migration.rs
@@ -142,7 +142,7 @@ fn v1_vec_string_okunabilir() {
     );
 }
 
-/// V1 format load_or_default üzerinden V2'ye migrate edilmeli.
+/// V1 format `load_or_default` üzerinden V2'ye migrate edilmeli.
 #[test]
 fn v1_otomatik_v2_ye_migrate() {
     let json = r#"{
@@ -263,7 +263,7 @@ fn roundtrip_v1_serialize_deserialize_identical() {
     assert_eq!(s, back);
 }
 
-/// Eski JSON'da tip yanlış yazılmışsa (örn. trusted_devices bir obje): fallback.
+/// Eski JSON'da tip yanlış yazılmışsa (örn. `trusted_devices` bir obje): fallback.
 #[test]
 fn trusted_devices_yanlis_tip_fallback_default() {
     let bad = r#"{"trusted_devices": "not-a-list"}"#;

--- a/crates/hekadrop-app/tests/trust_hijack.rs
+++ b/crates/hekadrop-app/tests/trust_hijack.rs
@@ -37,7 +37,7 @@
 //! Bu test, full handshake yerine `Settings::is_trusted_by_hash` katmanında
 //! senaryoyu doğrular — tasarım 017 §7.2'nin karar kurallarını birebir
 //! karşılayan unit-harness. Full connection-level integration testi
-//! (socket + UKEY2 + PayloadAssembler) bu PR için aşırı kapsamlı; burada
+//! (socket + UKEY2 + `PayloadAssembler`) bu PR için aşırı kapsamlı; burada
 //! yalnız trust-karar mekaniği izole edilmiştir.
 
 use serde_json::json;

--- a/crates/hekadrop-app/tests/ukey2_downgrade.rs
+++ b/crates/hekadrop-app/tests/ukey2_downgrade.rs
@@ -21,11 +21,11 @@
     clippy::map_err_ignore
 )]
 
-//! UKEY2 ServerInit downgrade regression — wire-format seviyesi.
+//! UKEY2 `ServerInit` downgrade regression — wire-format seviyesi.
 //!
 //! `src/ukey2.rs::validate_server_init` happy-path dışında mutation-survivor
-//! riski taşıyordu (saldırgan peer, ClientInit'te teklif etmediğimiz zayıf bir
-//! cipher — örn. `CURVE25519_SHA512` ya da `RESERVED` — ile ServerInit dönerse
+//! riski taşıyordu (saldırgan peer, `ClientInit`'te teklif etmediğimiz zayıf bir
+//! cipher — örn. `CURVE25519_SHA512` ya da `RESERVED` — ile `ServerInit` dönerse
 //! validator BAIL etmeli, yoksa sessizce düşülmüş bir handshake olur).
 //!
 //! Bu integration test:
@@ -35,9 +35,9 @@
 //!      üretim tarafıyla paylaşılır.
 //!   2) Aynı byte dizisini decode edip `hekadrop::validate_server_init`'e
 //!      besler — üretim kodunun çağırdığı fonksiyonun aynısı.
-//!   3) P256_SHA512 dışı her cipher için hata mesajı `cipher downgrade` içerir.
+//!   3) `P256_SHA512` dışı her cipher için hata mesajı `cipher downgrade` içerir.
 //!   4) Version 1 dışı her değer için `yalnız V1` hata yolu çalışır.
-//!   5) Happy path (V1 + P256_SHA512) regresyona karşı yeşil kalır.
+//!   5) Happy path (V1 + `P256_SHA512`) regresyona karşı yeşil kalır.
 //!
 //! Neden integration (binary-external)? Üretim decode pipeline'ı `prost`
 //! varsayılanlarının (absent = `None`) doğru yorumlanmasına bağlı; bu test
@@ -59,7 +59,7 @@ fn wrap_server_init_to_wire(si: &Ukey2ServerInit) -> Vec<u8> {
     msg.encode_to_vec()
 }
 
-/// Wire bytes'tan ServerInit'i decode edip validator'a besleyen uçtan uca
+/// Wire bytes'tan `ServerInit`'i decode edip validator'a besleyen uçtan uca
 /// pipeline — gerçek ağ frame'inin yaşayacağı yol.
 fn decode_and_validate(wire: &[u8]) -> Result<Ukey2ServerInit> {
     let outer = Ukey2Message::decode(wire)?;

--- a/crates/hekadrop-app/tests/ukey2_handshake.rs
+++ b/crates/hekadrop-app/tests/ukey2_handshake.rs
@@ -24,9 +24,9 @@
 //! UKEY2 handshake protokolü uyumluluğu — P-256 ECDH + HKDF + Java-uyumlu
 //! signed byte encoding'i tam simülasyon ile doğrular.
 //!
-//! Bu test crate'i HekaDrop binary'sine bağlamaz: aynı dış crate'leri
+//! Bu test crate'i `HekaDrop` binary'sine bağlamaz: aynı dış crate'leri
 //! ([p256], [hkdf], [sha2], [prost]) kullanarak "Alice ↔ Bob" senaryosu kurar.
-//! Amaç: HekaDrop tarafının ürettiği anahtarları başka bir peer'ın aynı
+//! Amaç: `HekaDrop` tarafının ürettiği anahtarları başka bir peer'ın aynı
 //! formülle yeniden türetebilmesini garanti etmek.
 
 mod common;
@@ -37,7 +37,7 @@ use p256::{ecdh::diffie_hellman, PublicKey, SecretKey};
 use rand::rngs::OsRng;
 
 /// İki taraf için HKDF ile türetilen 4+ anahtarı kapsayan yardımcı.
-/// HekaDrop `DerivedKeys` yapısıyla aynı alanlar.
+/// `HekaDrop` `DerivedKeys` yapısıyla aynı alanlar.
 #[derive(Debug)]
 struct DerivedKeys {
     client_aes: [u8; 32],
@@ -111,7 +111,7 @@ fn ecdh_iki_taraf_ayni_shared_secret_uretir() {
 }
 
 /// Full handshake simülasyonu: Alice (client) ve Bob (server) aynı transcript
-/// üzerinden aynı 4 AES/HMAC anahtarı + aynı auth_key + aynı PIN'i türetmeli.
+/// üzerinden aynı 4 AES/HMAC anahtarı + aynı `auth_key` + aynı PIN'i türetmeli.
 #[test]
 fn alice_bob_handshake_ayni_derived_keys_uretir() {
     let alice_sk = SecretKey::random(&mut OsRng);
@@ -148,7 +148,7 @@ fn alice_bob_handshake_ayni_derived_keys_uretir() {
     assert_eq!(alice_keys.pin_code, bob_keys.pin_code);
 }
 
-/// client_init ya da server_init transcript'i farklıysa (MITM birinin mesajını
+/// `client_init` ya da `server_init` transcript'i farklıysa (MITM birinin mesajını
 /// değiştirmiş) türetilen anahtarlar ayrışmalı — bu yüzden MITM tespiti olabilir.
 #[test]
 fn transcript_binding_farkli_transcript_farkli_anahtar() {
@@ -187,7 +187,7 @@ fn pin_code_her_zaman_4_basamak() {
     }
 }
 
-/// NearDrop referansı ile aynı PIN algoritması — Java BigInteger signed-byte
+/// `NearDrop` referansı ile aynı PIN algoritması — Java `BigInteger` signed-byte
 /// davranışı burada önemli. 0x80'lik bir byte Java'da -128 olmalı, Rust'ta
 /// `b as i8 as i64` = -128 çıkmalı.
 #[test]
@@ -235,7 +235,7 @@ fn to_signed_bytes_bos_slice_bos_kalir() {
 }
 
 /// P-256 public key encode → `to_signed_bytes(X) || to_signed_bytes(Y)`.
-/// Gerçek Android peer'ları bu formatı zorunlu olarak bekler (Java BigInteger).
+/// Gerçek Android peer'ları bu formatı zorunlu olarak bekler (Java `BigInteger`).
 #[test]
 fn p256_public_key_signed_encoding_java_uyumlu() {
     let sk = SecretKey::random(&mut OsRng);
@@ -262,7 +262,7 @@ fn p256_public_key_signed_encoding_java_uyumlu() {
 }
 
 /// HKDF-SHA256 RFC 5869 A.1 vektörü — crypto modülünün hkdf çağrısı standart.
-/// Bizim common::hkdf_sha256 yardımcımız doğru çalışıyor mu?
+/// Bizim `common::hkdf_sha256` yardımcımız doğru çalışıyor mu?
 #[test]
 fn hkdf_sha256_rfc5869_a1_test_vector() {
     let ikm = hex::decode("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b").unwrap();
@@ -276,9 +276,9 @@ fn hkdf_sha256_rfc5869_a1_test_vector() {
     assert_eq!(okm, expected);
 }
 
-/// Derived keys'in "rol simetrisi": client taraf encrypt_key olarak client_aes'i
-/// kullanırsa, server taraf decrypt_key olarak aynı key'i kullanmalı. Bu test
-/// HekaDrop `DerivedKeys` doldurmasının simetrik olduğunu doğrular.
+/// Derived keys'in "rol simetrisi": client taraf `encrypt_key` olarak `client_aes`'i
+/// kullanırsa, server taraf `decrypt_key` olarak aynı key'i kullanmalı. Bu test
+/// `HekaDrop` `DerivedKeys` doldurmasının simetrik olduğunu doğrular.
 #[test]
 fn rol_simetrisi_client_enc_eq_server_dec() {
     let alice_sk = SecretKey::random(&mut OsRng);

--- a/crates/hekadrop-cli/src/main.rs
+++ b/crates/hekadrop-cli/src/main.rs
@@ -1,4 +1,4 @@
-//! HekaDrop CLI — v0.7'de yalnız stub. v0.10.0'da `send`, `receive`,
+//! `HekaDrop` CLI — v0.7'de yalnız stub. v0.10.0'da `send`, `receive`,
 //! `daemon`, `list-peers`, `trust`, `doctor`, `version`, `gui` komutları
 //! ile şişecek (ROADMAP §Q1 v0.10.0).
 //!

--- a/crates/hekadrop-core/src/capabilities.rs
+++ b/crates/hekadrop-core/src/capabilities.rs
@@ -1,4 +1,4 @@
-//! HekaDrop protocol extension capability negotiation (RFC-0003 §3.2).
+//! `HekaDrop` protocol extension capability negotiation (RFC-0003 §3.2).
 //!
 //! Bu modül [`hekadrop_proto::hekadrop_ext`] altındaki üretilmiş
 //! `Capabilities` ve `HekaDropFrame` mesajlarını idiomatic Rust API

--- a/crates/hekadrop-core/src/chunk_hmac.rs
+++ b/crates/hekadrop-core/src/chunk_hmac.rs
@@ -28,8 +28,8 @@ pub const CHUNK_HMAC_HKDF_INFO: &[u8] = b"hekadrop chunk-hmac v1";
 pub const TAG_LEN: usize = 32;
 
 /// HMAC input prefix uzunluğu (body öncesi sabit alanlar).
-/// Hesap: 8 (payload_id BE i64) + 8 (chunk_index BE i64) + 8 (offset BE i64)
-///       + 4 (body_len BE u32) = 28 bayt.
+/// Hesap: 8 (`payload_id` BE i64) + 8 (`chunk_index` BE i64) + 8 (offset BE i64)
+///       + 4 (`body_len` BE u32) = 28 bayt.
 pub const HMAC_INPUT_PREFIX_LEN: usize = 8 + 8 + 8 + 4;
 
 /// UKEY2 `next_secret` IKM'inden chunk-HMAC anahtarını türet.
@@ -214,7 +214,7 @@ mod tests {
     }
 
     /// Domain separation: chunk-HMAC label başka label'lardan farklı key
-    /// üretir. SecureMessage HKDF (different info) ile çakışma olmamalı.
+    /// üretir. `SecureMessage` HKDF (different info) ile çakışma olmamalı.
     #[test]
     fn key_derivation_domain_separated() {
         let ikm = [0x42u8; 32];
@@ -225,7 +225,7 @@ mod tests {
         assert_ne!(chunk_key.as_slice(), other.as_slice());
     }
 
-    /// Round-trip: compute_tag + verify_tag (eşleşen body) → Ok.
+    /// Round-trip: `compute_tag` + `verify_tag` (eşleşen body) → Ok.
     #[test]
     fn compute_then_verify_ok() {
         let key = derive_chunk_hmac_key(&[0x42u8; 32]);
@@ -236,7 +236,7 @@ mod tests {
         assert_eq!(verify_tag(&key, &ci, body), Ok(()));
     }
 
-    /// Body bit-flip → TagMismatch.
+    /// Body bit-flip → `TagMismatch`.
     #[test]
     fn verify_detects_body_tampering() {
         let key = derive_chunk_hmac_key(&[0x42u8; 32]);
@@ -252,7 +252,7 @@ mod tests {
         );
     }
 
-    /// Yanlış payload_id → TagMismatch (tag binding redundant alanları içerir).
+    /// Yanlış `payload_id` → `TagMismatch` (tag binding redundant alanları içerir).
     #[test]
     fn verify_detects_payload_id_rebinding() {
         let key = derive_chunk_hmac_key(&[0x42u8; 32]);
@@ -271,7 +271,7 @@ mod tests {
         assert_eq!(verify_tag(&key, &ci, body), Err(VerifyError::TagMismatch));
     }
 
-    /// Yanlış chunk_index → TagMismatch.
+    /// Yanlış `chunk_index` → `TagMismatch`.
     #[test]
     fn verify_detects_chunk_index_rebinding() {
         let key = derive_chunk_hmac_key(&[0x42u8; 32]);
@@ -288,7 +288,7 @@ mod tests {
         assert_eq!(verify_tag(&key, &ci, body), Err(VerifyError::TagMismatch));
     }
 
-    /// Yanlış offset → TagMismatch.
+    /// Yanlış offset → `TagMismatch`.
     #[test]
     fn verify_detects_offset_rebinding() {
         let key = derive_chunk_hmac_key(&[0x42u8; 32]);
@@ -305,7 +305,7 @@ mod tests {
         assert_eq!(verify_tag(&key, &ci, body), Err(VerifyError::TagMismatch));
     }
 
-    /// Yanlış key → TagMismatch.
+    /// Yanlış key → `TagMismatch`.
     #[test]
     fn verify_detects_wrong_key() {
         let k1 = derive_chunk_hmac_key(&[0x42u8; 32]);
@@ -317,7 +317,7 @@ mod tests {
         assert_eq!(verify_tag(&k2, &ci, body), Err(VerifyError::TagMismatch));
     }
 
-    /// Tag uzunluğu 32 değil → WrongTagLength (constant-time öncesi).
+    /// Tag uzunluğu 32 değil → `WrongTagLength` (constant-time öncesi).
     #[test]
     fn verify_rejects_short_tag() {
         let key = derive_chunk_hmac_key(&[0x42u8; 32]);
@@ -354,7 +354,7 @@ mod tests {
         );
     }
 
-    /// `body_len` mismatch → BodyLenMismatch (HMAC compute öncesi yakalanır).
+    /// `body_len` mismatch → `BodyLenMismatch` (HMAC compute öncesi yakalanır).
     #[test]
     fn verify_rejects_body_len_mismatch() {
         let key = derive_chunk_hmac_key(&[0x42u8; 32]);
@@ -406,7 +406,7 @@ mod tests {
         assert_eq!(&input[28..], &body[..]);
     }
 
-    /// Chunk index'leri sıralı ama farklı payload_id'lerde aynı body için
+    /// Chunk index'leri sıralı ama farklı `payload_id`'lerde aynı body için
     /// farklı tag çıkarmalı (binding redundancy doğrulaması).
     #[test]
     fn different_payload_ids_produce_different_tags_for_same_body() {

--- a/crates/hekadrop-core/src/config.rs
+++ b/crates/hekadrop-core/src/config.rs
@@ -39,7 +39,7 @@ pub const DEVICE_TYPE_COMPUTER: u8 = 3;
 
 /// `EndpointInfo` yapısı — TXT record `n=` değerinin base64'ten öncesi.
 /// Yerleşim:
-///   `[0]`      bitmap: (sürüm<<5)|(görünürlük<<`4)|(cihaz_tipi`<<1)|rez
+///   `[0]`      bitmap: (sürüm<<5)|(görünürlük<<4)|(`cihaz_tipi`<<1)|rez
 ///   `[1..17]`  16 bayt rastgele
 ///   `[17]`     ad uzunluğu (u8)
 ///   `[18..]`   UTF-8 cihaz adı

--- a/crates/hekadrop-core/src/config.rs
+++ b/crates/hekadrop-core/src/config.rs
@@ -37,9 +37,9 @@ pub fn instance_name(endpoint_id: [u8; 4]) -> String {
 
 pub const DEVICE_TYPE_COMPUTER: u8 = 3;
 
-/// EndpointInfo yapısı — TXT record `n=` değerinin base64'ten öncesi.
+/// `EndpointInfo` yapısı — TXT record `n=` değerinin base64'ten öncesi.
 /// Yerleşim:
-///   `[0]`      bitmap: (sürüm<<5)|(görünürlük<<4)|(cihaz_tipi<<1)|rez
+///   `[0]`      bitmap: (sürüm<<5)|(görünürlük<<`4)|(cihaz_tipi`<<1)|rez
 ///   `[1..17]`  16 bayt rastgele
 ///   `[17]`     ad uzunluğu (u8)
 ///   `[18..]`   UTF-8 cihaz adı

--- a/crates/hekadrop-core/src/connection.rs
+++ b/crates/hekadrop-core/src/connection.rs
@@ -1,13 +1,13 @@
 //! Inbound Nearby/Quick Share bağlantı state machine'i.
 //!
 //! Akış:
-//!   1) Plain ConnectionRequest                       (peer → us)
-//!   2) UKEY2 ClientInit                              (peer → us)
-//!   3) UKEY2 ServerInit                              (us   → peer)
-//!   4) UKEY2 ClientFinished                          (peer → us)    [anahtarlar türetilir]
-//!   5) Plain ConnectionResponse                      (peer → us)
-//!   6) Plain ConnectionResponse (Accept)             (us   → peer)
-//!   7) Şifreli loop — tüm sonraki frame'ler SecureMessage katmanından geçer.
+//!   1) Plain `ConnectionRequest`                       (peer → us)
+//!   2) UKEY2 `ClientInit`                              (peer → us)
+//!   3) UKEY2 `ServerInit`                              (us   → peer)
+//!   4) UKEY2 `ClientFinished`                          (peer → us)    [anahtarlar türetilir]
+//!   5) Plain `ConnectionResponse`                      (peer → us)
+//!   6) Plain `ConnectionResponse` (Accept)             (us   → peer)
+//!   7) Şifreli loop — tüm sonraki frame'ler `SecureMessage` katmanından geçer.
 
 use crate::error::HekaError;
 use crate::frame;
@@ -44,7 +44,7 @@ use tracing::{info, warn};
 /// platform-bağımlı yardımcılar.
 ///
 /// I-1 (CLAUDE.md): connection core'a taşınınca `crate::platform`
-/// (open_url / copy_to_clipboard) referansı sızmasın diye trait üzerinden
+/// (`open_url` / `copy_to_clipboard`) referansı sızmasın diye trait üzerinden
 /// dispatch ediyoruz. App-side `PlatformShim` minimal `Send + Sync` impl'i
 /// `crate::platform::*` çağrılarına forward eder.
 pub trait PlatformOps: Send + Sync {
@@ -467,7 +467,7 @@ pub async fn handle(
 /// Reject, kullanıcı Cancel, peer Disconnect, I/O hatası veya socket
 /// kopması durumlarının hepsinde güvenli biçimde çağrılır; idempotent'tir.
 /// Yaptığı işler:
-///   * `pending_names` içindeki her payload_id için `PayloadAssembler::cancel`
+///   * `pending_names` içindeki her `payload_id` için `PayloadAssembler::cancel`
 ///     çağrılır — yarım yazılmış dosyalar ve açık dosya kulpları temizlenir,
 ///     disk sızıntısı önlenir.
 ///   * `pending_texts` ve `pending_names` tamamen boşaltılır.
@@ -1319,7 +1319,7 @@ pub(crate) fn build_connection_response_accept() -> OfflineFrame {
 /// [`crate::error::HekaError`] variant'ları (tip-safe ayrım), sonra
 /// `std::io::Error` (generic I/O). String-match son çare değil — düşmüyoruz,
 /// fallback kasıtlı olarak `err.pin_mismatch`: UKEY2 handshake spec'inde
-/// handshake tamamlansa ama ClientFinished commitment reddedilse bu noktada
+/// handshake tamamlansa ama `ClientFinished` commitment reddedilse bu noktada
 /// `Ukey2CommitmentMismatch` downcast yakalar; bilinmeyen generic hata
 /// kullanıcı için de pratikte "PIN eşleşmedi" olarak yorumlanır (en sık neden).
 fn classify_handshake_error(e: &anyhow::Error) -> &'static str {
@@ -1382,7 +1382,7 @@ fn parse_remote_name(endpoint_info: &[u8]) -> Option<String> {
 ///
 /// **Why checked aritmetik:** Üç giriş alanı da unvalidated peer data. Naïve
 /// `(offset + body_len) * 100 / total` hesabı i64 overflow ile (debug panic /
-/// release wrap) yanlış progress veya DoS açar. Overflow ya da geçersiz `total`
+/// release wrap) yanlış progress veya `DoS` açar. Overflow ya da geçersiz `total`
 /// (0/negatif) → `None` (caller progress update'ini sessizce atlar).
 ///
 /// Bkz. [`crate::sender::compute_percent`] sender tarafı muadili (`bytes_before`

--- a/crates/hekadrop-core/src/connection.rs
+++ b/crates/hekadrop-core/src/connection.rs
@@ -1053,7 +1053,7 @@ fn human_size(bytes: i64) -> String {
     }
 }
 
-/// HekaDrop extension frame'i parse + handle eder. Magic-prefix dispatch
+/// `HekaDrop` extension frame'i parse + handle eder. Magic-prefix dispatch
 /// (`frame::dispatch_frame_body`) sonrası caller bu helper'ı çağırır.
 ///
 /// Davranış:
@@ -1949,7 +1949,7 @@ mod tests {
 
     // ─── PR #114 (CRITICAL): receiver dispatch + capabilities response ───
 
-    /// `dispatch_frame_body` HekaDrop magic (`0xA5DEB201`) içeren plaintext
+    /// `dispatch_frame_body` `HekaDrop` magic (`0xA5DEB201`) içeren plaintext
     /// için `FrameKind::HekaDrop` döner; capabilities exchange wire path
     /// bunu kullanır. Receiver loop bu varyanta opportunistic handler ile
     /// cevap verir.

--- a/crates/hekadrop-core/src/crypto.rs
+++ b/crates/hekadrop-core/src/crypto.rs
@@ -35,9 +35,9 @@ pub fn sha256(data: &[u8]) -> [u8; 32] {
 }
 
 /// Quick Share 4-haneli PIN: authKey 32 bayttan türetilir.
-/// NearDrop algoritması birebir:
+/// `NearDrop` algoritması birebir:
 ///   hash=0, mult=1
-///   for b in key: hash = (hash + b_signed * mult) % 9973, mult = (mult * 31) % 9973
+///   for b in key: hash = (hash + `b_signed` * mult) % 9973, mult = (mult * 31) % 9973
 ///   pin = abs(hash) 4 hane
 pub fn pin_code_from_auth_key(key: &[u8]) -> String {
     let mut hash: i64 = 0;
@@ -131,9 +131,9 @@ mod tests {
         assert_eq!(pin.len(), 4);
     }
 
-    /// NearDrop referans PIN algoritmasına birebir KAT (known-answer test).
+    /// `NearDrop` referans PIN algoritmasına birebir KAT (known-answer test).
     ///
-    /// Beklenen değerler NearDrop spec'indeki aynı akışı Python ile bağımsız
+    /// Beklenen değerler `NearDrop` spec'indeki aynı akışı Python ile bağımsız
     /// olarak koşturup çıkarıldı:
     /// ```python
     /// def pin(key):
@@ -177,17 +177,17 @@ mod tests {
     /// Known-answer golden vector: 32-baytlık sabit bir `auth_key` → sabit 4-haneli PIN.
     ///
     /// Kapsam: yalnız `pin_code_from_auth_key` regression guard'ı — HKDF burada
-    /// çalıştırılmıyor, test doğrudan sabit bir auth_key besliyor. Amaç, gelecekte
+    /// çalıştırılmıyor, test doğrudan sabit bir `auth_key` besliyor. Amaç, gelecekte
     /// `MOD=9973`, `mult*=31` çarpanı, `rem_euclid` ya da signed-byte yorumlaması
     /// **sessizce** değişirse bu testin kırılmasıyla fark edilsin. Mutation testing
     /// survivor'larını da kapatır (operatör flip, sabit değişikliği, signedness kaybı).
     ///
-    /// HKDF → auth_key → PIN uçtan uca KAT testi ayrı bir vektör olarak eklenebilir;
+    /// HKDF → `auth_key` → PIN uçtan uca KAT testi ayrı bir vektör olarak eklenebilir;
     /// bu test özellikle PIN derivation adımını izole tutar.
     ///
-    /// Kaynak: NearDrop referans algoritmasının Python'a birebir port'u ile bağımsız
+    /// Kaynak: `NearDrop` referans algoritmasının Python'a birebir port'u ile bağımsız
     /// olarak türetildi (vektörü değiştirmek = algoritmayı değiştirmek).
-    ///   https://github.com/grishka/NearDrop (PIN türetme Android paketinde benzer akış)
+    ///   <https://github.com/grishka/NearDrop> (PIN türetme Android paketinde benzer akış)
     ///
     /// **Bu vektör bir kez kaydedildi — gelecekte değişirse PIN derivation algoritması
     /// değişti demek, incele.** Değişiklik kasıtlıysa yeni beklenen PIN'i güncelle

--- a/crates/hekadrop-core/src/discovery_types.rs
+++ b/crates/hekadrop-core/src/discovery_types.rs
@@ -9,7 +9,7 @@ use std::net::IpAddr;
 
 /// Quick Share peer device kategorisi (TXT record `device_type` byte'ından).
 /// Display string'leri caller (UI/CLI) tarafında i18n + emoji ile çözülür —
-/// core UI/locale-agnostic kalır. PR #93 review (Copilot): kind_label() Türkçe
+/// core UI/locale-agnostic kalır. PR #93 review (Copilot): `kind_label()` Türkçe
 /// + emoji string'leri core'dan çıkartıldı.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DeviceKind {
@@ -42,9 +42,9 @@ pub struct DiscoveredDevice {
     pub device_type: u8,
     pub fullname: String,
     /// `true` ise peer mDNS TXT record'unda `ext=1` flag'i göndermiş —
-    /// HekaDrop extension protocol (capabilities envelope, chunk-HMAC,
+    /// `HekaDrop` extension protocol (capabilities envelope, chunk-HMAC,
     /// resume, folder) destekli. `false` (eski Quick Share peer):
-    /// HekaDropFrame yollanmamalı; legacy mode kullanılır.
+    /// `HekaDropFrame` yollanmamalı; legacy mode kullanılır.
     ///
     /// RFC-0003 §3.3 peer-detection signal. Eski Quick Share peer'larında
     /// `ext` alanı yok → parser default `false` set eder.

--- a/crates/hekadrop-core/src/error.rs
+++ b/crates/hekadrop-core/src/error.rs
@@ -27,7 +27,7 @@ pub enum HekaError {
     /// `#[from]` — `?` ile `std::io::Error` otomatik dönüşüm için.
     #[error("I/O hatası: {0}")]
     Io(#[from] std::io::Error),
-    /// `read_frame`: 4-byte length-prefix MAX_FRAME_SIZE'ı aştı.
+    /// `read_frame`: 4-byte length-prefix `MAX_FRAME_SIZE`'ı aştı.
     #[error("çerçeve boyutu sınır aştı: {0}")]
     FrameTooLarge(usize),
     /// `read_frame`: stream beklenmedik biçimde sonlandı (kısa okuma).
@@ -42,7 +42,7 @@ pub enum HekaError {
     /// Rate limiter aynı IP'den pencere aşımı tespit etti (trusted muaf).
     #[error("rate limit: aynı IP'den çok fazla bağlantı denemesi ({0})")]
     RateLimited(String),
-    /// TcpStream::connect üst sınırı aşıldı (erişilemez host / router drop).
+    /// `TcpStream::connect` üst sınırı aşıldı (erişilemez host / router drop).
     #[error("bağlantı zaman aşımına uğradı ({secs} sn): {addr}")]
     ConnectTimeout { secs: u64, addr: String },
 
@@ -65,13 +65,13 @@ pub enum HekaError {
     /// korunur).
     #[error("UKEY2: {0}")]
     Ukey2(String),
-    /// UKEY2 ServerInit cipher downgrade reddedildi (P256_SHA512 dışı).
+    /// UKEY2 `ServerInit` cipher downgrade reddedildi (`P256_SHA512` dışı).
     #[error("ServerInit cipher downgrade reddedildi: beklenen P256_SHA512, gelen {0}")]
     Ukey2CipherDowngrade(String),
-    /// UKEY2 ServerInit version downgrade reddedildi (V1 dışı).
+    /// UKEY2 `ServerInit` version downgrade reddedildi (V1 dışı).
     #[error("ServerInit version={0} — yalnız V1 destekleniyor")]
     Ukey2VersionDowngrade(String),
-    /// UKEY2 ClientFinished commitment doğrulaması başarısız (PIN / MITM).
+    /// UKEY2 `ClientFinished` commitment doğrulaması başarısız (PIN / MITM).
     #[error("UKEY2: cipher commitment uyuşmadı")]
     Ukey2CommitmentMismatch,
 
@@ -79,13 +79,13 @@ pub enum HekaError {
     /// Protobuf decode ya da beklenen alan eksikliği.
     #[error("protokol hatası: {0}")]
     Protocol(String),
-    /// Beklenen state'te değiliz (örn. beklenen CLIENT_INIT, alınan X).
+    /// Beklenen state'te değiliz (örn. beklenen `CLIENT_INIT`, alınan X).
     #[error("protokol durumu: {0}")]
     ProtocolState(String),
-    /// Introduction / CipherCommitment repeated-field flood (DoS).
+    /// Introduction / `CipherCommitment` repeated-field flood (`DoS`).
     #[error("Introduction cardinality flood: {files} dosya, {texts} metin (limit 1000/64)")]
     IntroductionFlood { files: usize, texts: usize },
-    /// UKEY2 CipherCommitment repeated-field flood (DoS).
+    /// UKEY2 `CipherCommitment` repeated-field flood (`DoS`).
     #[error("cipher_commitment flood: {0} eleman (max 8)")]
     CipherCommitmentFlood(usize),
 
@@ -116,7 +116,7 @@ pub enum HekaError {
     /// Unique dosya adı 10k denemede bulunamadı (dizin dolu).
     #[error("uygun dosya adı bulunamadı (10k deneme)")]
     FileNameExhausted,
-    /// Payload katmanı IO (disk full, permission, generic std::io wrap
+    /// Payload katmanı IO (disk full, permission, generic `std::io` wrap
     /// etmesek de context string taşıyanlar).
     #[error("payload IO: {0}")]
     PayloadIo(String),
@@ -133,7 +133,7 @@ pub enum HekaError {
     /// "0 bayt dosya" değil, "hiç dosya yok".
     #[error("hiç dosya seçilmedi")]
     NoFilesSelected,
-    /// Tek dosya boyutu i64::MAX üstü (saçma büyük).
+    /// Tek dosya boyutu `i64::MAX` üstü (saçma büyük).
     #[error("dosya çok büyük (>= {max} bayt, desteklenmiyor): {path}")]
     FileTooLarge { max: i64, path: String },
 

--- a/crates/hekadrop-core/src/frame.rs
+++ b/crates/hekadrop-core/src/frame.rs
@@ -6,13 +6,13 @@ use tokio::net::TcpStream;
 
 const MAX_FRAME_SIZE: usize = 16 * 1024 * 1024;
 
-/// Handshake fazında (ConnectionRequest, UKEY2) slow-loris saldırılarına karşı
+/// Handshake fazında (`ConnectionRequest`, UKEY2) slow-loris saldırılarına karşı
 /// frame okuma süresinin üst sınırı. 30 sn gerçek peer için fazlasıyla yeter;
 /// bu sürede tek bir frame bile gelmezse saldırgan ya da ağ arızası varsayılır.
 pub const HANDSHAKE_READ_TIMEOUT: Duration = Duration::from_secs(30);
 
-/// Şifreli loop (PayloadTransfer / KeepAlive) fazında idle üst sınır.
-/// Quick Share peer'ları periyodik KeepAlive gönderdiği için 60 sn sessizlik
+/// Şifreli loop (`PayloadTransfer` / `KeepAlive`) fazında idle üst sınır.
+/// Quick Share peer'ları periyodik `KeepAlive` gönderdiği için 60 sn sessizlik
 /// ölü bağlantı olarak kabul edilir; slow-loris tokio task sızıntısı
 /// engellenir.
 pub const STEADY_READ_TIMEOUT: Duration = Duration::from_secs(60);
@@ -70,7 +70,7 @@ pub async fn write_frame(stream: &mut TcpStream, data: &[u8]) -> Result<(), Heka
 /// Wire-byte-exact spec: `docs/protocol/capabilities.md` §2.
 pub const HEKADROP_MAGIC_BE: [u8; 4] = [0xA5, 0xDE, 0xB2, 0x01];
 
-/// `dispatch_frame_body`'nin döndürdüğü ayrım — caller frame'in HekaDrop
+/// `dispatch_frame_body`'nin döndürdüğü ayrım — caller frame'in `HekaDrop`
 /// extension mı yoksa upstream Quick Share mi olduğunu bilir.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum FrameKind<'a> {
@@ -87,7 +87,7 @@ pub enum FrameKind<'a> {
 /// 4-byte magic prefix kontrolü O(1) memcmp'tir; protobuf parse maliyeti
 /// yoktur. Eski Quick Share peer'ı bizim magic'i içeren bir frame görürse
 /// `OfflineFrame::decode` hatası alır ve drop eder — bu zaten capabilities
-/// gate aktif değilken HekaDrop'un GÖNDERMEMESİ gereken bir frame'dir;
+/// gate aktif değilken `HekaDrop`'un GÖNDERMEMESİ gereken bir frame'dir;
 /// dispatcher defense-in-depth.
 #[must_use]
 pub fn dispatch_frame_body(body: &[u8]) -> FrameKind<'_> {

--- a/crates/hekadrop-core/src/lib.rs
+++ b/crates/hekadrop-core/src/lib.rs
@@ -1,4 +1,4 @@
-//! HekaDrop core protocol engine — UKEY2 handshake, kripto primitive'leri,
+//! `HekaDrop` core protocol engine — UKEY2 handshake, kripto primitive'leri,
 //! frame codec ve guard'lar. (Payload assembler RFC-0001 Adım 4'te taşınacak.)
 //!
 //! RFC-0001 §5 Adım 3 ile `hekadrop-app`'tan ayrıştırıldı. Hedef: protocol

--- a/crates/hekadrop-core/src/log_redact.rs
+++ b/crates/hekadrop-core/src/log_redact.rs
@@ -1,6 +1,6 @@
 //! Log dosyası için PII redaction yardımcıları.
 //!
-//! HekaDrop log dosyası (`platform::logs_dir()` altında, 3 gün rolling)
+//! `HekaDrop` log dosyası (`platform::logs_dir()` altında, 3 gün rolling)
 //! troubleshooting için paylaşılabilir. Paylaşım senaryosunda kullanıcının
 //! ev dizin yapısı, cross-user eşleştirilebilen dosya parmakları (SHA-256)
 //! veya URL query token'ları ifşa olmamalı — bu yardımcılar `info!` / `warn!`

--- a/crates/hekadrop-core/src/negotiation.rs
+++ b/crates/hekadrop-core/src/negotiation.rs
@@ -1,15 +1,15 @@
 //! Capabilities exchange — runtime helper (RFC-0003 §3.3).
 //!
-//! [`negotiate_capabilities`] PairedKeyEncryption sonrası, herhangi bir
-//! HekaDrop extension frame'i emit edilmeden önce çağrılır. Send + receive
+//! [`negotiate_capabilities`] `PairedKeyEncryption` sonrası, herhangi bir
+//! `HekaDrop` extension frame'i emit edilmeden önce çağrılır. Send + receive
 //! + 2 sn timeout fallback semantiğini tek async fn içine paketler.
 //!
 //! Wire-byte-exact spec: [`docs/protocol/capabilities.md`] §5.
 //!
 //! **State machine entegrasyon notu (v0.8):** Bu helper henüz `sender.rs`
 //! veya `connection.rs` ana akışına bağlı değildir; eski Quick Share peer'ları
-//! HekaDropFrame'i decode edemediğinde davranışları bilinmez (büyük olasılık
-//! connection drop). Peer-detection logic (HekaDrop extension flag'i mDNS
+//! `HekaDropFrame`'i decode edemediğinde davranışları bilinmez (büyük olasılık
+//! connection drop). Peer-detection logic (`HekaDrop` extension flag'i mDNS
 //! TXT'te) eklendikten sonra ayrı bir PR ile sender + receiver akışlarına
 //! entegre edilir.
 
@@ -28,7 +28,7 @@ use prost::Message;
 /// §5.1 spec değeri (2 sn).
 pub const DEFAULT_CAPABILITIES_TIMEOUT: Duration = Duration::from_millis(2000);
 
-/// PairedKeyEncryption sonrası HekaDrop extension capabilities exchange'ini
+/// `PairedKeyEncryption` sonrası `HekaDrop` extension capabilities exchange'ini
 /// gerçekleştir.
 ///
 /// Akış:
@@ -44,7 +44,7 @@ pub const DEFAULT_CAPABILITIES_TIMEOUT: Duration = Duration::from_millis(2000);
 /// = legacy mode (no extension features). Kullanıcıya hata gösterilmez;
 /// transfer normal Quick Share akışıyla devam edebilir.
 ///
-/// Caller bu helper'ı PairedKeyResult swap'tan sonra, Introduction gönderme/
+/// Caller bu helper'ı `PairedKeyResult` swap'tan sonra, Introduction gönderme/
 /// alma öncesinde çağırmalıdır (state machine entegrasyonu için bkz. modül
 /// dokümantasyonu).
 pub async fn negotiate_capabilities(
@@ -125,7 +125,7 @@ mod tests {
         )
     }
 
-    /// İki HekaDrop peer'ı paralel `negotiate_capabilities` çağırırsa ikisi
+    /// İki `HekaDrop` peer'ı paralel `negotiate_capabilities` çağırırsa ikisi
     /// de `ALL_SUPPORTED` aktif kümeyi döndürmeli (loopback genuine path).
     #[tokio::test]
     async fn loopback_negotiate_all_features_active() {
@@ -204,7 +204,7 @@ mod tests {
         assert_eq!(active.raw(), 0);
     }
 
-    /// Peer geçersiz bytes yollarsa (HekaDrop magic'siz, decrypt fails veya
+    /// Peer geçersiz bytes yollarsa (`HekaDrop` magic'siz, decrypt fails veya
     /// protobuf decode fails) helper legacy'ye düşmeli — exception leak yok.
     #[tokio::test]
     async fn peer_garbage_falls_back_to_legacy() {

--- a/crates/hekadrop-core/src/payload.rs
+++ b/crates/hekadrop-core/src/payload.rs
@@ -25,19 +25,19 @@ use std::path::PathBuf;
 use std::time::{Duration, Instant};
 use tracing::warn;
 
-/// BufWriter iç tampon boyutu. 128 KiB, Quick Share'in 512 KiB chunk'ları için
+/// `BufWriter` iç tampon boyutu. 128 KiB, Quick Share'in 512 KiB chunk'ları için
 /// ~4 chunk'lık tampon sağlar; syscall sayısını düşürürken RAM maliyeti düşük.
-/// Performans raporu 100 Mbps'de tokio::fs async write per-chunk ~5-10 µs
-/// syscall + wakeup overhead rapor etti; sync std::io + BufWriter bunu eler.
+/// Performans raporu 100 Mbps'de `tokio::fs` async write per-chunk ~5-10 µs
+/// syscall + wakeup overhead rapor etti; sync `std::io` + `BufWriter` bunu eler.
 const FILE_WRITE_BUF_CAPACITY: usize = 128 * 1024;
 
 /// Sync bir closure'ı runtime flavor'una göre çalıştırır:
-/// - **MultiThread runtime** (prod, `#[tokio::test(flavor = "multi_thread")]`):
+/// - **`MultiThread` runtime** (prod, `#[tokio::test(flavor = "multi_thread")]`):
 ///   [`tokio::task::block_in_place`] sinyaliyle sar — tokio bu worker'ı
 ///   "blocking" olarak işaretler, park halindeki async task'ları başka
 ///   worker'a taşır. Böylece yavaş disk (iCloud Drive, SMB/NFS mount,
 ///   yavaş USB) syscall'ları network read / UI task'ları geciktirmez.
-/// - **CurrentThread runtime** (default `#[tokio::test]`): `block_in_place`
+/// - **`CurrentThread` runtime** (default `#[tokio::test]`): `block_in_place`
 ///   çağrısı panik atar; closure'ı direkt çağırırız. Tek worker'ı zaten
 ///   tutuyoruz, kaybedecek diğer worker yok.
 /// - **Runtime yok** (senkron çağrı path'i): direkt çağır.
@@ -87,11 +87,11 @@ struct BytesBuf {
 /// Disk I/O **senkron** (`std::fs::File` + `std::io::BufWriter`). Async
 /// (`tokio::fs`) sürümü chunk başına ~5-10 µs tokio task-pool + syscall
 /// overhead getiriyordu; 512 KiB chunk'lar zaten kısa süreli blocking I/O'ya
-/// izin verir ve 128 KiB BufWriter tamponu syscall sayısını azaltır.
+/// izin verir ve 128 KiB `BufWriter` tamponu syscall sayısını azaltır.
 /// Sync I/O çağrıları `ingest_file` içinde [`block_in_place_if_multi`] ile
 /// sarılır — multi-thread runtime'da tokio'ya "blocking" sinyali verilir ki
 /// yavaş disk (iCloud Drive, SMB/NFS, yavaş USB) runtime worker'ını tutmasın;
-/// current_thread runtime'da (unit test) `block_in_place` panik edeceği için
+/// `current_thread` runtime'da (unit test) `block_in_place` panik edeceği için
 /// sync çağrı direkt yapılır.
 struct FileSink {
     writer: BufWriter<File>,
@@ -125,7 +125,7 @@ impl PayloadAssembler {
     /// İlk chunk geldiğinde bu yol kullanılarak dosya `std::fs::File::create` ile açılır.
     ///
     /// SECURITY: Aynı `payload_id` ile iki kez kayıt → önceki hedef **silent
-    /// overwrite** olurdu (HashMap::insert). Saldırgan Introduction'da
+    /// overwrite** olurdu (`HashMap::insert`). Saldırgan Introduction'da
     /// `id=X → legit.pdf` + aynı Introduction'da `id=X → _evil.sh` yollayarak
     /// UI'ın kullanıcıya `legit.pdf`'i göstermesini ama gerçekte `_evil.sh`'in
     /// yazılmasını sağlayabilirdi. İkinci register artık hata döner.

--- a/crates/hekadrop-core/src/secure.rs
+++ b/crates/hekadrop-core/src/secure.rs
@@ -1,11 +1,11 @@
 //! Secure message katmanı — UKEY2 sonrası tüm trafik bu sarmalayıcıdan geçer.
 //!
 //! Akış (outbound):
-//!   plaintext (OfflineFrame veya NearbyFrame bytes)
-//!     → DeviceToDeviceMessage{ seq, message=plaintext }
-//!     → AES-256-CBC-PKCS7(encrypt_key, random_iv, d2d_bytes)
-//!     → HeaderAndBody{ header{iv, schemes, meta}, body=ciphertext }
-//!     → SecureMessage{ header_and_body, signature=HMAC-SHA256(send_hmac, hb) }
+//!   plaintext (`OfflineFrame` veya `NearbyFrame` bytes)
+//!     → `DeviceToDeviceMessage`{ seq, message=plaintext }
+//!     → AES-256-CBC-PKCS7(encrypt_key, `random_iv`, `d2d_bytes`)
+//!     → `HeaderAndBody`{ header{iv, schemes, meta}, body=ciphertext }
+//!     → `SecureMessage`{ `header_and_body`, signature=HMAC-SHA256(send_hmac, hb) }
 //!
 //! Inbound aynı sırayla tersine.
 

--- a/crates/hekadrop-core/src/sender.rs
+++ b/crates/hekadrop-core/src/sender.rs
@@ -2,16 +2,16 @@
 //!
 //! Akış:
 //!   1) TCP connect
-//!   2) ConnectionRequest (plain, bizim endpoint_info)
-//!   3) UKEY2 client handshake → DerivedKeys + PIN
-//!   4) Plain ConnectionResponse değişimi (biz → peer, peer → biz)
-//!   5) SecureCtx kur — artık tüm trafik şifreli
-//!   6) PairedKeyEncryption gönder (biz başlatırız)
-//!   7) Peer'den PairedKeyEncryption al → PairedKeyResult gönder
-//!   8) Peer'den PairedKeyResult al
+//!   2) `ConnectionRequest` (plain, bizim `endpoint_info`)
+//!   3) UKEY2 client handshake → `DerivedKeys` + PIN
+//!   4) Plain `ConnectionResponse` değişimi (biz → peer, peer → biz)
+//!   5) `SecureCtx` kur — artık tüm trafik şifreli
+//!   6) `PairedKeyEncryption` gönder (biz başlatırız)
+//!   7) Peer'den `PairedKeyEncryption` al → `PairedKeyResult` gönder
+//!   8) Peer'den `PairedKeyResult` al
 //!   9) Introduction gönder (dosya metadata'sı ile)
 //!  10) Peer'den Response (Accept/Reject) bekle
-//!  11) Accept ise: dosya chunk'larını PayloadTransfer olarak gönder
+//!  11) Accept ise: dosya chunk'larını `PayloadTransfer` olarak gönder
 //!  12) Disconnection
 
 use crate::config;
@@ -433,10 +433,10 @@ pub async fn send(req: SendRequest, state: Arc<AppState>) -> Result<()> {
 
 /// Tek bir metin parçasını Quick Share üzerinden gönderir.
 ///
-/// Dosya yolundaki akışın birebir aynısı — UKEY2 → PairedKey → Introduction →
-/// Consent → PayloadTransfer. Tek farkı: Introduction'da `text_metadata` olur
-/// (file_metadata yerine), payload chunk'ı `PayloadType::Bytes` tipinde tek
-/// chunk (küçük metin) ya da CHUNK_SIZE sınırıyla parçalanmış çoklu chunk
+/// Dosya yolundaki akışın birebir aynısı — UKEY2 → `PairedKey` → Introduction →
+/// Consent → `PayloadTransfer`. Tek farkı: Introduction'da `text_metadata` olur
+/// (`file_metadata` yerine), payload chunk'ı `PayloadType::Bytes` tipinde tek
+/// chunk (küçük metin) ya da `CHUNK_SIZE` sınırıyla parçalanmış çoklu chunk
 /// halinde yollanır. Android Quick Share alıcısı Bytes payload'ı `TextType`
 /// meta'sıyla eşleyip pano/URL açma akışına sokuyor.
 pub struct SendTextRequest {
@@ -444,7 +444,7 @@ pub struct SendTextRequest {
     pub text: String,
 }
 
-/// TcpStream::connect için üst sınır. Hedef cihaz kapalı/erişilemez iken
+/// `TcpStream::connect` için üst sınır. Hedef cihaz kapalı/erişilemez iken
 /// OS TCP SYN retry'ını ~75 sn bekletmesin diye 10 sn ile keser.
 const CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 
@@ -732,7 +732,7 @@ pub async fn send_text(
 }
 
 /// Metni Bytes payload olarak gönderir. Küçük metin tek chunk + son empty
-/// chunk ile biter; büyük metin CHUNK_SIZE sınırıyla bölünür (Android
+/// chunk ile biter; büyük metin `CHUNK_SIZE` sınırıyla bölünür (Android
 /// tarafı her iki durumu da assembler reassembly ile ele alır).
 #[allow(clippy::too_many_arguments)]
 async fn send_text_bytes(

--- a/crates/hekadrop-core/src/server.rs
+++ b/crates/hekadrop-core/src/server.rs
@@ -16,7 +16,7 @@ const DEFAULT_PORT: u16 = 47893;
 ///
 /// **Neden:** Her bağlantı tokio task + payload buffer + crypto state +
 /// pending destination path'leri tüketir. Limit yoksa saldırgan yüzlerce
-/// TCP bağlantısı açıp kaynakları şişirerek DoS yapabilir (rate limiter
+/// TCP bağlantısı açıp kaynakları şişirerek `DoS` yapabilir (rate limiter
 /// aynı IP için 10/60sn kural koyar ama farklı IP'lerden gelenleri
 /// kaplamayı engellemez). 32 sınırı tipik ev kullanımı için fazlasıyla
 /// yeterli; aşan bağlantılar semaphore'da bekletilmek yerine TCP RST ile

--- a/crates/hekadrop-core/src/settings.rs
+++ b/crates/hekadrop-core/src/settings.rs
@@ -7,7 +7,7 @@
 //!
 //! ## Güven kaydı — v0.6 hardening (Issue #17 / design 017)
 //!
-//! v0.5.x `TrustedDevice { name, id }` ile "ad + endpoint_id" çifti üzerinden
+//! v0.5.x `TrustedDevice { name, id }` ile "ad + `endpoint_id`" çifti üzerinden
 //! güven kararı veriyordu. `endpoint_id` 4 ASCII bayt — her oturumda rastgele
 //! ve kriptografik olarak bağlayıcı değil. v0.6:
 //!
@@ -95,7 +95,7 @@ impl LogLevel {
         }
     }
 
-    /// UI'dan gelen serbest string değeri LogLevel'e çevirir; bilinmeyen
+    /// UI'dan gelen serbest string değeri `LogLevel`'e çevirir; bilinmeyen
     /// değerler `Info` default'una düşer (invalid input'ta sessiz güven).
     pub fn parse_or_default(raw: &str) -> Self {
         match raw.trim().to_ascii_lowercase().as_str() {
@@ -111,7 +111,7 @@ impl LogLevel {
 ///
 /// v0.6'dan itibaren güven kararı **`secret_id_hash`** (cihaz-kalıcı HKDF
 /// türetmesi) üzerinden verilir. `name` UI'da gösterilen insan-okunur ad,
-/// `id` endpoint_id — yalnızca legacy kayıtlar için trust anahtarı, yeni
+/// `id` `endpoint_id` — yalnızca legacy kayıtlar için trust anahtarı, yeni
 /// kayıtlarda yardımcı (ör. UI'da kısa etiket). `trusted_at_epoch` sliding
 /// TTL için kullanılır.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -417,7 +417,7 @@ impl Settings {
 
     /// TTL dolmuş kayıtları listeden siler; dönen sayı silinen kayıt adedi.
     ///
-    /// **v0.6'da startup'ta otomatik çağrılır** (bkz. `main.rs` run_app):
+    /// **v0.6'da startup'ta otomatik çağrılır** (bkz. `main.rs` `run_app)`:
     /// eskiden "soft-expire" idi (listede kalırdı), ancak Issue #17 kapsamında
     /// legacy kayıtların kalıcı yaşaması saldırı yüzeyi yarattı — hash-suppress
     /// saldırısıyla peer hash göndermezse `is_trusted_legacy` yoluyla trust
@@ -490,7 +490,7 @@ impl Settings {
 
     /// Yalnızca isme göre tüm eşleşen kayıtları siler.
     ///
-    /// UI katmanı (main.rs) "trust_remove::NAME" IPC mesajıyla sadece adı
+    /// UI katmanı (main.rs) "`trust_remove::NAME`" IPC mesajıyla sadece adı
     /// iletir; geriye dönük uyum için bu imza korunur. Aynı adın birden çok
     /// id ile kaydı varsa hepsi silinir. ID tabanlı hassas silme için
     /// [`Self::remove_trusted_by_id`] kullanın.
@@ -508,7 +508,7 @@ impl Settings {
             .retain(|d| !(d.name == device_name && d.id == id));
     }
 
-    /// UI için her kaydın "Ad (id_kisa)" formatında görünüm listesini döner.
+    /// UI için her kaydın "Ad (`id_kisa`)" formatında görünüm listesini döner.
     ///
     /// v0.6'da zengin UI (TTL rozeti) kullanılmaya başlandığından ana UI
     /// yolu `push_trusted_to_ui` içindeki yapılandırılmış JSON'u tercih
@@ -674,7 +674,7 @@ static DEBOUNCE_TASK: parking_lot::Mutex<Option<tokio::task::JoinHandle<()>>> =
 /// kalabilir ama adı sabit değil, re-probe doğru davranır).
 ///
 /// Public API: `main.rs::handle_settings_save` doğrudan da çağırabilir
-/// (Settings::save zaten kullanıyor, ikinci doğrulama idempotent).
+/// (`Settings::save` zaten kullanıyor, ikinci doğrulama idempotent).
 pub fn validate_download_dir(path: &Path) -> Result<()> {
     let meta = std::fs::metadata(path).map_err(|e| HekaError::DownloadDirInvalid {
         path: path.display().to_string(),
@@ -730,7 +730,7 @@ impl Drop for TmpCleanup {
 }
 
 /// Cross-platform atomik replace. Unix'te `fs::rename` zaten atomik
-/// (O_RENAME) ve destination mevcutsa üzerine yazar. Windows'ta
+/// (`O_RENAME`) ve destination mevcutsa üzerine yazar. Windows'ta
 /// `std::fs::rename` **destination varsa hata verir** — her `save()` ikinci
 /// çağrıdan itibaren sessizce başarısız olurdu. `MoveFileExW` +
 /// `MOVEFILE_REPLACE_EXISTING` bu durumu çözer; `MOVEFILE_WRITE_THROUGH`
@@ -774,7 +774,7 @@ fn replace_atomic(tmp: &std::path::Path, dst: &std::path::Path) -> std::io::Resu
 /// İki concurrent `save()` çağrısı (ör. connection.rs Stats + sender.rs Stats
 /// aynı anda) diske yazılırken, yazım sırası ters dönebilirdi: geç başlayan
 /// save önce bitip eski snapshot'ı diske bırakabilirdi (kernel scheduler,
-/// disk I/O queue vb.). Settings RwLock'u artık lock dışında save yaptığımız
+/// disk I/O queue vb.). Settings `RwLock`'u artık lock dışında save yaptığımız
 /// için koruma sağlamıyor. Bu mutex her `save()`'i FIFO sırasına sokar.
 /// Settings ve Stats ayrı hot-path ancak tek bir lock yeterli ve kolay.
 static SETTINGS_DISK_LOCK: parking_lot::Mutex<()> = parking_lot::Mutex::new(());
@@ -1461,7 +1461,7 @@ mod tests {
         assert!(s.is_trusted_by_hash(&[0xAA; 6]));
     }
 
-    /// PR #35 review (Copilot HIGH, discussion_r3107564927) regression:
+    /// PR #35 review (Copilot HIGH, `discussion_r3107564927`) regression:
     /// Legacy `(name, id)` kaydı olan cihaz **unknown/mismatched** bir hash
     /// ile bağlandığında trusted sayılMAMALI — dialog ZORUNLU. Aksi halde
     /// legacy spoofing vektörü açıktır: attacker kurbanın (name, id)'sini
@@ -1470,12 +1470,12 @@ mod tests {
     /// legacy kayda bağlar → kalıcı silent bypass. Bu nedenle strict
     /// hash-first semantic seçildi; OR fallback kabul edilmez.
     ///
-    /// Doğru trust karar mantığı (connection.rs handle_sharing_frame):
-    ///   Some(h) => is_trusted_by_hash(h)          // YALNIZ hash
-    ///   None    => is_trusted_legacy(name, id)    // pre-v0.6 peer
+    /// Doğru trust karar mantığı (connection.rs `handle_sharing_frame)`:
+    ///   Some(h) => `is_trusted_by_hash(h)`          // YALNIZ hash
+    ///   None    => `is_trusted_legacy(name`, id)    // pre-v0.6 peer
     ///
     /// Bu test connection.rs'teki `trusted` ifadesini Settings seviyesinde
-    /// simüle eder — tam flow (prompt_accept) için test harness yok.
+    /// simüle eder — tam flow (`prompt_accept`) için test harness yok.
     ///
     /// Legacy kullanıcı migration UX: ilk v0.6 bağlantısında one-time
     /// dialog kullanıcıya gösterilir; Accept sonrası connection.rs'in
@@ -1723,10 +1723,10 @@ mod tests {
     /// tmp dosyayı baştan `O_EXCL | mode(0o600)` ile açmalı ve rename sonucu
     /// final path da group/world-accessible OLMAMALI — umask ne olursa olsun.
     /// Önceki akışta tmp default (0644) ile açılıp rename SONRASI
-    /// set_permissions ile düzeltiliyordu; bu pencerede dosya
+    /// `set_permissions` ile düzeltiliyordu; bu pencerede dosya
     /// world-readable'dı.
     ///
-    /// Assertion fix (PR #35 review, Copilot MED, discussion_r3107564937):
+    /// Assertion fix (PR #35 review, Copilot MED, `discussion_r3107564937)`:
     /// Önceki test `mode == 0o600` exact eşitliğini kontrol ediyordu.
     /// `OpenOptionsExt::mode(0o600)` umask ile AND'lenir — yalnız daha
     /// **restrictive** hale gelebilir. Hardened ortamlarda (umask 0o077

--- a/crates/hekadrop-core/src/settings.rs
+++ b/crates/hekadrop-core/src/settings.rs
@@ -417,7 +417,7 @@ impl Settings {
 
     /// TTL dolmuş kayıtları listeden siler; dönen sayı silinen kayıt adedi.
     ///
-    /// **v0.6'da startup'ta otomatik çağrılır** (bkz. `main.rs` `run_app)`:
+    /// **v0.6'da startup'ta otomatik çağrılır** (bkz. `main.rs` `run_app`):
     /// eskiden "soft-expire" idi (listede kalırdı), ancak Issue #17 kapsamında
     /// legacy kayıtların kalıcı yaşaması saldırı yüzeyi yarattı — hash-suppress
     /// saldırısıyla peer hash göndermezse `is_trusted_legacy` yoluyla trust
@@ -1470,9 +1470,9 @@ mod tests {
     /// legacy kayda bağlar → kalıcı silent bypass. Bu nedenle strict
     /// hash-first semantic seçildi; OR fallback kabul edilmez.
     ///
-    /// Doğru trust karar mantığı (connection.rs `handle_sharing_frame)`:
+    /// Doğru trust karar mantığı (`connection.rs` `handle_sharing_frame`):
     ///   Some(h) => `is_trusted_by_hash(h)`          // YALNIZ hash
-    ///   None    => `is_trusted_legacy(name`, id)    // pre-v0.6 peer
+    ///   None    => `is_trusted_legacy(name, id)`    // pre-v0.6 peer
     ///
     /// Bu test connection.rs'teki `trusted` ifadesini Settings seviyesinde
     /// simüle eder — tam flow (`prompt_accept`) için test harness yok.
@@ -1726,7 +1726,7 @@ mod tests {
     /// `set_permissions` ile düzeltiliyordu; bu pencerede dosya
     /// world-readable'dı.
     ///
-    /// Assertion fix (PR #35 review, Copilot MED, `discussion_r3107564937)`:
+    /// Assertion fix (PR #35 review, Copilot MED, `discussion_r3107564937`):
     /// Önceki test `mode == 0o600` exact eşitliğini kontrol ediyordu.
     /// `OpenOptionsExt::mode(0o600)` umask ile AND'lenir — yalnız daha
     /// **restrictive** hale gelebilir. Hardened ortamlarda (umask 0o077

--- a/crates/hekadrop-core/src/state.rs
+++ b/crates/hekadrop-core/src/state.rs
@@ -6,9 +6,9 @@
 //! katmanda — `crates/hekadrop-app/src/state.rs` — yer alır.
 //!
 //! Public surface:
-//! - `AppState` (RwLock'lu state container)
+//! - `AppState` (`RwLock`'lu state container)
 //! - `ProgressState`, `HistoryItem` (POD enum/struct)
-//! - `RateLimiter` (sliding-window IP-bazlı limiter, AppState alanı)
+//! - `RateLimiter` (sliding-window IP-bazlı limiter, `AppState` alanı)
 //! - `TransferGuard` (RAII; `Arc<AppState>` tutar, Drop'ta unregister)
 //! - `DEFAULT_COMPLETED_IDLE_DELAY` (Completed → Idle gecikme sabiti)
 
@@ -100,11 +100,11 @@ pub struct AppState {
     pub rate_limiter: RateLimiter,
     /// Kalıcı kullanım istatistikleri.
     pub stats: RwLock<Stats>,
-    /// Settings persistence yolu — app crate'inde resolve edilir, AppState
+    /// Settings persistence yolu — app crate'inde resolve edilir, `AppState`
     /// burada cache'ler. Connection trusted-list update'leri bu yolu
     /// doğrudan kullanır (paths app-only).
     pub config_path: PathBuf,
-    /// Stats persistence yolu — app crate'inde resolve edilir, AppState
+    /// Stats persistence yolu — app crate'inde resolve edilir, `AppState`
     /// burada cache'ler. Sender ve connection RX path bu yolu doğrudan
     /// kullanır (paths app-only).
     pub stats_path: PathBuf,
@@ -377,7 +377,7 @@ impl AppState {
     /// araya giremez. Bu fonksiyon Tokio runtime context'i içinde
     /// çağrılmalıdır.
     ///
-    /// `Weak` referans saklanır — sleep sırasında AppState drop edilirse
+    /// `Weak` referans saklanır — sleep sırasında `AppState` drop edilirse
     /// (test teardown / process shutdown) reset task no-op'lar.
     ///
     /// `Handle::try_current()` ile mevcut Tokio runtime detect edilir; runtime
@@ -484,7 +484,7 @@ impl RateLimiter {
 
     /// Bu IP için kaydedilmiş son timestamp'i siler. Trusted hash
     /// doğrulandıktan sonra geriye-dönük muafiyet uygulamak için kullanılır
-    /// (gate'de hash yoktu, PairedKey sonrası kanıt geldi → sayacı düzelt).
+    /// (gate'de hash yoktu, `PairedKey` sonrası kanıt geldi → sayacı düzelt).
     /// Issue #17.
     pub fn forget_most_recent(&self, ip: IpAddr) {
         let mut windows = self.windows.write();

--- a/crates/hekadrop-core/src/stats.rs
+++ b/crates/hekadrop-core/src/stats.rs
@@ -3,7 +3,7 @@
 //!   - Linux: `~/.config/HekaDrop/stats.json`
 //!
 //! Her başarılı aktarım sonrası güncellenir. UI'da "Tanı" sekmesinde gösterilir.
-//! SystemTime yerine UNIX epoch saniye olarak saklanır (serde'de kolay, taşınabilir).
+//! `SystemTime` yerine UNIX epoch saniye olarak saklanır (serde'de kolay, taşınabilir).
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};

--- a/crates/hekadrop-core/src/ui_port.rs
+++ b/crates/hekadrop-core/src/ui_port.rs
@@ -1,8 +1,8 @@
 //! UI port — connection/sender/server modüllerinin UI'a yönlenmesi
-//! için abstract interface. Implementation app crate'inde (UiAdapter).
+//! için abstract interface. Implementation app crate'inde (`UiAdapter`).
 //!
 //! RFC-0001 §5 Adım 5b — RFC §9 R1 önerisi: connection handler'ın UI
-//! modülüne doğrudan bağımlılığı kırılır; UiPort trait üzerinden
+//! modülüne doğrudan bağımlılığı kırılır; `UiPort` trait üzerinden
 //! caller (app) UI yönlendirmesini sağlar. Bu sayede core'a taşınınca
 //! UI (tao/wry/notify-rust) sızmaz.
 //!

--- a/crates/hekadrop-core/src/ukey2.rs
+++ b/crates/hekadrop-core/src/ukey2.rs
@@ -1,10 +1,10 @@
 //! UKEY2 handshake — Quick Share'in P-256 + HKDF tabanlı anahtar değişim protokolü.
 //!
 //! Akış (receiver/server rolü):
-//!   1) İstemci → ConnectionRequest (offline_wire_formats)
-//!   2) İstemci → Ukey2ClientInit  (bu modül ele alır)
-//!   3) Biz    → Ukey2ServerInit   (P-256 public key ile)
-//!   4) İstemci → Ukey2ClientFinished (cipher commitment ile doğrulanır)
+//!   1) İstemci → `ConnectionRequest` (`offline_wire_formats`)
+//!   2) İstemci → `Ukey2ClientInit`  (bu modül ele alır)
+//!   3) Biz    → `Ukey2ServerInit`   (P-256 public key ile)
+//!   4) İstemci → `Ukey2ClientFinished` (cipher commitment ile doğrulanır)
 //!   5) ECDH → HKDF ile 4 anahtar + 4-haneli PIN
 
 use crate::crypto;
@@ -38,10 +38,10 @@ pub struct DerivedKeys {
 }
 
 /// Gönderici (client) rolünde tam UKEY2 handshake.
-/// Socket üzerinde: biz ClientInit → peer ServerInit → biz ClientFinished → ECDH + HKDF.
+/// Socket üzerinde: biz `ClientInit` → peer `ServerInit` → biz `ClientFinished` → ECDH + HKDF.
 ///
-/// Döndürülen DerivedKeys **client perspektifinde** doldurulur:
-///   encrypt/send_hmac = client_* (bizden peer'a), decrypt/recv_hmac = server_* (peer'den bize)
+/// Döndürülen `DerivedKeys` **client perspektifinde** doldurulur:
+///   `encrypt/send_hmac` = client_* (bizden peer'a), `decrypt/recv_hmac` = server_* (peer'den bize)
 pub async fn client_handshake(socket: &mut TcpStream) -> Result<DerivedKeys> {
     use sha2::{Digest, Sha512};
 
@@ -195,7 +195,7 @@ fn normalize_32(v: &[u8]) -> Vec<u8> {
 }
 
 /// Java `BigInteger.toByteArray()` ile uyumlu: MSB ≥ 0x80 ise başına 0x00 ekler.
-/// Aksi halde peer Java tarafında değeri negatif yorumlar ve ServerInit'i reddeder.
+/// Aksi halde peer Java tarafında değeri negatif yorumlar ve `ServerInit`'i reddeder.
 fn to_signed_bytes(v: &[u8]) -> Vec<u8> {
     if !v.is_empty() && v[0] >= 0x80 {
         let mut out = Vec::with_capacity(v.len() + 1);
@@ -212,12 +212,12 @@ fn to_signed_bytes(v: &[u8]) -> Vec<u8> {
 /// Saldırgan bir peer, daha zayıf ya da tanımsız bir cipher (örneğin
 /// `CurveCurve25519_Sha512`, `Unknown`, ya da dağıtımdan önce kaldırılmış
 /// algoritmalar) dönerek handshake'i bilinen-zayıf bir alana yönlendirmeye
-/// çalışabilir. ClientInit sadece `P256_SHA512` öneriyor — ServerInit farklı
+/// çalışabilir. `ClientInit` sadece `P256_SHA512` öneriyor — `ServerInit` farklı
 /// değer dönerse hatasız kabul etmek regression olurdu.
 ///
 /// `client_handshake` çağrısında inline olarak yapılıyordu; testlenebilir
 /// olması için saf fonksiyona ayrıldı (mutation survivor #10 — research-v2
-/// raporundaki "ServerInit cipher downgrade" kontrolü artık unit test ile
+/// raporundaki "`ServerInit` cipher downgrade" kontrolü artık unit test ile
 /// kapatılıyor).
 pub fn validate_server_init(s: &Ukey2ServerInit) -> Result<()> {
     if s.handshake_cipher != Some(Ukey2HandshakeCipher::P256Sha512 as i32) {

--- a/crates/hekadrop-net/src/discovery.rs
+++ b/crates/hekadrop-net/src/discovery.rs
@@ -115,12 +115,12 @@ fn parse(info: &ResolvedService) -> Option<DiscoveredDevice> {
     })
 }
 
-/// RFC-0003 §3.3 peer-detection — TXT record'undaki `ext` alanından HekaDrop
+/// RFC-0003 §3.3 peer-detection — TXT record'undaki `ext` alanından `HekaDrop`
 /// extension destek flag'ini parse et.
 ///
 /// Eski Quick Share peer'larında (Pixel/Samsung/NearDrop/rquickshare) `ext`
 /// alanı yoktur → `None` → `false` (legacy mode).
-/// HekaDrop peer'ları `ext=1` yollar → `Some("1")` → `true`.
+/// `HekaDrop` peer'ları `ext=1` yollar → `Some("1")` → `true`.
 /// Beklenmeyen değerler (`"0"`, `"true"`, vb.) → `false` (defensive — yalnız
 /// "1" tam pozitif sinyal sayılır).
 #[must_use]
@@ -138,7 +138,7 @@ mod tests {
         assert!(!parse_extension_flag(None));
     }
 
-    /// HekaDrop peer — `ext=1` spec değeri.
+    /// `HekaDrop` peer — `ext=1` spec değeri.
     #[test]
     fn ext_one_signals_extension_support() {
         assert!(parse_extension_flag(Some("1")));

--- a/crates/hekadrop-net/src/lib.rs
+++ b/crates/hekadrop-net/src/lib.rs
@@ -1,4 +1,4 @@
-//! HekaDrop network adapter — mDNS discovery + peer browse.
+//! `HekaDrop` network adapter — mDNS discovery + peer browse.
 //!
 //! Bu crate, Quick Share'in keşif katmanı için tek noktadır. Domain tipleri
 //! (`DiscoveredDevice` vb.) `hekadrop-core::discovery_types` içindedir; bu

--- a/crates/hekadrop-proto/src/lib.rs
+++ b/crates/hekadrop-proto/src/lib.rs
@@ -1,4 +1,4 @@
-//! HekaDrop'un Quick Share / Nearby Connections protobuf bindings'i.
+//! `HekaDrop`'un Quick Share / Nearby Connections protobuf bindings'i.
 //!
 //! Tüm `pub mod` blokları `build.rs` üzerinden `prost-build` tarafından
 //! `OUT_DIR`'a üretilen modülleri include eder. Bu crate runtime mantığı
@@ -29,6 +29,7 @@
 
 #[allow(
     clippy::all,
+    clippy::doc_markdown,
     non_snake_case,
     non_camel_case_types,
     dead_code,
@@ -42,6 +43,7 @@ pub mod securegcm {
 
 #[allow(
     clippy::all,
+    clippy::doc_markdown,
     non_snake_case,
     non_camel_case_types,
     dead_code,
@@ -55,6 +57,7 @@ pub mod securemessage {
 
 #[allow(
     clippy::all,
+    clippy::doc_markdown,
     non_snake_case,
     non_camel_case_types,
     dead_code,
@@ -80,6 +83,7 @@ pub mod location {
 
 #[allow(
     clippy::all,
+    clippy::doc_markdown,
     non_snake_case,
     non_camel_case_types,
     dead_code,
@@ -99,12 +103,13 @@ pub mod sharing {
 /// raw prefix — ardından `HekaDropFrame` protobuf encoding'i. Magic
 /// dispatcher seviyesinde strip edilir (`hekadrop-core::frame`).
 ///
-/// Slot tahsisi: capabilities=10, chunk_tag=11, resume_hint=12,
-/// resume_reject=13, folder_mft=14. 1..9 ve 15..63 reserved.
+/// Slot tahsisi: capabilities=10, `chunk_tag=11`, `resume_hint=12`,
+/// `resume_reject=13`, `folder_mft=14`. 1..9 ve 15..63 reserved.
 ///
 /// Wire-byte-exact spec: `docs/protocol/capabilities.md`.
 #[allow(
     clippy::all,
+    clippy::doc_markdown,
     non_snake_case,
     non_camel_case_types,
     dead_code,


### PR DESCRIPTION
## Özet

PR #87 deferred listesinin **en büyük kalemi** (648 hit). Auto-fix 242 site, kalan 406 site **tüm** generated proto code — bu zaten module-level \`#[allow]\` pattern'inde (PR #86); listeye \`clippy::doc_markdown\` eklendi.

## Değişim

* \`cargo clippy --fix --workspace --all-targets --all-features -- -W clippy::doc_markdown\` → 242 site otomatik. Tipik dönüşüm: \`tag\` / \`path\` / \`HashMap\` / \`PathBuf\` gibi identifier'lara backtick eklendi.
* \`crates/hekadrop-proto/src/lib.rs\` — 5 module-level \`#[allow]\` bloğuna \`clippy::doc_markdown\` eklendi. Proto comment'ları upstream Google protobuf doc'larından geliyor; biz yazmadığımız için stylistic lint uygulanamaz.
* Root \`Cargo.toml\`:
  \`\`\`toml
  doc_markdown = "warn"
  \`\`\`

## CLAUDE.md pre-commit invariant scan

| Kontrol | Sonuç |
|---|---|
| \`cargo clippy -D warnings\` | ✓ |
| \`cargo test --workspace\` | ✓ 27 test suite (davranış parity, sadece doc string'leri) |
| \`cargo fmt --check\` | ✓ |
| I-1 (boundary) | değişmedi ✓ |
| I-2 (allow disiplini) | proto module-level — generated kod istisnası belgelenmiş ✓ |

48 dosya, +217/-212 net küçülme yok (tipik backtick eklemeleri).

## Test plan

- [x] Lokal CI dry-run yeşil
- [ ] CI matrix (mac/Linux/Windows + extra-lints + cargo-deny + coverage)

## PR #87 deferred listesi durumu (6/10 enforce)

| Lint | Hit | Durum |
|---|---|---|
| \`cast_possible_wrap\` | 36 | ✓ #101 |
| \`uninlined_format_args\` | 110 | ✓ #107 |
| \`unreachable_pub\` | 58 | ✓ #107 |
| \`match_same_arms\` | 16 | ✓ #108 |
| \`doc_markdown\` | 648 | ✓ **bu PR** |
| \`clippy::pedantic\` umbrella | ~1,228 | sırada — modular |
| \`must_use_candidate\` | 208 | sırada — annotation pass |
| \`items_after_statements\`, vb. | <100 each | sonra |

🤖 Generated with [Claude Code](https://claude.com/claude-code)