### PR TITLE
docs(audit): PR #102 review yorumları — markdown + spec uyumu

### DIFF
--- a/docs/protocol/capabilities.md
+++ b/docs/protocol/capabilities.md
@@ -41,7 +41,7 @@ each `SecureCtx`-encrypted frame is structured as:
 ```
 +---------------------+----------------------------------------+
 |   magic (4 bytes)   |        HekaDropFrame protobuf          |
-|   0xA5 0xDE 0xB2 01 |   (varint-delimited proto3 fields)     |
+|   0xA5 0xDE 0xB2 0x01 |   (varint-delimited proto3 fields)   |
 +---------------------+----------------------------------------+
         ▲                              ▲
         │                              │
@@ -344,7 +344,9 @@ A5 DE B2 01 08 01 52 04 08 01 10 07
 
 Same 12 bytes; only the last byte differs (`0x00` → `0x07`).
 
-The full KAT corpus lives at `docs/protocol/captures/capabilities-kat-*.txt`.
+The full KAT corpus is planned for the implementation phase at
+`docs/protocol/captures/capabilities-kat-*.txt`; that directory is not yet
+present in this repo.
 
 ---
 

--- a/docs/protocol/chunk-hmac.md
+++ b/docs/protocol/chunk-hmac.md
@@ -301,9 +301,11 @@ in [`docs/protocol/capabilities.md`](capabilities.md). Summary:
 
 ## 7. Test vectors (KAT)
 
-The implementation MUST pass these known-answer tests. Vectors are derived
-from a reference Python port of the algorithm (independent of the Rust
-implementation, to catch regressions where "wrong is wrong consistently").
+These known-answer tests are **provisional** until the vectors are finalized
+and committed with concrete expected outputs. Once finalized, implementations
+MUST pass them. The vectors are derived from a reference Python port of the
+algorithm (independent of the Rust implementation, to catch regressions where
+"wrong is wrong consistently").
 
 ### KAT-1 — Empty body, all-zero key
 
@@ -323,11 +325,13 @@ hmac_input      = 00 00 00 00 00 00 00 00     (payload_id BE i64)
 
 tag             = HMAC-SHA256(0x00*32, hmac_input)
                 = b613679a 0814d9ec 772f95d7 78c35fc5
-                  ff1697c4 93715653 c6c712 14429192
+                  ff1697c4 93715653 c6c71200 14429192
                   ↑ Note: this exact value pending verification with the
                     reference impl during v0.8 implementation phase. Treat
-                    as placeholder until KAT-1 is signed off in
-                    docs/protocol/captures/chunk-hmac-kat-1.txt.
+                    as placeholder (uzunluk: 32 byte = 64 hex char) until
+                    KAT-1 is signed off in
+                    docs/protocol/captures/chunk-hmac-kat-1.txt (planned
+                    for the implementation phase; not yet committed).
 ```
 
 ### KAT-2 — Single chunk full body, deterministic key
@@ -351,8 +355,10 @@ tag             = (computed; written to docs/protocol/captures/chunk-hmac-kat-2.
                    during implementation; binds the spec to the wire format)
 ```
 
-The full KAT corpus lives at `docs/protocol/captures/chunk-hmac-kat-*.txt`
-and is shared with `fuzz_chunk_hmac_verify` as a golden seed.
+During implementation, the full KAT corpus will be added at
+`docs/protocol/captures/chunk-hmac-kat-*.txt`; once added, it will be shared
+with `fuzz_chunk_hmac_verify` as a golden seed. The directory does not yet
+exist in the repo.
 
 ---
 
@@ -385,7 +391,7 @@ concurrently with the next chunk's read.
 | Tag verify fails (constant-time `ct_eq` returns false) | Abort, remove `.part`/`.meta`, send Disconnection, log `IntegrityFailure` (no body, no tag) | Reconnect with `offset = 0`; user notified of "transfer corrupted" | None — partial state untrusted |
 | Out-of-order: chunk N+1 body before chunk N tag | Abort, treat as protocol violation | Sender bug — should not happen | None |
 | Receiver expects tag (capability set) but sender omits | Abort after a 5 second post-body grace period | Sender bug or downgrade attack | None |
-| Sender sends tag but receiver lacks capability | Receiver receives an unexpected `HekaDropFrame` and ignores it (frame routing layer); transfer continues without chunk-HMAC verify | Sender bug — should not have negotiated `CHUNK_HMAC_V1` | N/A |
+| Sender sends tag but receiver lacks capability | Abort, treat as protocol violation, remove `.part`/`.meta`, send Disconnection; receiver MUST NOT silently ignore the unexpected `HekaDropFrame` (consistent with §6 capability-mismatch handling) | Sender bug — should not have negotiated `CHUNK_HMAC_V1` | None |
 
 ---
 

--- a/docs/rfcs/0003-chunk-hmac.md
+++ b/docs/rfcs/0003-chunk-hmac.md
@@ -170,10 +170,19 @@ Negotiated `active_caps = my_caps & peer_caps`. Bit-AND seçimi: bir taraf bir �
 
 ```
 IKM  = next_secret          # mevcut UKEY2 türevi, src/crypto.rs Level-2 (§6.3 threat-model)
-salt = sha256("hekadrop:chunk-hmac:v1")
+salt = empty                # zero-length salt; domain separation `info` etiketinden geliyor
 info = b"hekadrop chunk-hmac v1"
-chunk_hmac_key = HKDF-Expand(HKDF-Extract(salt, IKM), info, 32)
+chunk_hmac_key = HKDF-SHA256(IKM, salt, info, 32)
 ```
+
+> **Salt seçimi notu (PR #102 Copilot review reconciliation):** Önceki taslak
+> `salt = sha256("hekadrop:chunk-hmac:v1")` öneriyordu, ancak wire-byte
+> spec (`docs/protocol/chunk-hmac.md` §4) ve referans implementasyon
+> (`hekadrop-core::chunk_hmac::derive_chunk_hmac_key`) **empty salt + `info`
+> etiketi** ile domain separation sağlıyor. RFC ve spec birlikte tek
+> derivasyona kilitli; KAT'lar bu derivasyon ile üretilir. v1.x cycle'ında
+> derivasyon değişirse `chunk_hmac_v2` capability bit'i ile yeni RFC
+> revizyonu açılır.
 
 Her iki yön için **aynı** `chunk_hmac_key` kullanılır (dosya transferi tek yönlüdür; ama simetri korunur). `next_secret` halihazırda `DerivedKeys` içinde yaşıyor (bkz. threat-model §6.3 Level-1); yeni bir UKEY2 round-trip gerekmez.
 


### PR DESCRIPTION
## Summary

PR #102'de Gemini ve Copilot tarafından flag'lenen 6 doc yorumunu kapatır. Hepsi docs-only, düşük riskli.

| Yorum | Konu | Aksiyon |
|---|---|---|
| `capabilities.md:44` | Magic prefix tablosu son baytta `0x` öneki eksik | `0xA5 0xDE 0xB2 0x01` |
| `chunk-hmac.md:326` | KAT-1 placeholder hex 31 byte (32 olmalı) | `c6c71200` ile pad'le, pending-verification not korundu |
| `chunk-hmac.md:172` + `rfcs/0003-chunk-hmac.md:173` | HKDF salt: spec empty, RFC `sha256(...)` çelişiyor | RFC empty salt'a hizalandı; reference impl ile tek kilit |
| `chunk-hmac.md:388` | Failure-mode "receiver ignores" §6 ile contradicted | Abort + Disconnection + protocol violation |
| `chunk-hmac.md:306` | KAT bölümü "MUST pass" + placeholder = contradiction | "Provisional, MUST once finalized" |
| `chunk-hmac.md:358` + `capabilities.md:347` | `docs/protocol/captures/` mevcut değil | Planning wording'ine çevrildi |

## Why

KAT placeholder uzunluğu hatası implementasyon aşamasında kafa karışıklığı yaratabilirdi; HKDF salt çatışması ise iki uyumsuz implementasyonun ship edilmesine yol açabilirdi (Copilot doğru tespit etti).

## Test plan

- [x] `git diff --stat` — sadece `docs/` altı dosyalar
- [x] Manuel review: tüm değişiklikler markdown veya spec content; kod davranışı değişmedi

🤖 Generated with [Claude Code](https://claude.com/claude-code)