### PR TITLE
fix(post-merge): PR #115/#116/#117 review yorumları (3 medium)

### DIFF
--- a/crates/hekadrop-core/src/chunk_hmac.rs
+++ b/crates/hekadrop-core/src/chunk_hmac.rs
@@ -73,7 +73,12 @@ fn build_hmac_input(
 ) -> Result<Vec<u8>, ChunkBuildError> {
     let body_len_u32 = checked_body_len_u32(body.len())?;
 
-    let mut input = Vec::with_capacity(HMAC_INPUT_PREFIX_LEN + body.len());
+    // CLAUDE.md I-5: 32-bit hedeflerde `body.len() + HMAC_INPUT_PREFIX_LEN`
+    // usize taşmasına yol açabilir (u32::MAX + 28 → debug panic). Capacity
+    // hint için saturating_add yeter — gerçek allocation `extend_from_slice`
+    // tarafından yönetilir; capacity overshoot olsa bile sadece reallocate
+    // gerekir, doğruluğu etkilemez. (PR #116 Gemini medium yorumu.)
+    let mut input = Vec::with_capacity(body.len().saturating_add(HMAC_INPUT_PREFIX_LEN));
     input.extend_from_slice(&payload_id.to_be_bytes());
     input.extend_from_slice(&chunk_index.to_be_bytes());
     input.extend_from_slice(&offset.to_be_bytes());

--- a/crates/hekadrop-core/src/negotiation.rs
+++ b/crates/hekadrop-core/src/negotiation.rs
@@ -322,7 +322,9 @@ mod tests {
             // payload yolla (legacy OfflineFrame'i simüle ediyor — pratikte
             // protobuf encode'una gerek yok; magic mismatch dispatch'te
             // FrameKind::Offline döndürecek, plain bytes leftover'a düşecek).
-            let plain_legacy = b"NOT_A_HEKADROP_FRAME_SENTINEL".to_vec();
+            // PR #115 Gemini medium: `Bytes::from_static` heap allocation
+            // önler + dönüş tipi Bytes olarak kalır (assert_eq! tip uyumu).
+            let plain_legacy = Bytes::from_static(b"NOT_A_HEKADROP_FRAME_SENTINEL");
             let enc = server_ctx.encrypt(&plain_legacy).unwrap();
             let _ = frame::write_frame(&mut server_socket, &enc).await;
             tokio::time::sleep(Duration::from_millis(100)).await;

--- a/docs/rfcs/0003-chunk-hmac.md
+++ b/docs/rfcs/0003-chunk-hmac.md
@@ -170,7 +170,7 @@ Negotiated `active_caps = my_caps & peer_caps`. Bit-AND seçimi: bir taraf bir �
 
 ```
 IKM  = next_secret          # mevcut UKEY2 türevi, src/crypto.rs Level-2 (§6.3 threat-model)
-salt = empty                # zero-length salt; domain separation `info` etiketinden geliyor
+salt = []                   # zero-length byte sequence; domain separation `info` etiketinden geliyor
 info = b"hekadrop chunk-hmac v1"
 chunk_hmac_key = HKDF-SHA256(IKM, salt, info, 32)
 ```


### PR DESCRIPTION
## Summary

PR #115/#116/#117 merge sonrası Gemini code-assist 3 medium yorum eklemişti:

| PR | Konu | Aksiyon |
|---|---|---|
| #116 | `chunk_hmac.rs:76` 32-bit overflow riski | `body.len().saturating_add(HMAC_INPUT_PREFIX_LEN)` |
| #115 | `negotiation.rs:325` test heap alloc | `Bytes::from_static(...)` |
| #117 | `rfcs/0003-chunk-hmac.md:173` salt notation | `salt = []` |

## Why

- **chunk_hmac**: `checked_body_len_u32` `body.len() <= u32::MAX` garantiler, ama 32-bit hedeflerde (`target_pointer_width = "32"`) `body.len() + 28` debug modunda panic'leyebilir. `saturating_add` capacity hint olarak yeterli — doğruluğu etkilemez (CLAUDE.md I-5).
- **negotiation**: Statik literal'i `to_vec()` ile heap'e taşımak gereksiz; `Bytes::from_static` zero-copy.
- **RFC**: `salt = empty` ifadesi ambiguous; crypto spec convention `salt = []`.

## Test plan

- [x] `cargo test -p hekadrop-core` — 219/219 yeşil
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — temiz
- [x] CLAUDE.md invariant scan — temiz

🤖 Generated with [Claude Code](https://claude.com/claude-code)