### PR TITLE
fix(mdns): RFC 6763 §6.1 TXT record 255-byte limit garantisi (PR #111 medium)

### DIFF
--- a/crates/hekadrop-app/tests/mdns_discovery.rs
+++ b/crates/hekadrop-app/tests/mdns_discovery.rs
@@ -57,16 +57,26 @@ fn instance_name(endpoint_id: &[u8; 4]) -> String {
 ///   [0]      bitmap (cihaz tipi << 1)
 ///   [1..17]  16 bayt rastgele
 ///   [17]     ad uzunluğu (u8)
-///   [18..]   UTF-8 cihaz adı
+///   [18..]   UTF-8 cihaz adı (RFC 6763 §6.1: `n=<base64>` ≤ 255 bayt
+///            zorunluluğu nedeniyle ad ≤ 171 bayt)
 fn endpoint_info(device_name: &str, random: &[u8; 16]) -> Vec<u8> {
+    // src/config.rs MAX_DEVICE_NAME_BYTES değeriyle birebir tutmalı.
+    const MAX_DEVICE_NAME_BYTES: usize = 171;
+
     let mut out = Vec::with_capacity(18 + device_name.len());
     out.push(DEVICE_TYPE_COMPUTER << 1);
     out.extend_from_slice(random);
 
-    let mut name_bytes = device_name.as_bytes();
-    if name_bytes.len() > 255 {
-        name_bytes = &name_bytes[..255];
-    }
+    let bytes = device_name.as_bytes();
+    let name_bytes = if bytes.len() <= MAX_DEVICE_NAME_BYTES {
+        bytes
+    } else {
+        let mut end = MAX_DEVICE_NAME_BYTES;
+        while end > 0 && !device_name.is_char_boundary(end) {
+            end -= 1;
+        }
+        &bytes[..end]
+    };
     out.push(name_bytes.len() as u8);
     out.extend_from_slice(name_bytes);
     out
@@ -144,15 +154,25 @@ fn endpoint_info_utf8_turkce_karakter() {
     assert_eq!(name, "Ömer");
 }
 
+/// RFC 6763 §6.1 — `n=<base64>` toplam ≤ 255 bayt; bu nedenle ham ad
+/// alanı 171 bayt'ta clamp'lenir. Eski davranış (255 bayt'a clamp) Quick
+/// Share / Android tarafında TXT entry'nin drop edilmesine yol açıyordu.
 #[test]
-fn endpoint_info_255_bayt_ustunde_truncate() {
+fn endpoint_info_171_bayt_ustunde_truncate_rfc6763() {
     let random = [0u8; 16];
     // 300 karakter ASCII
     let long = "A".repeat(300);
     let info = endpoint_info(&long, &random);
-    // `u8` max 255 → kayda giren ad 255 bayt olmalı
-    assert_eq!(info[17], 255);
-    assert_eq!(info.len(), 18 + 255);
+    assert_eq!(info[17], 171, "ad uzunluğu 171 bayt'a clamp edilmeli");
+    assert_eq!(info.len(), 18 + 171);
+
+    // Bu raw payload'un base64'ü `n=` ile birlikte 255 bayt sınırını aşmamalı.
+    let b64 = URL_SAFE_NO_PAD.encode(&info);
+    let txt_entry_len = "n=".len() + b64.len();
+    assert!(
+        txt_entry_len <= 255,
+        "n=<base64> = {txt_entry_len} bayt > 255 (RFC 6763 §6.1 ihlali)",
+    );
 }
 
 #[test]

--- a/crates/hekadrop-core/src/config.rs
+++ b/crates/hekadrop-core/src/config.rs
@@ -37,14 +37,59 @@ pub fn instance_name(endpoint_id: [u8; 4]) -> String {
 
 pub const DEVICE_TYPE_COMPUTER: u8 = 3;
 
+/// RFC 6763 §6.1 — bir TXT record içindeki her `<key>=<value>` string'i
+/// UTF-8 olarak en fazla 255 bayt olabilir. mDNS yayınımız `n=<base64>`
+/// formatında olduğundan key (`n=` = 2 bayt) + base64 değer ≤ 255 olmalı.
+const MAX_TXT_STRING_LEN: usize = 255;
+const N_KEY_PREFIX_LEN: usize = 2; // "n="
+
+/// `endpoint_info` ham byte yerleşimi sabit prefix'i: bitmap(1) + random(16) +
+/// `name_len`(1) = 18 bayt; bunu takiben ad bayt'ları gelir.
+const ENDPOINT_INFO_HEADER_LEN: usize = 18;
+
+/// URL-safe base64 (paddingsiz) `n` bayt → `ceil(n * 4 / 3)` karakter üretir.
+/// `n=` + base64 ≤ 255 sınırından geriye yürüterek izin verilen ham
+/// `endpoint_info` boyutunu hesapla:
+///
+/// ```text
+/// base64_len_max = 255 - 2 = 253
+/// raw_max        = floor(base64_len_max * 3 / 4) = 189
+/// name_max       = raw_max - 18 = 171
+/// ```
+///
+/// Bu değer hem RFC 6763 §6.1 limit'ini hem de wire `name_len` u8 sınırını
+/// (≤ 255) aynı anda sağlar — daha sıkı olan bu limittir.
+const MAX_DEVICE_NAME_BYTES: usize = {
+    let base64_max = MAX_TXT_STRING_LEN - N_KEY_PREFIX_LEN;
+    let raw_max = (base64_max * 3) / 4;
+    raw_max - ENDPOINT_INFO_HEADER_LEN
+};
+
+/// Ad bayt'larını verilen `max` limitine clamp et — UTF-8 karakter
+/// sınırlarını koru (ortadan kırpıp invalid UTF-8 üretme).
+fn clamp_to_utf8_boundary(name: &str, max: usize) -> &[u8] {
+    if name.len() <= max {
+        return name.as_bytes();
+    }
+    // `floor_char_boundary` stable değil (Rust 1.90); manuel olarak `max`'ten
+    // geriye doğru en yakın char boundary'yi bul.
+    let mut end = max;
+    while end > 0 && !name.is_char_boundary(end) {
+        end -= 1;
+    }
+    &name.as_bytes()[..end]
+}
+
 /// `EndpointInfo` yapısı — TXT record `n=` değerinin base64'ten öncesi.
 /// Yerleşim:
 ///   `[0]`      bitmap: (sürüm<<5)|(görünürlük<<4)|(`cihaz_tipi`<<1)|rez
 ///   `[1..17]`  16 bayt rastgele
 ///   `[17]`     ad uzunluğu (u8)
-///   `[18..]`   UTF-8 cihaz adı
+///   `[18..]`   UTF-8 cihaz adı (max [`MAX_DEVICE_NAME_BYTES`] bayt — bkz.
+///              RFC 6763 §6.1 TXT record limit derivasyonu)
 pub fn endpoint_info(device_name: &str) -> Vec<u8> {
-    let mut out = Vec::with_capacity(18 + device_name.len());
+    let name_bytes = clamp_to_utf8_boundary(device_name, MAX_DEVICE_NAME_BYTES);
+    let mut out = Vec::with_capacity(ENDPOINT_INFO_HEADER_LEN + name_bytes.len());
     out.push(DEVICE_TYPE_COMPUTER << 1);
 
     let mut rng = rand::thread_rng();
@@ -52,11 +97,8 @@ pub fn endpoint_info(device_name: &str) -> Vec<u8> {
     rng.fill(&mut rnd);
     out.extend_from_slice(&rnd);
 
-    let mut name_bytes = device_name.as_bytes();
-    if name_bytes.len() > 255 {
-        name_bytes = &name_bytes[..255];
-    }
-    // PROTO: ad uzunluğu wire'da u8 — yukarıda 255'e clamp ediliyor, truncation imkansız.
+    // PROTO: `name_bytes.len()` ≤ MAX_DEVICE_NAME_BYTES (= 171) << 255, yani
+    // u8 dönüşümü truncation üretmez.
     #[allow(clippy::cast_possible_truncation)]
     let name_len = name_bytes.len() as u8;
     out.push(name_len);
@@ -66,4 +108,51 @@ pub fn endpoint_info(device_name: &str) -> Vec<u8> {
 
 pub fn endpoint_info_b64(device_name: &str) -> String {
     URL_SAFE_NO_PAD.encode(endpoint_info(device_name))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// RFC 6763 §6.1 — `n=<base64>` toplam string'i ≤ 255 bayt olmalı.
+    /// Cihaz adı kullanıcı kontrollü olduğu için arbitrary uzunluktaki
+    /// input'larda da limit'in tutması gerekir; aksi halde Quick Share /
+    /// Android tarafı TXT entry'i drop edebilir.
+    #[test]
+    fn endpoint_info_b64_rfc6763_txt_record_limit() {
+        for &len in &[0usize, 1, 32, 100, 171, 200, 255, 1024, 4096] {
+            let name = "A".repeat(len);
+            let b64 = endpoint_info_b64(&name);
+            let txt_entry_len = "n=".len() + b64.len();
+            assert!(
+                txt_entry_len <= MAX_TXT_STRING_LEN,
+                "input len={len} → n=<{b64_len}> = {txt_entry_len} bayt (255 limit aşıldı)",
+                b64_len = b64.len(),
+            );
+        }
+    }
+
+    /// Uzun ad UTF-8 char boundary'sinde clamp edilmeli — yarım byte
+    /// sequence ile invalid UTF-8 üretmemeli.
+    #[test]
+    fn endpoint_info_utf8_boundary_safe_clamp() {
+        // Her karakter 4 bayt olan emoji string — 200 karakter = 800 bayt.
+        let name = "😀".repeat(200);
+        let info = endpoint_info(&name);
+        let name_len = info[17] as usize;
+        let name_slice = &info[18..18 + name_len];
+        assert!(
+            std::str::from_utf8(name_slice).is_ok(),
+            "clamp UTF-8 char boundary'sinde olmalı"
+        );
+        assert!(name_len <= MAX_DEVICE_NAME_BYTES);
+    }
+
+    /// Limit altındaki ad'lar dokunulmadan geçmeli.
+    #[test]
+    fn endpoint_info_short_name_passthrough() {
+        let info = endpoint_info("MacBook");
+        assert_eq!(info[17] as usize, "MacBook".len());
+        assert_eq!(&info[18..], b"MacBook");
+    }
 }


### PR DESCRIPTION
## Özet

PR #111 Gemini code-assist medium-priority bulgusunun fix'i: `endpoint_info` ad'ı 255 bayt'a clamp ediyordu — base64 (URL-safe, paddingsiz) sonrası `n=<base64>` TXT record stringi ~366 bayt'a çıkıyor ve **RFC 6763 §6.1** "her TXT string ≤ 255 bayt" sınırını aşıyordu.

## Neden

Cihaz adı kullanıcı kontrollü (settings → `device_name`). Uzun ad senaryosunda:

```
endpoint_info ham byte:  bitmap(1) + random(16) + name_len(1) + name(255) = 273 bayt
URL_SAFE_NO_PAD base64:  ceil(273 * 4 / 3) ≈ 364 char
TXT entry "n=<b64>":     2 + 364 = 366 bayt > 255
```

Quick Share / Android peer'ı bu durumda **TXT entry'i sessizce drop edebilir** veya bağlantı kuramaz; saldırı yüzeyi olmasa da regression-prone (örn. uzun hostname, `Mehmet'in MacBook Pro M4 Max — Çalışma`).

## Çözüm

`crates/hekadrop-core/src/config.rs`:

- `MAX_TXT_STRING_LEN = 255`, `N_KEY_PREFIX_LEN = 2`, `ENDPOINT_INFO_HEADER_LEN = 18` const'larını const expr ile birleştirip `MAX_DEVICE_NAME_BYTES = 171` derive et — sihirli sayı yok, kaynak RFC 6763.
- `clamp_to_utf8_boundary` helper'ı: ad'ı 171 bayt'a clamp ederken **UTF-8 char boundary'sini koru** (emoji / Türkçe karakterler için kritik; aksi halde invalid UTF-8 üretilir ve receiver `from_utf8_lossy` ile bozar).
- Mevcut `as u8` cast'i kalıyor ama yorumu güncellendi: 171 << 255 olduğu için truncation imkansız.

`crates/hekadrop-app/tests/mdns_discovery.rs`:

- `endpoint_info_255_bayt_ustunde_truncate` → `endpoint_info_171_bayt_ustunde_truncate_rfc6763` (yeni davranış doğrulanır + ek olarak `n=<base64>` ≤ 255 assertion'ı)
- Integration test'in lokal `endpoint_info` parity-implementation'ı da güncellendi (kaynak değişirse regression yakalanır mantığı).

## Test plan

- [x] `cargo build --workspace` — yeşil
- [x] `cargo test --workspace` — 222 main + 3 net + integration; 0 fail
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — temiz
- [x] `cargo fmt --check` — temiz
- [x] `cargo machete --with-metadata` — 0 unused
- [x] CLAUDE.md invariant grep'leri (I-1 / I-2 / I-3) — yeni hit yok
- [x] 3 yeni unit test:
  - `endpoint_info_b64_rfc6763_txt_record_limit` — 0..4096 bayt input → `n=<base64>` ≤ 255
  - `endpoint_info_utf8_boundary_safe_clamp` — emoji ad clamp'inde UTF-8 valid
  - `endpoint_info_short_name_passthrough` — limit altı dokunulmaz

## İlgili

- PR #111 Gemini code-assist medium-priority comment
- RFC 6763 §6.1 (DNS-SD TXT record string limit)
- `docs/protocol/discovery.md` (mDNS encoding spec — değişiklik gerekmedi, zaten "max 255 byte" demiyordu)

🤖 Generated with [Claude Code](https://claude.com/claude-code)