### PR TITLE
feat(chunk-hmac): RFC-0003 §3.5 sender/receiver pipeline entegrasyonu

### DIFF
--- a/crates/hekadrop-app/tests/hmac_tag_length.rs
+++ b/crates/hekadrop-app/tests/hmac_tag_length.rs
@@ -49,6 +49,7 @@ fn derived_keys_fixed() -> DerivedKeys {
         send_hmac_key: [44u8; 32],
         auth_key: [55u8; 32],
         pin_code: "0000".to_string(),
+        next_secret: [66u8; 32],
     }
 }
 
@@ -66,6 +67,7 @@ fn decrypt_rejects_short_hmac_tag() {
         send_hmac_key: [22u8; 32],
         auth_key: [55u8; 32],
         pin_code: "0000".to_string(),
+        next_secret: [66u8; 32],
     };
     let keys_b = derived_keys_fixed();
 

--- a/crates/hekadrop-core/src/connection.rs
+++ b/crates/hekadrop-core/src/connection.rs
@@ -301,6 +301,11 @@ pub async fn handle(
                     &mut active_capabilities,
                     &mut peer_capabilities_received,
                     &mut our_capabilities_sent,
+                    &mut assembler,
+                    &keys,
+                    state.as_ref(),
+                    &remote_name_shared,
+                    ui.as_ref(),
                 )
                 .await
                 {
@@ -423,70 +428,15 @@ pub async fn handle(
                             sha256,
                         } => {
                             pending_names.remove(&id);
-                            let sha_hex = hex::encode(sha256);
-                            info!(
-                                "[{}] ✓ {} alındı — SHA-256: {}",
-                                peer,
-                                crate::log_redact::path_basename(&path),
-                                crate::log_redact::sha_short(&sha_hex)
+                            finalize_received_file(
+                                &peer,
+                                &path,
+                                total_size,
+                                sha256,
+                                &remote_name_shared,
+                                state.as_ref(),
+                                ui.as_ref(),
                             );
-                            {
-                                // PERF/SAFETY: RwLock write guard altında senkron disk I/O
-                                // yapılmamalı — yavaş diskte tüm okuyucular (UI event loop)
-                                // bloklanır. Snapshot clone + drop guard + lock-dışı save.
-                                //
-                                // H#4 privacy: `keep_stats=false` iken RAM'deki Stats yine
-                                // güncellenir (UI Tanı sekmesi session boyunca doğru kalsın)
-                                // ama disk yazma atlanır. Mevcut stats.json silinmez —
-                                // kullanıcı sonradan tekrar açabilir, eski metrik kaybolmaz.
-                                let keep = state.settings.read().keep_stats;
-                                let snap_opt = {
-                                    let mut s = state.stats.write();
-                                    // payload.rs ingest_file aşamasında `total_size < 0` reddediliyor — burada >= 0 garanti.
-                                    #[allow(clippy::cast_sign_loss)]
-                                    let total_size_u = total_size as u64;
-                                    s.record_received(&remote_name_shared, total_size_u);
-                                    if keep {
-                                        Some(s.clone())
-                                    } else {
-                                        None
-                                    }
-                                };
-                                if let Some(snap) = snap_opt {
-                                    // PR #93 + #109: spawn_blocking + persistence_blocked guard
-                                    // (bozuk stats.json startup'ta backup başarısızsa save'i
-                                    // skip eder — kullanıcı verisini override etmez).
-                                    state.try_save_stats(snap);
-                                }
-                            }
-                            let file_name = path
-                                .file_name()
-                                .and_then(|n| n.to_str())
-                                .unwrap_or("dosya")
-                                .to_string();
-                            state.set_progress(ProgressState::Completed {
-                                file: file_name.clone(),
-                            });
-                            state.push_history(HistoryItem {
-                                file_name: file_name.clone(),
-                                path: path.clone(),
-                                size: total_size,
-                                device: remote_name_shared.clone(),
-                                when: std::time::SystemTime::now(),
-                                sha256_short: sha_hex.chars().take(16).collect(),
-                            });
-                            info!(
-                                "[{}] ✓ kaydedildi: {} ({} bayt)",
-                                peer,
-                                crate::log_redact::path_basename(&path),
-                                total_size
-                            );
-                            ui.notify(UiNotification::FileReceived {
-                                title_key: "notify.app_name",
-                                body_key: "notify.received",
-                                body_args: vec![file_name.clone(), human_size(total_size)],
-                                path: path.clone(),
-                            });
                         }
                     }
                 }
@@ -526,6 +476,86 @@ pub async fn handle(
     );
 
     Ok(())
+}
+
+/// `CompletedPayload::File` finalize ortak işleri (stats record, history push,
+/// progress update, UI notify). PR refactor: legacy assembler completion
+/// path'i ile RFC-0003 chunk-HMAC verify path'i (yine `verify_chunk_tag` ile
+/// finalize üretir) aynı helper'ı çağırsın diye çıkarıldı; logic duplikasyonu
+/// olmasın.
+fn finalize_received_file(
+    peer: &SocketAddr,
+    path: &std::path::Path,
+    total_size: i64,
+    sha256: [u8; 32],
+    remote_name: &str,
+    state: &AppState,
+    ui: &dyn UiPort,
+) {
+    let sha_hex = hex::encode(sha256);
+    info!(
+        "[{}] ✓ {} alındı — SHA-256: {}",
+        peer,
+        crate::log_redact::path_basename(path),
+        crate::log_redact::sha_short(&sha_hex)
+    );
+    {
+        // PERF/SAFETY: RwLock write guard altında senkron disk I/O
+        // yapılmamalı — yavaş diskte tüm okuyucular (UI event loop)
+        // bloklanır. Snapshot clone + drop guard + lock-dışı save.
+        //
+        // H#4 privacy: `keep_stats=false` iken RAM'deki Stats yine
+        // güncellenir (UI Tanı sekmesi session boyunca doğru kalsın)
+        // ama disk yazma atlanır. Mevcut stats.json silinmez —
+        // kullanıcı sonradan tekrar açabilir, eski metrik kaybolmaz.
+        let keep = state.settings.read().keep_stats;
+        let snap_opt = {
+            let mut s = state.stats.write();
+            // payload.rs ingest_file aşamasında `total_size < 0` reddediliyor — burada >= 0 garanti.
+            #[allow(clippy::cast_sign_loss)]
+            let total_size_u = total_size as u64;
+            s.record_received(remote_name, total_size_u);
+            if keep {
+                Some(s.clone())
+            } else {
+                None
+            }
+        };
+        if let Some(snap) = snap_opt {
+            // PR #93 + #109: spawn_blocking + persistence_blocked guard
+            // (bozuk stats.json startup'ta backup başarısızsa save'i
+            // skip eder — kullanıcı verisini override etmez).
+            state.try_save_stats(snap);
+        }
+    }
+    let file_name = path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("dosya")
+        .to_string();
+    state.set_progress(ProgressState::Completed {
+        file: file_name.clone(),
+    });
+    state.push_history(HistoryItem {
+        file_name: file_name.clone(),
+        path: path.to_path_buf(),
+        size: total_size,
+        device: remote_name.to_string(),
+        when: std::time::SystemTime::now(),
+        sha256_short: sha_hex.chars().take(16).collect(),
+    });
+    info!(
+        "[{}] ✓ kaydedildi: {} ({} bayt)",
+        peer,
+        crate::log_redact::path_basename(path),
+        total_size
+    );
+    ui.notify(UiNotification::FileReceived {
+        title_key: "notify.app_name",
+        body_key: "notify.received",
+        body_args: vec![file_name, human_size(total_size)],
+        path: path.to_path_buf(),
+    });
 }
 
 /// Yarım kalan alıcı state'ini temizler.
@@ -1066,6 +1096,7 @@ fn human_size(bytes: i64) -> String {
 /// - Bilinmeyen `Payload` varyantı → log + skip (forward-compat).
 ///
 /// Hata döner: socket write, ctx.encrypt, prost decode failure'ları.
+#[allow(clippy::too_many_arguments)]
 async fn handle_hekadrop_frame(
     bytes: &[u8],
     peer: &SocketAddr,
@@ -1074,6 +1105,11 @@ async fn handle_hekadrop_frame(
     active_capabilities: &mut crate::capabilities::ActiveCapabilities,
     peer_capabilities_received: &mut bool,
     our_capabilities_sent: &mut bool,
+    assembler: &mut PayloadAssembler,
+    keys: &ukey2::DerivedKeys,
+    state: &AppState,
+    remote_name: &str,
+    ui: &dyn UiPort,
 ) -> Result<()> {
     use hekadrop_proto::hekadrop_ext::{heka_drop_frame::Payload, HekaDropFrame};
     use tracing::debug;
@@ -1114,6 +1150,19 @@ async fn handle_hekadrop_frame(
                 active_capabilities.has(crate::capabilities::features::FOLDER_STREAM_V1),
             );
 
+            // RFC-0003 §4.1: capability aktif ise chunk-HMAC anahtarını
+            // assembler'a kur. PayloadAssembler artık her FILE chunk'ını
+            // pending buffer'a alır, ChunkIntegrity verify olduktan sonra
+            // diske yazar (storage corruption early-abort).
+            if active_capabilities.has(crate::capabilities::features::CHUNK_HMAC_V1) {
+                let key = crate::chunk_hmac::derive_chunk_hmac_key(&keys.next_secret);
+                assembler.set_chunk_hmac_key(key);
+                info!(
+                    "[{}] chunk-HMAC anahtarı türetildi + assembler'a kuruldu (RFC-0003 §4.1)",
+                    peer
+                );
+            }
+
             if !*our_capabilities_sent {
                 let our = crate::capabilities::build_capabilities_frame(
                     crate::capabilities::build_self_capabilities(),
@@ -1132,15 +1181,59 @@ async fn handle_hekadrop_frame(
             Ok(())
         }
         Payload::ChunkTag(ci) => {
-            // RFC-0003 §3.6: chunk tag verify. Şu an stub — full pipeline
-            // PayloadAssembler entegrasyonuyla v0.8 sonraki PR'ı (critical
-            // fix scope dışı). En azından frame'i drop ETMİYORUZ ki bağlantı
-            // hatasız ilerlesin.
+            // RFC-0003 §5: ChunkIntegrity verify pipeline. Capability gate
+            // kapalıysa peer protocol violation yapıyor (spec §9 son satır:
+            // "Sender sends tag but receiver lacks capability") — abort +
+            // disconnect (caller `?` ile yukarı propagate edip session sonu
+            // tetikler).
+            if !active_capabilities.has(crate::capabilities::features::CHUNK_HMAC_V1) {
+                return Err(HekaError::ProtocolState(format!(
+                    "[{peer}] ChunkIntegrity geldi ama CHUNK_HMAC_V1 capability negotiate edilmemiş (spec §9)"
+                )).into());
+            }
             debug!(
-                "[{}] ChunkTag (integrity) received: payload_id={}, chunk_index={} (verify TODO)",
-                peer, ci.payload_id, ci.chunk_index
+                "[{}] ChunkTag verify: payload_id={}, chunk_index={}, offset={}, body_len={}",
+                peer, ci.payload_id, ci.chunk_index, ci.offset, ci.body_len
             );
-            Ok(())
+            // PRIVACY (spec §10): ChunkIntegrity.tag içeriği log'a düşmez —
+            // sadece kategori metadata. Hata durumunda da mesajda tag yok.
+            match assembler.verify_chunk_tag(&ci).await {
+                Ok(None) => Ok(()),
+                Ok(Some(crate::payload::CompletedPayload::File {
+                    id,
+                    path,
+                    total_size,
+                    sha256,
+                })) => {
+                    debug!("[{}] chunk-HMAC verify path: dosya finalize id={id}", peer);
+                    finalize_received_file(peer, &path, total_size, sha256, remote_name, state, ui);
+                    Ok(())
+                }
+                Ok(Some(other)) => {
+                    // Bytes payload'lar verify pipeline'ından geçmez (sender
+                    // chunk-HMAC sadece FILE chunk'ları için emit eder).
+                    // Defensive: forward-compat için error.
+                    Err(anyhow!(
+                        "[{peer}] verify_chunk_tag beklenmedik CompletedPayload varyantı: {other:?}"
+                    ))
+                }
+                Err(e) => {
+                    // Spec §9: cleanup_transfer_state + Disconnection.
+                    // Caller (steady loop) `?` ile yakalar, log + cleanup
+                    // ardından send_disconnection. .part dosyası kapalı
+                    // FileSink artakaldıysa sonraki cleanup_transfer_state
+                    // çağrısı yarım dosyayı kanca'dan düşürür.
+                    warn!(
+                        "[{}] chunk-HMAC verify FAIL — protokol ihlali / corruption (payload_id={}, chunk_index={}): {}",
+                        peer, ci.payload_id, ci.chunk_index, e
+                    );
+                    // Failure path'inde pending_chunk hâlâ FileSink içinde
+                    // olabilir (verify_chunk_tag erken return etti). Sink'i
+                    // cancel et ki .part diskten silinsin (RFC-0003 §9 row 3).
+                    assembler.cancel(ci.payload_id);
+                    Err(e)
+                }
+            }
         }
         // Forward-compat: ResumeHint/ResumeReject (RFC-0004) +
         // FolderMft (RFC-0005) henüz implement edilmedi; placeholder

--- a/crates/hekadrop-core/src/negotiation.rs
+++ b/crates/hekadrop-core/src/negotiation.rs
@@ -158,6 +158,7 @@ mod tests {
             send_hmac_key: hmac_b,
             auth_key: [0u8; 32],
             pin_code: "0000".to_string(),
+            next_secret: [0u8; 32],
         };
         let client_keys = DerivedKeys {
             decrypt_key: key_b,
@@ -166,6 +167,7 @@ mod tests {
             send_hmac_key: hmac_a,
             auth_key: [0u8; 32],
             pin_code: "0000".to_string(),
+            next_secret: [0u8; 32],
         };
 
         (

--- a/crates/hekadrop-core/src/payload.rs
+++ b/crates/hekadrop-core/src/payload.rs
@@ -12,8 +12,10 @@
 //! süreden uzun sessiz kalmış girişleri düşürür; [`PayloadAssembler::ingest`]
 //! her çağrıda otomatik olarak bu GC'yi çalıştırır ([`ASSEMBLER_GC_TIMEOUT`]).
 
+use crate::chunk_hmac;
 use crate::error::HekaError;
 use anyhow::{anyhow, Context, Result};
+use hekadrop_proto::hekadrop_ext::ChunkIntegrity;
 use hekadrop_proto::location::nearby::connections::{
     payload_transfer_frame::payload_header::PayloadType, PayloadTransferFrame,
 };
@@ -101,6 +103,29 @@ struct FileSink {
     written: i64,
     hasher: Sha256,
     last_chunk_at: Instant,
+    /// RFC-0003 §5: chunk-HMAC capability aktif iken her data chunk'ı geçici
+    /// olarak burada tutulur, sonraki frame'de `ChunkIntegrity` gelir, verify
+    /// ok ise diske flush olur. None → henüz beklenen chunk yok (ya capability
+    /// kapalı ya da önceki chunk verify olup yazıldı).
+    pending_chunk: Option<PendingChunk>,
+    /// Bir sonraki beklenen chunk indeksi (0-tabanlı, monoton). Receiver
+    /// `ChunkIntegrity.chunk_index`'i bununla karşılaştırır → out-of-order
+    /// veya skipped chunk anında protokol ihlali.
+    next_chunk_index: i64,
+}
+
+/// Verify-bekleyen chunk için geçici buffer. Body sahipli (`Vec<u8>`)
+/// tutulur — `ChunkIntegrity` doğrulamadan diske yazılmaz (RFC-0003 §1.2:
+/// storage corruption early-abort). Pratikte her chunk en fazla
+/// `payload.rs` `BufWriter` capacity (128 KiB) × 4 = 512 KiB civarı RAM
+/// tutar (Quick Share chunk pratiği), kabul edilebilir overhead.
+struct PendingChunk {
+    body: Vec<u8>,
+    /// Chunk başlangıç offset'i — `compute_tag`/`verify_tag` input'unda
+    /// redundant binding alanı.
+    offset: i64,
+    /// Bu chunk son frame mi (flag bit 1)? Verify sonrası finalize için.
+    last_chunk: bool,
 }
 
 /// Introduction'da onaylanmış ama hiç chunk gelmemiş dosyanın hedef yolu.
@@ -114,11 +139,36 @@ pub struct PayloadAssembler {
     bytes_buffers: HashMap<i64, BytesBuf>,
     file_sinks: HashMap<i64, FileSink>,
     pending_destinations: HashMap<i64, PendingDest>,
+    /// RFC-0003 §4.1: chunk-HMAC anahtarı. `None` → capability kapalı,
+    /// chunk body'leri eskisi gibi chunk geldiği anda diske yazılır
+    /// (legacy Quick Share davranışı). `Some(key)` → her FILE chunk'ı
+    /// geçici buffer'a alınır, takip eden `ChunkIntegrity` verify olduktan
+    /// sonra diske flush olur.
+    ///
+    /// Capability negotiation tamamlandığında [`Self::set_chunk_hmac_key`]
+    /// ile set edilir; transfer süresince değişmez (mid-flight downgrade
+    /// engelleme — capabilities.md §6).
+    chunk_hmac_key: Option<[u8; 32]>,
 }
 
 impl PayloadAssembler {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// RFC-0003 §4.1: chunk-HMAC anahtarı kur. Capability negotiation
+    /// `CHUNK_HMAC_V1` aktif çıktıysa caller bu fonksiyonu `PayloadAssembler`
+    /// chunk işlemeye başlamadan ÖNCE çağırmalıdır. Sonradan değiştirme
+    /// sessiz downgrade riski yaratır → idempotent değil, ikinci çağrı
+    /// `None`'a (kapatma) izin vermez (caller-side defense).
+    pub fn set_chunk_hmac_key(&mut self, key: [u8; 32]) {
+        self.chunk_hmac_key = Some(key);
+    }
+
+    /// Chunk-HMAC capability aktif mi (test/diagnostics).
+    #[must_use]
+    pub fn chunk_hmac_enabled(&self) -> bool {
+        self.chunk_hmac_key.is_some()
     }
 
     /// Introduction sırasında onaylanan dosya için diskteki hedef yolu kaydeder.
@@ -311,6 +361,23 @@ impl PayloadAssembler {
     ) -> Result<Option<CompletedPayload>> {
         use std::collections::hash_map::Entry;
 
+        // RFC-0003 §2 ordering invariant: chunk-HMAC capability aktif iken
+        // her FILE data chunk'ı bir ChunkIntegrity envelope'u beklemeli.
+        // Yeni bir data chunk geldiğinde önceki chunk için pending_chunk
+        // hâlâ doluysa peer "body N, body N+1, tag N" pattern'iyle out-of-order
+        // gönderdi → protokol ihlali (spec §2 "Receivers that observe an
+        // out-of-order pair MUST treat this as a protocol violation").
+        if self.chunk_hmac_key.is_some() {
+            if let Some(sink) = self.file_sinks.get(&id) {
+                if sink.pending_chunk.is_some() {
+                    return Err(HekaError::ProtocolState(format!(
+                        "chunk-HMAC ordering violation: payload_id={id} bir önceki chunk için ChunkIntegrity gelmeden yeni chunk arrived"
+                    ))
+                    .into());
+                }
+            }
+        }
+
         // İlk chunk: dosyayı aç.
         // NOT: `connection::unique_downloads_path` dosyayı `create_new(true)`
         // ile **placeholder** olarak zaten oluşturmuş oldu (TOCTOU fix).
@@ -376,6 +443,8 @@ impl PayloadAssembler {
                 written: 0,
                 hasher: Sha256::new(),
                 last_chunk_at: Instant::now(),
+                pending_chunk: None,
+                next_chunk_index: 0,
             });
         }
 
@@ -393,14 +462,43 @@ impl PayloadAssembler {
             let body_len = i64::try_from(body.len()).map_err(|e| {
                 HekaError::PayloadIo(format!("chunk body i64'a sığmıyor (id={id}): {e}"))
             })?;
-            let new_written = sink
+            // Overrun guard cumulative tracking ile; chunk-HMAC path'inde de
+            // tetiklenir çünkü `written` pending_chunk flush'unda artar değil
+            // — burada **provisional** kontrol: pending body henüz yazılmamış
+            // olsa bile total > deklare edilen size'a ulaşmamalı.
+            let provisional_written = sink
                 .written
                 .checked_add(body_len)
                 .ok_or_else(|| HekaError::PayloadIo(format!("yazım toplamı taştı (id={id})")))?;
-            if new_written > sink.total_size {
+            if self.chunk_hmac_key.is_some() {
+                // Chunk-HMAC path: body'yi disk'e yazma; pending_chunk'a buffer'la.
+                // Verify ChunkIntegrity geldiğinde flush + written increment olur.
+                // Offset = `sink.written` (henüz yazılmamış olanlar dahil değil
+                // — `written` sadece flush'lanmış total).
+                let chunk_offset = sink.written;
+                if provisional_written > sink.total_size {
+                    return Err(HekaError::PayloadOverrun {
+                        id,
+                        written: provisional_written,
+                        total: sink.total_size,
+                    }
+                    .into());
+                }
+                sink.pending_chunk = Some(PendingChunk {
+                    body: body.to_vec(),
+                    offset: chunk_offset,
+                    last_chunk,
+                });
+                sink.last_chunk_at = Instant::now();
+                // Caller verify_chunk_tag çağıracak; tamamlanma `last_chunk`
+                // verify path'inden gelir, burada erken `Ok(None)` döneriz.
+                return Ok(None);
+            }
+            // Legacy path: chunk-HMAC kapalı, eskisi gibi anında diske yaz.
+            if provisional_written > sink.total_size {
                 return Err(HekaError::PayloadOverrun {
                     id,
-                    written: new_written,
+                    written: provisional_written,
                     total: sink.total_size,
                 }
                 .into());
@@ -412,11 +510,23 @@ impl PayloadAssembler {
             // çağrı — block_in_place current_thread'de panik eder.
             block_in_place_if_multi(|| sink.writer.write_all(body)).context("disk yazma")?;
             sink.hasher.update(body);
-            sink.written = new_written;
+            sink.written = provisional_written;
             sink.last_chunk_at = Instant::now();
         }
 
         if last_chunk {
+            // Chunk-HMAC: pending_chunk doluysa finalize verify_chunk_tag'a
+            // havale (peer'ın tag'ini bekliyoruz). Yalnız body=[] terminator
+            // chunk'ı geldiğinde direkt finalize'a düşer (boş body için tag
+            // yok — sender de emit etmez, RFC-0003 §3.5 caller pratik).
+            if self.chunk_hmac_key.is_some() {
+                if let Some(sink) = self.file_sinks.get(&id) {
+                    if sink.pending_chunk.is_some() {
+                        // Tag bekliyoruz; verify path bayrağa düşürecek.
+                        return Ok(None);
+                    }
+                }
+            }
             let mut sink = self
                 .file_sinks
                 .remove(&id)
@@ -450,6 +560,154 @@ impl PayloadAssembler {
             flush_sync_res.with_context(|| {
                 format!(
                     "dosya finalize edilemedi (flush/fsync): id={} path={}",
+                    id,
+                    sink.path.display()
+                )
+            })?;
+            let digest = sink.hasher.finalize();
+            let mut sha256 = [0u8; 32];
+            sha256.copy_from_slice(&digest);
+            return Ok(Some(CompletedPayload::File {
+                id,
+                path: sink.path,
+                total_size: sink.total_size,
+                sha256,
+            }));
+        }
+        Ok(None)
+    }
+
+    /// RFC-0003 §5: peer'ın yolladığı `ChunkIntegrity` envelope'unu doğrula
+    /// ve doğrulanan body'yi diske flush et.
+    ///
+    /// Çağrı sırası (sender pipeline'ı): bir önceki [`Self::ingest`]
+    /// çağrısında bir FILE chunk body'si pending'e alınmış olmalı. Bu fn
+    /// pending chunk'ı tag input'uyla karşılaştırır:
+    ///   1. `chunk_hmac_key` set değilse → `Err` (capability mismatch /
+    ///      protocol violation; spec §9 son satır).
+    ///   2. Sink yoksa veya `pending_chunk` yoksa → `Err` (peer "tag without
+    ///      preceding body" attı; out-of-order).
+    ///   3. `chunk_index`, `offset`, `body_len` field'ları beklenen değerlerle
+    ///      eşleşmeli — değilse protokol ihlali.
+    ///   4. `chunk_hmac::verify_tag(key, ci, body)` — HMAC mismatch → `Err`.
+    ///   5. Verify ok → body'yi diske yaz, `written` artır, `next_chunk_index`
+    ///      artır, `last_chunk` ise finalize edip [`CompletedPayload::File`]
+    ///      döndür. `last_chunk` değilse `Ok(None)`.
+    ///
+    /// Hata durumunda caller spec §9 davranışını uygulamalı: `.part`/`.meta`
+    /// silimi (`cancel(payload_id)`) + `Disconnection` frame.
+    pub async fn verify_chunk_tag(
+        &mut self,
+        ci: &ChunkIntegrity,
+    ) -> Result<Option<CompletedPayload>> {
+        let key = self.chunk_hmac_key.ok_or_else(|| {
+            HekaError::ProtocolState(format!(
+                "ChunkIntegrity geldi ama chunk-HMAC capability aktif değil (payload_id={})",
+                ci.payload_id
+            ))
+        })?;
+        let id = ci.payload_id;
+
+        // Sink ve pending_chunk varlığını sınırlı borrow ile kontrol et —
+        // body verify için reference olarak alınır, sonra mutable borrow
+        // flush için tekrar lock'lanır.
+        {
+            let sink = self.file_sinks.get(&id).ok_or_else(|| {
+                HekaError::ProtocolState(format!(
+                    "ChunkIntegrity payload_id={id} için açık FileSink yok"
+                ))
+            })?;
+            let pending = sink.pending_chunk.as_ref().ok_or_else(|| {
+                HekaError::ProtocolState(format!(
+                    "ChunkIntegrity payload_id={id} için bekleyen chunk yok (out-of-order)"
+                ))
+            })?;
+            // Spec §3.2 redundant binding kontrolleri (HMAC verify body içerse
+            // de erken yakalama daha açık hata mesajı verir).
+            if ci.chunk_index != sink.next_chunk_index {
+                return Err(HekaError::ProtocolState(format!(
+                    "ChunkIntegrity.chunk_index {} ≠ beklenen {} (payload_id={})",
+                    ci.chunk_index, sink.next_chunk_index, id
+                ))
+                .into());
+            }
+            if ci.offset != pending.offset {
+                return Err(HekaError::ProtocolState(format!(
+                    "ChunkIntegrity.offset {} ≠ beklenen {} (payload_id={})",
+                    ci.offset, pending.offset, id
+                ))
+                .into());
+            }
+            // body_len ve tag uzunluğu + HMAC compute — `chunk_hmac::verify_tag`
+            // içinde yapılır, kategorik hata kategorisi döner.
+            chunk_hmac::verify_tag(&key, ci, &pending.body).map_err(|e| {
+                HekaError::ProtocolState(format!(
+                    "chunk-HMAC verify fail (payload_id={id}, chunk_index={}): {e}",
+                    ci.chunk_index
+                ))
+            })?;
+        }
+
+        // Verify ok — pending'i çek, diske flush et.
+        let sink = self
+            .file_sinks
+            .get_mut(&id)
+            .ok_or_else(|| anyhow!("verify sonrası sink kayıp: id={id}"))?;
+        // Çek (ownership al) — verify zaten ok, pending tüketildi.
+        let pending = sink
+            .pending_chunk
+            .take()
+            .ok_or_else(|| anyhow!("verify sonrası pending kayıp: id={id}"))?;
+        let body_len = i64::try_from(pending.body.len())
+            .with_context(|| format!("flush body i64'a sığmıyor (id={id})"))?;
+        let new_written = sink.written.checked_add(body_len).ok_or_else(|| {
+            HekaError::PayloadIo(format!("verify flush yazım toplamı taştı (id={id})"))
+        })?;
+        // Re-check overrun — provisional check ingest'te yapıldı, defensive
+        // olarak burada da koruyoruz.
+        if new_written > sink.total_size {
+            return Err(HekaError::PayloadOverrun {
+                id,
+                written: new_written,
+                total: sink.total_size,
+            }
+            .into());
+        }
+        block_in_place_if_multi(|| sink.writer.write_all(&pending.body))
+            .context("verify sonrası disk yazma")?;
+        sink.hasher.update(&pending.body);
+        sink.written = new_written;
+        sink.next_chunk_index = sink
+            .next_chunk_index
+            .checked_add(1)
+            .ok_or_else(|| HekaError::PayloadIo(format!("chunk_index taştı (id={id})")))?;
+        sink.last_chunk_at = Instant::now();
+
+        // Bu chunk last_chunk mı? Eğer öyle ise hemen finalize et — caller
+        // ayrıca empty terminator beklemez (chunk-HMAC modunda tag-verified
+        // last_chunk completion sinyali olarak yeterli; empty terminator
+        // sender tarafından opsiyonel).
+        if pending.last_chunk {
+            let mut sink = self
+                .file_sinks
+                .remove(&id)
+                .ok_or_else(|| anyhow!("verify finalize sonrası sink kayıp: id={id}"))?;
+            if sink.written != sink.total_size {
+                return Err(HekaError::PayloadTruncated {
+                    id,
+                    written: sink.written,
+                    total: sink.total_size,
+                }
+                .into());
+            }
+            let flush_sync_res: std::io::Result<()> = block_in_place_if_multi(|| {
+                sink.writer.flush()?;
+                sink.writer.get_ref().sync_all()?;
+                Ok(())
+            });
+            flush_sync_res.with_context(|| {
+                format!(
+                    "dosya finalize edilemedi (verify path) id={} path={}",
                     id,
                     sink.path.display()
                 )
@@ -875,5 +1133,194 @@ mod tests {
         let f = make_frame_total(9, PbPayloadType::File, b"a", false, -1);
         let err = a.ingest(&f).await.expect_err("negatif total red");
         assert!(err.to_string().contains("negatif"));
+    }
+
+    // ---- RFC-0003 chunk-HMAC pipeline integration tests ----
+
+    use crate::chunk_hmac::{build_chunk_integrity, compute_tag, derive_chunk_hmac_key};
+
+    /// Helper: `PayloadTransferFrame` with explicit chunk offset (chunk-HMAC
+    /// path requires offset matching across body + tag frames).
+    fn make_frame_offset(
+        id: i64,
+        ptype: PbPayloadType,
+        body: &[u8],
+        last: bool,
+        total_size: i64,
+        offset: i64,
+    ) -> PayloadTransferFrame {
+        PayloadTransferFrame {
+            packet_type: None,
+            payload_header: Some(PayloadHeader {
+                id: Some(id),
+                r#type: Some(ptype as i32),
+                total_size: Some(total_size),
+                is_sensitive: None,
+                file_name: None,
+                parent_folder: None,
+                last_modified_timestamp_millis: None,
+            }),
+            payload_chunk: Some(PayloadChunk {
+                flags: Some(if last { 1 } else { 0 }),
+                offset: Some(offset),
+                body: Some(body.to_vec().into()),
+                index: None,
+            }),
+            control_message: None,
+        }
+    }
+
+    /// Happy-path: chunk-HMAC aktif, sender simule body + `ChunkIntegrity`
+    /// gönderir, receiver verify + flush sonunda dosyayı tamamlar.
+    #[tokio::test]
+    async fn chunk_hmac_happy_path_two_chunks_then_terminator() {
+        let tmp = std::env::temp_dir().join(format!("hd-chmac-ok-{}.bin", std::process::id()));
+        let _ = std::fs::remove_file(&tmp);
+        let mut a = PayloadAssembler::new();
+        let key = derive_chunk_hmac_key(&[0x42u8; 32]);
+        a.set_chunk_hmac_key(key);
+        assert!(a.chunk_hmac_enabled());
+        a.register_file_destination(7, tmp.clone()).unwrap();
+
+        let total = 6i64;
+        // chunk 0: "foo" @ offset 0
+        let body0 = b"foo".to_vec();
+        let f0 = make_frame_offset(7, PbPayloadType::File, &body0, false, total, 0);
+        // body ingest pending'e düşer, henüz disk'te bir şey yok.
+        assert!(a.ingest(&f0).await.unwrap().is_none());
+        // verify_chunk_tag çağrılmadan dosya boyutu hâlâ 0 olmalı (placeholder).
+        let on_disk_after_body0 = std::fs::metadata(&tmp).map(|m| m.len()).unwrap_or(0);
+        assert_eq!(
+            on_disk_after_body0, 0,
+            "verify öncesi disk'e yazma olmamalı"
+        );
+
+        let tag0 = compute_tag(&key, 7, 0, 0, &body0).unwrap();
+        let ci0 = build_chunk_integrity(7, 0, 0, body0.len(), tag0).unwrap();
+        assert!(a.verify_chunk_tag(&ci0).await.unwrap().is_none());
+
+        // chunk 1: "bar" @ offset 3, last_chunk=true
+        let body1 = b"bar".to_vec();
+        let f1 = make_frame_offset(7, PbPayloadType::File, &body1, true, total, 3);
+        // last_chunk olsa bile pending varsa Ok(None) döner — verify path'i
+        // beklenir.
+        assert!(a.ingest(&f1).await.unwrap().is_none());
+        let tag1 = compute_tag(&key, 7, 1, 3, &body1).unwrap();
+        let ci1 = build_chunk_integrity(7, 1, 3, body1.len(), tag1).unwrap();
+        let done = a
+            .verify_chunk_tag(&ci1)
+            .await
+            .unwrap()
+            .expect("verify last_chunk → Completed");
+        match done {
+            CompletedPayload::File {
+                path,
+                total_size,
+                sha256,
+                ..
+            } => {
+                assert_eq!(path, tmp);
+                assert_eq!(total_size, total);
+                let expected = {
+                    let mut h = Sha256::new();
+                    h.update(b"foobar");
+                    let d = h.finalize();
+                    let mut a = [0u8; 32];
+                    a.copy_from_slice(&d);
+                    a
+                };
+                assert_eq!(sha256, expected);
+            }
+            other => panic!("beklenen File, {other:?} geldi"),
+        }
+        let content = std::fs::read(&tmp).unwrap();
+        assert_eq!(content, b"foobar");
+        let _ = std::fs::remove_file(&tmp);
+    }
+
+    /// Tampered body → `verify_chunk_tag` mismatch hatası, `.part` diskten silinir.
+    #[tokio::test]
+    async fn chunk_hmac_body_tampering_detected_and_part_removed() {
+        let tmp = std::env::temp_dir().join(format!("hd-chmac-tamper-{}.bin", std::process::id()));
+        let _ = std::fs::remove_file(&tmp);
+        let mut a = PayloadAssembler::new();
+        let key = derive_chunk_hmac_key(&[0x99u8; 32]);
+        a.set_chunk_hmac_key(key);
+        a.register_file_destination(11, tmp.clone()).unwrap();
+
+        // Sender'ın yolladığı orijinal body
+        let original = b"clean-data".to_vec();
+        // "Storage corruption" simulation: receiver pending buffer'ına farklı
+        // bytes gelmiş gibi (in-memory tampering arası decrypt + buffer'ı
+        // kapsayan attack vector). Wire'da tag orijinal body için hesaplanmış.
+        let tampered = b"DIRTY-data".to_vec();
+        let total = original.len() as i64;
+        let f = make_frame_offset(11, PbPayloadType::File, &tampered, true, total, 0);
+        assert!(a.ingest(&f).await.unwrap().is_none());
+
+        // Tag orijinal body için hesaplanmış (sender bilseydi).
+        let tag = compute_tag(&key, 11, 0, 0, &original).unwrap();
+        let ci = build_chunk_integrity(11, 0, 0, original.len(), tag).unwrap();
+        let err = a
+            .verify_chunk_tag(&ci)
+            .await
+            .expect_err("tampered body → mismatch");
+        let s = err.to_string();
+        assert!(
+            s.contains("verify fail") || s.contains("mismatch") || s.contains("HMAC"),
+            "hata HMAC mismatch belirtmeli, aldı: {s}"
+        );
+        // Spec §9: caller cancel(payload_id) çağırmalı; bunu sim et + .part
+        // diskten silinmeli.
+        a.cancel(11);
+        assert!(
+            !tmp.exists(),
+            "verify fail sonrası caller cancel çağırınca .part silinmeli"
+        );
+    }
+
+    /// `ChunkIntegrity` capability-aktif değilken gelirse → `ProtocolState` hata.
+    #[tokio::test]
+    async fn chunk_hmac_tag_without_capability_protocol_violation() {
+        let mut a = PayloadAssembler::new();
+        // chunk_hmac_key set ETMİYORUZ → capability inactive.
+        let ci = ChunkIntegrity {
+            payload_id: 1,
+            chunk_index: 0,
+            offset: 0,
+            body_len: 0,
+            tag: vec![0u8; 32].into(),
+        };
+        let err = a
+            .verify_chunk_tag(&ci)
+            .await
+            .expect_err("capability inactive iken tag → red");
+        assert!(err.to_string().contains("capability aktif değil"));
+    }
+
+    /// Out-of-order: body N → body N+1 (tag N gelmeden) → ingest fail
+    /// (RFC-0003 §2 ordering invariant).
+    #[tokio::test]
+    async fn chunk_hmac_out_of_order_body_without_tag_rejected() {
+        let tmp = std::env::temp_dir().join(format!("hd-chmac-ooo-{}.bin", std::process::id()));
+        let _ = std::fs::remove_file(&tmp);
+        let mut a = PayloadAssembler::new();
+        let key = derive_chunk_hmac_key(&[0xCCu8; 32]);
+        a.set_chunk_hmac_key(key);
+        a.register_file_destination(22, tmp.clone()).unwrap();
+
+        let body0 = b"first".to_vec();
+        let f0 = make_frame_offset(22, PbPayloadType::File, &body0, false, 10, 0);
+        assert!(a.ingest(&f0).await.unwrap().is_none());
+
+        // Tag göndermeden ikinci body — protocol violation.
+        let body1 = b"second".to_vec();
+        let f1 = make_frame_offset(22, PbPayloadType::File, &body1, false, 10, 5);
+        let err = a
+            .ingest(&f1)
+            .await
+            .expect_err("body N+1, tag N gelmeden → red");
+        assert!(err.to_string().contains("ordering violation"));
+        a.cancel(22);
     }
 }

--- a/crates/hekadrop-core/src/sender.rs
+++ b/crates/hekadrop-core/src/sender.rs
@@ -201,11 +201,18 @@ pub async fn send(req: SendRequest, state: Arc<AppState>) -> Result<()> {
     // PR #112 Gemini medium: aktif capabilities transferin geri kalanında
     // (chunk-HMAC verify pipeline'ı, resume hint emit, folder bundle gating)
     // kullanılabilsin diye loop dışında yaşamalı. Default: legacy (legacy
-    // peer'larla geriye uyumluluk). Consumer pipeline (chunk-HMAC emit) henüz
-    // bağlı değil — initial assignment intentionally unused; bu PR sender
-    // state machine entegrasyon noktası, downstream PR'lar bu değeri okuyacak.
+    // peer'larla geriye uyumluluk). RFC-0003 §3.5 — `send_file_chunks` her
+    // PayloadTransferFrame'den sonra `chunk_hmac_key.is_some()` ise
+    // ChunkIntegrity envelope'u emit eder.
+    // INVARIANT (CLAUDE.md I-2): legacy() initial value capabilities exchange
+    // atlanırsa (peer extension_supported=false) kullanılan canonical default;
+    // exchange tetiklenirse `outcome.active` ile overwrite olur.
     #[allow(unused_assignments)]
     let mut active_caps = crate::capabilities::ActiveCapabilities::legacy();
+    // RFC-0003 §4.1: chunk-HMAC anahtarı capability negotiation sonrası
+    // `keys.next_secret`'ten HKDF-SHA256 ile türetilir; capability inactive
+    // ise None kalır → sender legacy davranışta.
+    let mut chunk_hmac_key: Option<[u8; 32]> = None;
     let peer_label = req.device.name.clone();
     let transfer_id = format!("out:{}:{}", req.device.addr, req.device.port);
     let _guard = state::TransferGuard::new(Arc::clone(&state), &transfer_id);
@@ -297,6 +304,17 @@ pub async fn send(req: SendRequest, state: Arc<AppState>) -> Result<()> {
                                 active_caps.has(crate::capabilities::features::RESUME_V1),
                                 active_caps.has(crate::capabilities::features::FOLDER_STREAM_V1),
                             );
+                            // RFC-0003 §4.1: capability aktif ise chunk-HMAC
+                            // anahtarını UKEY2 next_secret'ten türet. Sender
+                            // ve receiver aynı IKM + aynı HKDF label
+                            // (`"hekadrop chunk-hmac v1"`) kullandığı için
+                            // çıktı sembolik olarak eşleşir.
+                            if active_caps.has(crate::capabilities::features::CHUNK_HMAC_V1) {
+                                chunk_hmac_key = Some(crate::chunk_hmac::derive_chunk_hmac_key(
+                                    &keys.next_secret,
+                                ));
+                                info!("[sender] chunk-HMAC anahtarı türetildi (RFC-0003 §4.1)");
+                            }
                             // Frame loss önlemi (PR #110 high yorumu): peer
                             // extension_supported=true demiş ama legacy
                             // OfflineFrame yolladıysa plain bytes leftover'a
@@ -360,6 +378,7 @@ pub async fn send(req: SendRequest, state: Arc<AppState>) -> Result<()> {
                                 total_bytes,
                                 &cancel_token,
                                 state.as_ref(),
+                                chunk_hmac_key.as_ref(),
                             )
                             .await?;
                             bytes_sent += plan.size;
@@ -872,11 +891,15 @@ async fn send_file_chunks(
     total_bytes: i64,
     cancel: &CancellationToken,
     state: &AppState,
+    chunk_hmac_key: Option<&[u8; 32]>,
 ) -> Result<()> {
     let mut file = tokio::fs::File::open(path).await?;
     let mut buf = vec![0u8; CHUNK_SIZE];
     let mut offset: i64 = 0;
     let mut hasher = Sha256::new();
+    // RFC-0003 §3.2: chunk_index 0-tabanlı per-payload monoton sayaç.
+    // Capability gate altında her gönderilen non-empty chunk başına artar.
+    let mut chunk_index: i64 = 0;
 
     loop {
         // Disk read ile cancel'i paralel bekle — büyük chunk'larda ~512 KB'lık
@@ -904,10 +927,47 @@ async fn send_file_chunks(
         // Hot-path: tek kopya ile sahiplenilmiş `Bytes` üret — protobuf body alanı
         // `bytes::Bytes` (prost bytes feature) olduğundan buradan sonraki encode
         // zincirinde ek kopya oluşmaz (zero-copy reference semantics).
-        let body = Bytes::copy_from_slice(&buf[..n]);
+        let body_slice = &buf[..n];
+        let body = Bytes::copy_from_slice(body_slice);
         let wrapped = wrap_payload_transfer(payload_id, file_size, offset, 0, body);
         let enc = ctx.encrypt(&wrapped.encode_to_vec())?;
         frame::write_frame(socket, &enc).await?;
+
+        // RFC-0003 §2 ordering invariant: PayloadTransferFrame'den HEMEN
+        // SONRA, başka chunk göndermeden önce ChunkIntegrity envelope'unu
+        // emit et. capability gate kapalı (Some(key) yok) → legacy Quick
+        // Share davranışı, tag emission yok.
+        if let Some(key) = chunk_hmac_key {
+            let tag =
+                crate::chunk_hmac::compute_tag(key, payload_id, chunk_index, offset, body_slice)
+                    .with_context(|| {
+                        format!(
+                    "chunk-HMAC tag compute (payload_id={payload_id}, chunk_index={chunk_index})"
+                )
+                    })?;
+            let ci = crate::chunk_hmac::build_chunk_integrity(
+                payload_id,
+                chunk_index,
+                offset,
+                body_slice.len(),
+                tag,
+            )
+            .with_context(|| {
+                format!("ChunkIntegrity build (payload_id={payload_id}, chunk_index={chunk_index})")
+            })?;
+            let heka_frame = hekadrop_proto::hekadrop_ext::HekaDropFrame {
+                version: crate::capabilities::ENVELOPE_VERSION,
+                payload: Some(hekadrop_proto::hekadrop_ext::heka_drop_frame::Payload::ChunkTag(ci)),
+            };
+            let pb = heka_frame.encode_to_vec();
+            let wrapped_bytes = frame::wrap_hekadrop_frame(&pb);
+            let enc_tag = ctx.encrypt(&wrapped_bytes)?;
+            frame::write_frame(socket, &enc_tag).await?;
+            // Index taşma koruması — i64 pratik olarak taşmaz ama defensive.
+            chunk_index = chunk_index
+                .checked_add(1)
+                .ok_or_else(|| anyhow!("chunk_index taştı (payload_id={payload_id})"))?;
+        }
         // SAFETY-CAST: `n` AsyncReadExt::read'den geliyor, max CHUNK_SIZE
         // (4 KiB) ile sınırlı; usize → i64 wrap pratik olarak imkânsız.
         // Defensive: try_from + unwrap_or yerine allow + comment yeterli.

--- a/crates/hekadrop-core/src/ukey2.rs
+++ b/crates/hekadrop-core/src/ukey2.rs
@@ -35,6 +35,12 @@ pub struct DerivedKeys {
     #[allow(dead_code)]
     pub auth_key: [u8; 32],
     pub pin_code: String,
+    /// UKEY2 derive `next_secret` — `SecureMessage` D2D anahtarlarının türetildiği
+    /// IKM. RFC-0003 §4.1: `chunk-HMAC` anahtarı bu değerden HKDF-SHA256 ile
+    /// türetilir (info = `"hekadrop chunk-hmac v1"`). Hem `client_handshake`
+    /// hem `process_client_finish` doldurur (her iki uçta aynı değer üretilir,
+    /// UKEY2 simetrik).
+    pub next_secret: [u8; 32],
 }
 
 /// Gönderici (client) rolünde tam UKEY2 handshake.
@@ -179,6 +185,7 @@ pub async fn client_handshake(socket: &mut TcpStream) -> Result<DerivedKeys> {
         recv_hmac_key: into_32(server_hmac),
         auth_key: into_32(auth_key),
         pin_code,
+        next_secret: into_32(next_secret),
     })
 }
 
@@ -464,6 +471,7 @@ pub fn process_client_finish(raw_frame: &[u8], state: &ServerInitResult) -> Resu
         send_hmac_key: into_32(server_hmac),
         auth_key: into_32(auth_key),
         pin_code,
+        next_secret: into_32(next_secret),
     })
 }
 


### PR DESCRIPTION
## Summary

`chunk_hmac` primitive (PR #104, perf PR #122) capability negotiation hazırdı (PR #114, #119) ama transfer pipeline'ına bağlı değildi — sender ChunkIntegrity emit etmiyor, receiver gelen tag'leri no-op + log ile geçiyordu. Bu PR storage corruption early-abort özelliğini ([RFC-0003 §1.2](../blob/main/docs/rfcs/0003-chunk-hmac.md#1-why-this-exists-one-paragraph)) HekaDrop↔HekaDrop transferlerde fiilen aktive ediyor.

### Spec atıfları
- [docs/protocol/chunk-hmac.md §2](../blob/main/docs/protocol/chunk-hmac.md#2-frame-placement-in-the-session-state-machine) — frame placement + ordering invariant
- [§3](../blob/main/docs/protocol/chunk-hmac.md#3-chunkintegrity-message--wire-layout) — `ChunkIntegrity` envelope wire layout
- [§4.1](../blob/main/docs/protocol/chunk-hmac.md#41-key-derivation-hkdf) — HKDF key derivation (`next_secret` IKM, `"hekadrop chunk-hmac v1"` info)
- [§5](../blob/main/docs/protocol/chunk-hmac.md#5-tag-verification-receiver-side) — verify order + privacy
- [§9](../blob/main/docs/protocol/chunk-hmac.md#9-failure-modes--recovery) — failure modes (cleanup + Disconnection)

### Sender akışı
1. Capabilities exchange'de `CHUNK_HMAC_V1` aktif çıktıysa: `next_secret` → HKDF → `chunk_hmac_key` türetilir.
2. `send_file_chunks` her `PayloadTransferFrame` body'sinden HEMEN SONRA `ChunkIntegrity` envelope (`HekaDropFrame.chunk_tag`) gönderir. `chunk_index` 0-tabanlı per-payload monoton sayaç. Boş terminator chunk'a tag emit edilmez (chunk-HMAC modunda son verify-edilmiş chunk completion sinyali).

### Receiver akışı
1. Capabilities exchange'de `CHUNK_HMAC_V1` aktif çıktıysa: `assembler.set_chunk_hmac_key(...)`.
2. `PayloadAssembler` her FILE chunk'ı diske yazmadan ÖNCE `pending_chunk` buffer'ına alır (`PendingChunk` struct).
3. `ChunkIntegrity` geldiğinde `verify_chunk_tag` → ok ise diske flush + `hasher.update` + `next_chunk_index++`. `last_chunk` flag varsa hemen finalize edip `CompletedPayload::File` döner.
4. **Failure path** (mismatch / out-of-order / capability-yokken-tag-geliş / `body_len` mismatch): `assembler.cancel(payload_id)` (`.part` silinir) + `Disconnection` (steady loop `?` ile yakalar).

### Key API değişiklikleri
- `ukey2::DerivedKeys`'e `next_secret: [u8; 32]` field eklendi.
- `PayloadAssembler::set_chunk_hmac_key(key)` + `chunk_hmac_enabled()` API.
- `PayloadAssembler::verify_chunk_tag(&ChunkIntegrity)` async fn — yeni public API.
- `connection::handle_hekadrop_frame` `assembler` + `keys` + `state` + `remote_name` + `ui` argümanları aldı (ChunkTag verify için gerekli).
- `connection::finalize_received_file` helper'ı çıkarıldı — regular path + verify path duplicate logic'i tek yerde.

## Test plan

- [x] Birim: `chunk_hmac.rs::tests` 24 test yeşil
- [x] **Yeni** `payload::tests`'e 4 RFC-0003 entegrasyon testi:
  * `chunk_hmac_happy_path_two_chunks_then_terminator` — happy path: 2 chunk dosya gönder, verify + flush + finalize, SHA-256 doğrula
  * `chunk_hmac_body_tampering_detected_and_part_removed` — receiver pending buffer'ı `tampered`, sender tag `original` için → mismatch + `.part` cleanup
  * `chunk_hmac_tag_without_capability_protocol_violation` — capability inactive iken `verify_chunk_tag` çağrılırsa → `ProtocolState` (spec §9 son satır)
  * `chunk_hmac_out_of_order_body_without_tag_rejected` — body N → body N+1 (tag N gelmeden) → `ordering violation` (spec §2)
- [x] `cargo test --workspace` — 227 + diğer suite'lar tüm yeşil
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo machete --with-metadata` clean
- [x] `typos` clean

### CLAUDE.md invariant scan

| Invariant | Sonuç |
|---|---|
| **I-1** core'da app-only modül ref | pass — `crate::platform/paths/ui/i18n` referansı yok; `finalize_received_file` arg-injected |
| **I-2** `#[allow]` scoped + yorumlu | pass — sender.rs `unused_assignments` allow'una INVARIANT yorumu eklendi |
| **I-3** `with_context` vs `map_err |_e:|` | pass — `map_err.*\|_e:` grep 0 hit; `with_context` + `ok_or_else` + `anyhow!` kullanıldı |
| **I-5** untrusted aritmetik checked | pass — `chunk_index`, `written` `checked_add`; `ChunkIntegrity` field'ları redundant binding kontrolüyle önceden compare |
| **I-6** hidden global state | pass — `chunk_hmac_key` `PayloadAssembler` field'ı (per-instance), `static`/`OnceLock` yok |

## Açık konular / follow-up

- **KAT vectors**: `docs/protocol/captures/chunk-hmac-kat-*.txt` hâlâ pending (RFC-0003 §10 open question). Bu PR runtime davranışı kuruyor, KAT corpus ayrı PR.
- **Bytes payload chunk-HMAC**: Şu an FILE payload'lar için aktif. Sharing-frame (Bytes) chunk-HMAC'i scope dışı (küçük frame'ler, defense-in-depth değeri düşük).
- **Empty terminator chunk**: chunk-HMAC modunda sender empty body terminator için tag emit etmiyor (boş body integrity koruması anlamsız). Receiver da empty body için verify beklemiyor; verify sonrası `last_chunk` flag finalize sinyali olarak yeterli.

🤖 Generated with [Claude Code](https://claude.com/claude-code)