### PR TITLE
chore(cleanup): post-merge audit yorumları (PR #120/#121/#122 medium)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,14 +16,14 @@ hekadrop-core    protocol engine — kripto, frame, UKEY2, secure, payload,
                    server, ui_port (trait + UiNotification enum). UI/i18n/
                    global-state YOK.
    ↑
-hekadrop-net     mDNS discovery + advertising. Core'a bağımlı değil; app
+hekadrop-net     mDNS discovery + advertising. Core buna bağımlı değil; app
                    tarafından orchestrate edilir.
    ↑
 hekadrop-cli     headless CLI binary stub.
    ↑
 hekadrop-app     binary + UI (tao/wry/tray-icon) + platform shims +
                    state singleton plumbing + i18n + UiPort/PlatformOps
-                   trait impl'leri (UiAdapter).
+                   trait impl'leri (UiAdapter / PlatformAdapter).
 ```
 
 App `pub use hekadrop_core::*` shim ile core sembollerini re-export eder; in-tree call site'lar (`crate::crypto::*`, `crate::error::*`) dokunulmadan derlenir.

--- a/crates/hekadrop-app/tests/mdns_discovery.rs
+++ b/crates/hekadrop-app/tests/mdns_discovery.rs
@@ -63,10 +63,6 @@ fn endpoint_info(device_name: &str, random: &[u8; 16]) -> Vec<u8> {
     // src/config.rs MAX_DEVICE_NAME_BYTES değeriyle birebir tutmalı.
     const MAX_DEVICE_NAME_BYTES: usize = 171;
 
-    let mut out = Vec::with_capacity(18 + device_name.len());
-    out.push(DEVICE_TYPE_COMPUTER << 1);
-    out.extend_from_slice(random);
-
     let bytes = device_name.as_bytes();
     let name_bytes = if bytes.len() <= MAX_DEVICE_NAME_BYTES {
         bytes
@@ -77,6 +73,11 @@ fn endpoint_info(device_name: &str, random: &[u8; 16]) -> Vec<u8> {
         }
         &bytes[..end]
     };
+    // Capacity hint kırpma sonrası gerçek boyutla — `device_name.len()`
+    // kullanmak 171 byte üstü inputlarda gereksiz büyük allocation yapardı.
+    let mut out = Vec::with_capacity(18 + name_bytes.len());
+    out.push(DEVICE_TYPE_COMPUTER << 1);
+    out.extend_from_slice(random);
     out.push(name_bytes.len() as u8);
     out.extend_from_slice(name_bytes);
     out

--- a/crates/hekadrop-core/src/chunk_hmac.rs
+++ b/crates/hekadrop-core/src/chunk_hmac.rs
@@ -110,7 +110,7 @@ pub fn compute_tag(
     chunk_index: i64,
     offset: i64,
     body: &[u8],
-) -> Result<[u8; 32], ChunkBuildError> {
+) -> Result<[u8; TAG_LEN], ChunkBuildError> {
     let prefix = encode_hmac_prefix(payload_id, chunk_index, offset, body.len())?;
 
     // INVARIANT: `Hmac::<Sha256>::new_from_slice` HMAC-SHA256 spec'i (RFC 2104)
@@ -122,11 +122,7 @@ pub fn compute_tag(
         .expect("HMAC-SHA256 her key uzunluğunu kabul eder");
     mac.update(&prefix);
     mac.update(body);
-    let result = mac.finalize().into_bytes();
-
-    let mut tag = [0u8; TAG_LEN];
-    tag.copy_from_slice(&result);
-    Ok(tag)
+    Ok(mac.finalize().into_bytes().into())
 }
 
 /// Receiver-side: peer'ın yolladığı [`ChunkIntegrity`] mesajını local


### PR DESCRIPTION
## Summary

5 post-merge medium yorum — küçük correctness/clarity:

| Yorum | Konu |
|---|---|
| CLAUDE.md:20 (#120) | "Core'a bağımlı değil" → "Core buna bağımlı değil" — dependency yönü |
| CLAUDE.md:26 (#120) | UiAdapter referansına PlatformAdapter eklendi |
| chunk_hmac.rs:113 (#122) | return type \`[u8; TAG_LEN]\` (magic 32 yerine sabit) |
| chunk_hmac.rs:125-129 (#122) | \`GenericArray\` manual copy → tek satır \`.into()\` |
| mdns_discovery.rs:66 (#121) | \`Vec::with_capacity\` kırpma sonrası gerçek boyutla |

## Defer

- sender.rs:208/298 (#119) \`active_caps\` → \`active_capabilities\` rename: PR #123 (chunk-HMAC pipeline integration) sender.rs'i geniş değiştirdiği için merge sonrası ayrı PR'a alındı (çakışma riski).

## Test plan

- [x] cargo test --workspace — yeşil (227+ test)
- [x] cargo clippy --workspace --all-targets --all-features -- -D warnings — temiz
- [x] cargo fmt --check — temiz

🤖 Generated with [Claude Code](https://claude.com/claude-code)