### PR TITLE
chore(lint): must_use_candidate enforce — 37 source #[must_use] + workspace.lints

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -211,6 +211,8 @@ hedefini karşılıyor. Aktif iş **RFC-0003** (chunk-HMAC + capabilities exchan
 ## Deferred strictness sweep'leri (PR #87 body'sinde liste)
 
 Workspace'a eklenmemiş ama eklenmeli lint'ler — ayrı PR serisi:
-`clippy::pedantic` (~1,228), `clippy::doc_markdown` (445+792), `unreachable_pub` (349), `uninlined_format_args` (auto-fix yapıldı, lint enable yok), `must_use_candidate` (71), `match_same_arms` (68), `cast_possible_wrap` (36 — security audit gerek), `items_after_statements` (33), `map_unwrap_or` (28), vs.
+`clippy::pedantic` (~1,228), `clippy::doc_markdown` (445+792), `unreachable_pub` (349), `uninlined_format_args` (auto-fix yapıldı, lint enable yok), `match_same_arms` (68), `cast_possible_wrap` (36 — security audit gerek), `items_after_statements` (33), `map_unwrap_or` (28), vs.
+
+Enforce edilenler (sweep history): `clippy::must_use_candidate` (37 source `#[must_use]` + proto module-level allow generated kod için).
 
 Refactor (RFC-0001) bittikten sonra strictness sweep'lere dön.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,13 +19,15 @@ homepage = "https://github.com/YatogamiRaito/HekaDrop"
 #
 # Kapsam dışı bırakılanlar (RED-tier — ayrı tracking issue'larla cleanup):
 #   * clippy::pedantic umbrella (~1,228 hit)        — issue #TBD
-#   * clippy::must_use_candidate (71 hand)          — issue #TBD
 #   * unused_crate_dependencies                     — false-pos cascade, atlandı
 #
 # v0.7.x ile enforce edilenler (önceki "RED" listesinden):
 #   * clippy::cast_possible_wrap (36)               — PR #101 audit + enforce
 #   * clippy::uninlined_format_args (auto-fix +110) — PR #105 enforce
 #   * unreachable_pub (workspace refactor sonrası 58 hit) — bu PR cleanup + enforce
+#   * clippy::must_use_candidate (37 source + 170 generated proto) —
+#     bu PR: source'larda #[must_use] ekleme + proto module-level allow
+#     (generated `as_str_name` / `from_str_name` enum helper'ları)
 #
 # Konsensus referans: Embark, uv, ruff. Top-tier (tokio/ripgrep/rustls/hyper)
 # minimal config tercih ediyor; biz crypto/protocol surface taşıyan bir desktop
@@ -82,6 +84,7 @@ trivially_copy_pass_by_ref = "warn"
 single_match_else = "warn"
 default_trait_access = "warn"
 large_enum_variant = "warn"
+must_use_candidate = "warn"     # API hijyeni: pure pub fn/method'lar `#[must_use]` ister; sonuç atılırsa caller bug. Bu PR: 37 source + proto generated module-level allow.
 
 [workspace.lints.rustdoc]
 broken_intra_doc_links = "deny"

--- a/crates/hekadrop-core/src/config.rs
+++ b/crates/hekadrop-core/src/config.rs
@@ -6,6 +6,7 @@ use sha2::{Digest, Sha256};
 const NEARBY_SHARING_MARKER: &[u8] = b"NearbySharing";
 
 /// `_<hex>._tcp.local.` — Quick Share mDNS servis tipi.
+#[must_use]
 pub fn service_type() -> String {
     let hash = Sha256::digest(NEARBY_SHARING_MARKER);
     format!("_{}._tcp.local.", hex::encode_upper(&hash[..6]))
@@ -15,6 +16,7 @@ pub fn service_type() -> String {
 // shim'di — `platform` app'a ait olduğu için core'a sığmadı. Tek call site
 // (`settings::resolved_device_name`) artık platform helper'ı doğrudan çağırıyor.
 
+#[must_use]
 pub fn random_endpoint_id() -> [u8; 4] {
     const ALPHABET: &[u8] = b"0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
     let mut rng = rand::thread_rng();
@@ -27,6 +29,7 @@ pub fn random_endpoint_id() -> [u8; 4] {
 
 /// mDNS instance name (10 bayt, URL-safe base64, paddingsiz).
 /// Yerleşim: [0x23, id×4, 0xFC, 0x9F, 0x5E, 0x00, 0x00]
+#[must_use]
 pub fn instance_name(endpoint_id: [u8; 4]) -> String {
     let mut bytes = [0u8; 10];
     bytes[0] = 0x23; // PCP
@@ -87,6 +90,7 @@ fn clamp_to_utf8_boundary(name: &str, max: usize) -> &[u8] {
 ///   `[17]`     ad uzunluğu (u8)
 ///   `[18..]`   UTF-8 cihaz adı (max [`MAX_DEVICE_NAME_BYTES`] bayt — bkz.
 ///              RFC 6763 §6.1 TXT record limit derivasyonu)
+#[must_use]
 pub fn endpoint_info(device_name: &str) -> Vec<u8> {
     let name_bytes = clamp_to_utf8_boundary(device_name, MAX_DEVICE_NAME_BYTES);
     let mut out = Vec::with_capacity(ENDPOINT_INFO_HEADER_LEN + name_bytes.len());
@@ -106,6 +110,7 @@ pub fn endpoint_info(device_name: &str) -> Vec<u8> {
     out
 }
 
+#[must_use]
 pub fn endpoint_info_b64(device_name: &str) -> String {
     URL_SAFE_NO_PAD.encode(endpoint_info(device_name))
 }

--- a/crates/hekadrop-core/src/crypto.rs
+++ b/crates/hekadrop-core/src/crypto.rs
@@ -13,6 +13,7 @@ type HmacSha256 = Hmac<Sha256>;
 type Aes256CbcEnc = Encryptor<Aes256>;
 type Aes256CbcDec = Decryptor<Aes256>;
 
+#[must_use]
 pub fn hkdf_sha256(ikm: &[u8], salt: &[u8], info: &[u8], len: usize) -> Vec<u8> {
     let hk = Hkdf::<Sha256>::new(Some(salt), ikm);
     let mut out = vec![0u8; len];
@@ -25,6 +26,7 @@ pub fn hkdf_sha256(ikm: &[u8], salt: &[u8], info: &[u8], len: usize) -> Vec<u8> 
     out
 }
 
+#[must_use]
 pub fn sha256(data: &[u8]) -> [u8; 32] {
     let mut hasher = Sha256::new();
     hasher.update(data);
@@ -39,6 +41,7 @@ pub fn sha256(data: &[u8]) -> [u8; 32] {
 ///   hash=0, mult=1
 ///   for b in key: hash = (hash + `b_signed` * mult) % 9973, mult = (mult * 31) % 9973
 ///   pin = abs(hash) 4 hane
+#[must_use]
 pub fn pin_code_from_auth_key(key: &[u8]) -> String {
     let mut hash: i64 = 0;
     let mut mult: i64 = 1;
@@ -65,11 +68,13 @@ pub fn pin_code_from_auth_key(key: &[u8]) -> String {
 /// (256-bit entropi) kullanıyoruz — brute-force mümkün değil, fingerprint
 /// sender + receiver log'larını handshake boyunca ilişkilendirmeye
 /// yeter ama zayıf PIN uzayını hedef almaz.
+#[must_use]
 pub fn session_fingerprint(auth_key: &[u8]) -> String {
     let digest = sha256(auth_key);
     hex::encode(&digest[..3]) // 6 hex karakter
 }
 
+#[must_use]
 pub fn hmac_sha256(key: &[u8], data: &[u8]) -> [u8; 32] {
     // INVARIANT: HMAC-SHA256 spec'i (RFC 2104) tüm key uzunluklarını kabul eder
     // (kısa key zero-pad'lenir, uzun key SHA-256'dan geçer). `new_from_slice`
@@ -85,6 +90,7 @@ pub fn hmac_sha256(key: &[u8], data: &[u8]) -> [u8; 32] {
     out
 }
 
+#[must_use]
 pub fn hmac_sha256_verify(key: &[u8], data: &[u8], tag: &[u8]) -> bool {
     // SECURITY: `ct_eq` eşit-olmayan slice'larda sessiz false döner. Erken ve
     // açık reddedip caller'ın bu durumu ayırt edebilmesini (ve log/metric'e
@@ -97,6 +103,7 @@ pub fn hmac_sha256_verify(key: &[u8], data: &[u8], tag: &[u8]) -> bool {
     computed.ct_eq(tag).into()
 }
 
+#[must_use]
 pub fn aes256_cbc_encrypt(key: &[u8; 32], iv: &[u8; 16], plaintext: &[u8]) -> Vec<u8> {
     Aes256CbcEnc::new(key.into(), iv.into()).encrypt_padded_vec_mut::<Pkcs7>(plaintext)
 }
@@ -110,6 +117,7 @@ pub fn aes256_cbc_decrypt(
 }
 
 /// D2D key derivation sonrası secure-message HMAC salt'ı: SHA256("SecureMessage").
+#[must_use]
 pub fn secure_message_salt() -> [u8; 32] {
     sha256(b"SecureMessage")
 }

--- a/crates/hekadrop-core/src/discovery_types.rs
+++ b/crates/hekadrop-core/src/discovery_types.rs
@@ -20,6 +20,7 @@ pub enum DeviceKind {
 }
 
 impl DeviceKind {
+    #[must_use]
     pub fn from_byte(b: u8) -> Self {
         match b {
             1 => Self::Phone,
@@ -52,6 +53,7 @@ pub struct DiscoveredDevice {
 }
 
 impl DiscoveredDevice {
+    #[must_use]
     pub fn kind(&self) -> DeviceKind {
         DeviceKind::from_byte(self.device_type)
     }

--- a/crates/hekadrop-core/src/file_size_guard.rs
+++ b/crates/hekadrop-core/src/file_size_guard.rs
@@ -40,6 +40,7 @@ pub enum FileSizeGuard {
 }
 
 /// Tek bir `FileMetadata.size` değerini sınıflandırır.
+#[must_use]
 pub fn classify_file_size(size: i64) -> FileSizeGuard {
     if size < 0 {
         FileSizeGuard::Clamped

--- a/crates/hekadrop-core/src/identity.rs
+++ b/crates/hekadrop-core/src/identity.rs
@@ -122,6 +122,7 @@ impl DeviceIdentity {
     /// Cihaz anahtarı değişmediği sürece stabil. Domain separation için
     /// HKDF-SHA256 kullanılır — aynı master key'den ileride başka child-key
     /// (signing, vb.) türetmek çakışmadan mümkün olur.
+    #[must_use]
     pub fn secret_id_hash(&self) -> [u8; 6] {
         let h = crate::crypto::hkdf_sha256(
             &self.long_term_key,
@@ -137,6 +138,7 @@ impl DeviceIdentity {
     /// İleride `signed_data` doğrulaması için ECDSA imza anahtarı türetir.
     /// v0.6'da kullanılmıyor; imza akışı v0.7 pairing protokolüyle gelecek.
     #[allow(dead_code)]
+    #[must_use]
     pub fn signing_key(&self) -> [u8; 32] {
         let h = crate::crypto::hkdf_sha256(
             &self.long_term_key,

--- a/crates/hekadrop-core/src/log_redact.rs
+++ b/crates/hekadrop-core/src/log_redact.rs
@@ -17,6 +17,7 @@ use std::path::Path;
 ///
 /// `/home/alice/Belgeler/secret.pdf` → `secret.pdf`.
 /// Yol sadece bir bileşense veya parse edilemezse "?" döner.
+#[must_use]
 pub fn path_basename(path: &Path) -> String {
     path.file_name()
         .map(|n| n.to_string_lossy().into_owned())
@@ -26,6 +27,7 @@ pub fn path_basename(path: &Path) -> String {
 /// SHA-256'nın ilk 16 hex karakterini (ilk 8 bayt) döndürür. Self-verification
 /// için yeterli, cross-user fingerprint için yetersiz. Giriş 16 karakterden
 /// kısaysa olduğu gibi döner.
+#[must_use]
 pub fn sha_short(sha_hex: &str) -> &str {
     if sha_hex.len() >= 16 {
         &sha_hex[..16]
@@ -39,6 +41,7 @@ pub fn sha_short(sha_hex: &str) -> &str {
 ///
 /// `https://example.com/a?token=xyz` → `https://example.com`.
 /// Şema veya host parse edilemezse `<unparsable>` döner.
+#[must_use]
 pub fn url_scheme_host(url: &str) -> String {
     let trimmed = url.trim();
     let Some((scheme, rest)) = trimmed.split_once("://") else {

--- a/crates/hekadrop-core/src/payload.rs
+++ b/crates/hekadrop-core/src/payload.rs
@@ -156,6 +156,7 @@ pub struct PayloadAssembler {
 }
 
 impl PayloadAssembler {
+    #[must_use]
     pub fn new() -> Self {
         Self::default()
     }

--- a/crates/hekadrop-core/src/secure.rs
+++ b/crates/hekadrop-core/src/secure.rs
@@ -28,6 +28,7 @@ pub struct SecureCtx {
 }
 
 impl SecureCtx {
+    #[must_use]
     pub fn from_keys(keys: &crate::ukey2::DerivedKeys) -> Self {
         Self {
             encrypt_key: keys.encrypt_key,
@@ -84,6 +85,7 @@ impl SecureCtx {
     }
 
     #[cfg(test)]
+    #[must_use]
     pub fn new_with_keys(
         encrypt_key: [u8; 32],
         decrypt_key: [u8; 32],

--- a/crates/hekadrop-core/src/settings.rs
+++ b/crates/hekadrop-core/src/settings.rs
@@ -75,6 +75,7 @@ impl LogLevel {
     /// `hekadrop` crate'i için seviye set edilir; directive'e dahil
     /// olmayan modüller (tokio/hyper vb.) `EnvFilter` default'una (warn)
     /// düşer.
+    #[must_use]
     pub fn filter_directive(self) -> &'static str {
         match self {
             Self::Error => "hekadrop=error",
@@ -86,6 +87,7 @@ impl LogLevel {
 
     /// UI / JSON için küçük harfli etiket — serde `rename_all = "lowercase"`
     /// ile aynı değer. IPC JSON parsing tarafında string karşılaştırması için.
+    #[must_use]
     pub fn as_str(self) -> &'static str {
         match self {
             Self::Error => "error",
@@ -97,6 +99,7 @@ impl LogLevel {
 
     /// UI'dan gelen serbest string değeri `LogLevel`'e çevirir; bilinmeyen
     /// değerler `Info` default'una düşer (invalid input'ta sessiz güven).
+    #[must_use]
     pub fn parse_or_default(raw: &str) -> Self {
         match raw.trim().to_ascii_lowercase().as_str() {
             "error" => Self::Error,
@@ -190,6 +193,7 @@ fn now_epoch() -> u64 {
 impl TrustedDevice {
     /// UI'da "Samsung A52 (a1b2c3d4)" şeklinde göstermek için kısa format.
     /// ID boşsa (legacy kayıt) sadece ad döner.
+    #[must_use]
     pub fn display(&self) -> String {
         if self.id.is_empty() {
             self.name.clone()
@@ -312,6 +316,7 @@ impl Settings {
     // by-value `*hash` deref talebi kod akışını bozar. 2 byte pass-by-ref overhead
     // kabul edilebilir; bu yöntem hot path değil (trust kontrolü, frame başına ≤1).
     #[allow(clippy::trivially_copy_pass_by_ref)]
+    #[must_use]
     pub fn is_trusted_by_hash(&self, hash: &[u8; 6]) -> bool {
         let now = now_epoch();
         let ttl = self.trust_ttl_secs;
@@ -327,6 +332,7 @@ impl Settings {
     /// olarak kullanılır. Üç sürüm sonra (v0.7'de) legacy yolu tamamen
     /// devre dışı kalacak. TTL bu yolda uygulanmaz — legacy kayıtlar zaten
     /// timestamp içermiyor, kullanıcı eski kararını kaybetmemeli.
+    #[must_use]
     pub fn is_trusted_legacy(&self, device_name: &str, id: &str) -> bool {
         if device_name.is_empty() {
             return false;
@@ -344,6 +350,7 @@ impl Settings {
     /// çalıştırır, TTL kontrolü yapmaz. Yeni kodun `is_trusted_by_hash`
     /// kullanması beklenir.
     #[allow(dead_code)]
+    #[must_use]
     pub fn is_trusted(&self, device_name: &str, id: &str) -> bool {
         self.is_trusted_legacy(device_name, id)
     }
@@ -514,6 +521,7 @@ impl Settings {
     /// yolu `push_trusted_to_ui` içindeki yapılandırılmış JSON'u tercih
     /// eder; bu fonksiyon legacy IPC çağrıları ve testler için korunur.
     #[allow(dead_code)]
+    #[must_use]
     pub fn trusted_display_list(&self) -> Vec<String> {
         self.trusted_devices.iter().map(|d| d.display()).collect()
     }
@@ -569,6 +577,7 @@ impl Settings {
     /// Convenience: hata olursa default dön + hata bilgisini de dışa ver.
     /// Caller `Option<LoadError>`'ı log'a basıp UI'a notification gönderir,
     /// `Corrupt` durumunda dosyayı [`backup_corrupt_file`] ile yedekler.
+    #[must_use]
     pub fn load_or_default(path: &Path) -> (Self, Option<LoadError>) {
         match Self::load(path) {
             Ok(s) => (s, None),

--- a/crates/hekadrop-core/src/state.rs
+++ b/crates/hekadrop-core/src/state.rs
@@ -454,6 +454,7 @@ impl RateLimiter {
     const WINDOW: Duration = Duration::from_secs(60);
     const MAX_PER_WINDOW: usize = 10;
 
+    #[must_use]
     pub fn new() -> Self {
         Self {
             windows: RwLock::new(HashMap::new()),

--- a/crates/hekadrop-core/src/stats.rs
+++ b/crates/hekadrop-core/src/stats.rs
@@ -69,6 +69,7 @@ impl Stats {
     }
 
     /// Convenience: hata olursa default + hata bilgisi.
+    #[must_use]
     pub fn load_or_default(path: &Path) -> (Self, Option<crate::settings::LoadError>) {
         match Self::load(path) {
             Ok(s) => (s, None),
@@ -121,6 +122,7 @@ impl Stats {
     }
 
     /// En büyük aktarım hacmine sahip RX cihazı (name, bytes).
+    #[must_use]
     pub fn top_rx_device(&self) -> Option<(String, u64)> {
         self.per_device_rx
             .iter()
@@ -128,6 +130,7 @@ impl Stats {
             .map(|(n, s)| (n.clone(), s.bytes))
     }
 
+    #[must_use]
     pub fn top_tx_device(&self) -> Option<(String, u64)> {
         self.per_device_tx
             .iter()

--- a/crates/hekadrop-proto/src/lib.rs
+++ b/crates/hekadrop-proto/src/lib.rs
@@ -20,7 +20,9 @@
 //!   `clippy::all` (prost-generated derive'lar), `unused_qualifications`
 //!   (prost fully-qualified path kullanır), `rustdoc::invalid_html_tags`
 //!   (proto comment'lardaki `<...>` benzeri token'lar), `dead_code`
-//!   (test'lerde kullanılmayan tipler için).
+//!   (test'lerde kullanılmayan tipler için), `clippy::must_use_candidate`
+//!   (prost-generated `as_str_name` / `from_str_name` enum helper'ları —
+//!   workspace-wide enforce'a dahil edildi, generated kod düzeltilemez).
 //!
 //! Daha iyi olası iyileştirme (yapılmadı, GH issue'da takip edilmeli):
 //! `prost-build` config'inde `.message_attribute()` ile generated kod'a
@@ -30,6 +32,7 @@
 #[allow(
     clippy::all,
     clippy::doc_markdown,
+    clippy::must_use_candidate,
     non_snake_case,
     non_camel_case_types,
     dead_code,
@@ -44,6 +47,7 @@ pub mod securegcm {
 #[allow(
     clippy::all,
     clippy::doc_markdown,
+    clippy::must_use_candidate,
     non_snake_case,
     non_camel_case_types,
     dead_code,
@@ -58,6 +62,7 @@ pub mod securemessage {
 #[allow(
     clippy::all,
     clippy::doc_markdown,
+    clippy::must_use_candidate,
     non_snake_case,
     non_camel_case_types,
     dead_code,
@@ -84,6 +89,7 @@ pub mod location {
 #[allow(
     clippy::all,
     clippy::doc_markdown,
+    clippy::must_use_candidate,
     non_snake_case,
     non_camel_case_types,
     dead_code,
@@ -110,6 +116,7 @@ pub mod sharing {
 #[allow(
     clippy::all,
     clippy::doc_markdown,
+    clippy::must_use_candidate,
     non_snake_case,
     non_camel_case_types,
     dead_code,


### PR DESCRIPTION
## Summary

Deferred strictness sweep listesinden `clippy::must_use_candidate` workspace.lints'e enforce edildi.

**Hit dağılımı:** 207 toplam = 37 source + 170 generated proto.

- **37 source hit** (`hekadrop-core`): item-level `#[must_use]` attribute eklendi. Tüm fonksiyonlar pure (yan etkisi yok) → `#[must_use]` semantik olarak doğru. Yan-etkili pub fn için `#[allow]`'a düşülmedi (gerek olmadı). Etkilenen dosyalar:
  - `config.rs` (4: `service_type`, `random_endpoint_id`, `instance_name`, `endpoint_info`, `endpoint_info_b64`)
  - `crypto.rs` (8: `hkdf_sha256`, `sha256`, `pin_code_from_auth_key`, `session_fingerprint`, `hmac_sha256`, `hmac_sha256_verify`, `aes256_cbc_encrypt`, `secure_message_salt`)
  - `identity.rs` (2), `payload.rs` (1), `secure.rs` (2), `state.rs` (1)
  - `stats.rs` (3), `settings.rs` (8), `log_redact.rs` (3)
  - `discovery_types.rs` (2), `file_size_guard.rs` (1)
- **170 generated hit** (`hekadrop-proto`): prost-üretilmiş `as_str_name` / `from_str_name` enum helper'ları. Generated kod düzeltilemez → her module-level `#[allow(...)]` listesine `clippy::must_use_candidate` eklendi (CLAUDE.md I-2 izni: tek istisna `hekadrop-proto` generated module attribute'ları).

**Lint config:** `Cargo.toml` `[workspace.lints.clippy]` bloğuna `must_use_candidate = "warn"` eklendi (CI `-D warnings` ile enforce).

**CLAUDE.md:** "Deferred strictness sweep'leri" listesinden `must_use_candidate` çıkarıldı, "Enforce edilenler (sweep history)" satırı eklendi.

## Test plan

- [x] `cargo fmt --all -- --check` — temiz
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — temiz (macOS lokal)
- [x] `cargo test --workspace` — 227+ pass, 0 fail
- [x] CLAUDE.md I-1/I-2/I-3 grep'leri — temiz
- [ ] CI cross-platform (Linux/Windows) — push sonrası gözle (CLAUDE.md "bilinen gap": platform-gated kod lokal kapsam dışı; cross-cutting lint enforce'ta 1 ekstra iterasyon beklenir)

🤖 Generated with [Claude Code](https://claude.com/claude-code)