### PR TITLE
docs(claude): match_same_arms sweep history'e taşı (stale liste sync)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -211,11 +211,12 @@ hedefini karşılıyor. Aktif iş **RFC-0003** (chunk-HMAC + capabilities exchan
 ## Deferred strictness sweep'leri (PR #87 body'sinde liste)
 
 Workspace'a eklenmemiş ama eklenmeli lint'ler — ayrı PR serisi:
-`clippy::pedantic` (~1,228), `clippy::doc_markdown` (445+792), `unreachable_pub` (349), `uninlined_format_args` (auto-fix yapıldı, lint enable yok), `match_same_arms` (68), `cast_possible_wrap` (36 — security audit gerek), vs.
+`clippy::pedantic` (~1,228), `clippy::doc_markdown` (445+792), `unreachable_pub` (349), `uninlined_format_args` (auto-fix yapıldı, lint enable yok), `cast_possible_wrap` (36 — security audit gerek), vs.
 
 Enforce edilenler (sweep history):
 - `clippy::must_use_candidate` (37 source `#[must_use]` + proto module-level allow generated kod için).
 - `clippy::items_after_statements` (7 site fix — const/use/inner-fn yukarı taşındı).
 - `clippy::map_unwrap_or` (13 site auto-fix — `.map(f).unwrap_or(d)` → `.map_or(d, f)`).
+- `clippy::match_same_arms` (Cargo.toml'da `warn`; kod auto-fix sonrası 0 hit; 4 item-level scoped allow yorumla — connection.rs `compute_recv_percent` doc-arm + i18n.rs translation tabloları forward-compat için).
 
 Refactor (RFC-0001) bittikten sonra strictness sweep'lere dön.


### PR DESCRIPTION
## Summary

CLAUDE.md "Deferred strictness sweep'leri" listesinde stale satır vardı: `match_same_arms (68)`. Aslında bu lint **Cargo.toml line 80'de zaten `warn` olarak enforce ediliyor** (PR #87 sırası, "i18n table + 2 dokümantasyon arm scoped allow ile" yorumuyla). Kod base auto-fix sonrası 0 hit; 4 item-level scoped allow yorumla mevcut:

- `crates/hekadrop-core/src/connection.rs:687` — `compute_recv_percent` doc-arm
- `crates/hekadrop-core/src/connection.rs:1595` — connection state branch doc
- `crates/hekadrop-app/src/i18n.rs:141` — translation tablosu forward-compat
- `crates/hekadrop-app/src/i18n.rs:348` — translation tablosu forward-compat

Bu PR sadece dokümantasyonu gerçekle senkronlar:
- "Deferred" listesinden `match_same_arms (68)` çıkarıldı.
- "Enforce edilenler (sweep history)" bölümüne `clippy::match_same_arms` satırı eklendi (mevcut allow yorumlarıyla birlikte).

## Hit sayısı

- `cargo clippy --workspace --all-targets --all-features -- -W clippy::match_same_arms` → **0 hit** (lint zaten aktif).
- Kod değişikliği yok; sadece CLAUDE.md (1 dosya, +2/-1).

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace` (tamamı geçti)
- [x] CLAUDE.md grep'leri (I-1/I-2/I-3) temiz

## Notlar

- **Cross-platform CI gap (CLAUDE.md "Bilinen gap"):** lint zaten enforce edildiği ve kod 0 hit verdiği için Linux/Windows-gated kodda da temiz olması beklenir; ek iterasyon gerekmez.
- **Auto-fix gerekmedi:** önceki sweep'te (PR #87 era) zaten temizlenmiş.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>