### PR TITLE
chore(lint): unreachable_pub sweep history'e taşı (zaten enforced)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -211,9 +211,11 @@ hedefini karşılıyor. Aktif iş **RFC-0003** (chunk-HMAC + capabilities exchan
 ## Deferred strictness sweep'leri (PR #87 body'sinde liste)
 
 Workspace'a eklenmemiş ama eklenmeli lint'ler — ayrı PR serisi:
-`clippy::pedantic` (~1,228), `clippy::doc_markdown` (445+792), `unreachable_pub` (349), `uninlined_format_args` (auto-fix yapıldı, lint enable yok), `cast_possible_wrap` (36 — security audit gerek), vs.
+`clippy::pedantic` (~1,228), `clippy::doc_markdown` (445+792), `cast_possible_wrap` (36 — security audit gerek), vs.
 
 Enforce edilenler (sweep history):
+- `unreachable_pub` (PR #107: RFC-0001 workspace refactor sonrası 349 → 58 → 0 hit; `pub` → `pub(crate)` indirgemesi + workspace.lints.rust enforce. Bugün 0 hit + 0 allow ile temiz).
+- `clippy::uninlined_format_args` (PR #87 auto-fix + sonradan biriken 110 site PR'da tekrar auto-fix + workspace.lints enforce).
 - `clippy::must_use_candidate` (37 source `#[must_use]` + proto module-level allow generated kod için).
 - `clippy::items_after_statements` (7 site fix — const/use/inner-fn yukarı taşındı).
 - `clippy::map_unwrap_or` (13 site auto-fix — `.map(f).unwrap_or(d)` → `.map_or(d, f)`).


### PR DESCRIPTION
## Özet

CLAUDE.md \"Deferred strictness sweep'leri\" listesindeki `unreachable_pub` (349 hit) satırını **history'e taşıdım** — lint zaten **PR #107**'de enforce edilmişti.

### Bulgular

`unreachable_pub` task talebi geldiğinde önce diff/state taraması:

1. **Workspace.lints.rust durumu:**
   ```toml
   [workspace.lints.rust]
   ...
   unreachable_pub = \"warn\"
   ```
   Cargo.toml'da yorumlu olarak: `\"PR #87'de 349 hit'tən refactor sonrası 58'e düştü; cleanup + enforce.\"`

2. **Mevcut hit sayısı:**
   ```
   cargo clean
   cargo clippy --workspace --all-targets --all-features -- -W unreachable_pub | grep -c unreachable_pub
   → 0
   ```

3. **Source-level allow var mı?**
   ```
   grep -rn '#\\[allow(unreachable_pub)\\]\\|#!\\[allow(unreachable_pub)\\]' crates/
   → 0
   ```

4. **`-D warnings` ile clippy:** temiz.

5. **Workspace test:** tüm crate'ler yeşil (227 + alt suite'ler).

Sonuç: `unreachable_pub` zaten 0 hit, 0 allow ile **tam enforced**. Yapılacak iş yok — sadece CLAUDE.md stale.

### Yan bulgu

`uninlined_format_args` da Cargo.toml `[workspace.lints.clippy]` bloğunda `warn` olarak enforced (yorumla: \"PR #87 auto-fix sonrası 110 yeni site birikmişti; auto-fix tekrar uygulandı + lint enforce\"), ama yine deferred listesinde duruyordu. O da history'e taşındı.

### Diff

CLAUDE.md tek dosya, 3 satır:
- Deferred listeden: `unreachable_pub (349)` ve `uninlined_format_args (auto-fix yapıldı, lint enable yok)` satırları çıkarıldı.
- History'e: iki yeni satır eklendi (PR referansı + ne yapıldığı + bugünkü durum).

## Test plan

- [x] cargo fmt --all -- --check → temiz
- [x] cargo clippy --workspace --all-targets --all-features -- -D warnings → temiz
- [x] cargo test --workspace → tüm suite'ler yeşil
- [x] CLAUDE.md I-1/I-2/I-3 grep'leri → temiz
- [ ] CI cross-platform (Linux + Windows) clippy → bekleniyor (kod değişikliği yok ama best-practice)

\U0001f916 Generated with [Claude Code](https://claude.com/claude-code)