### PR TITLE
feat(rfc-0004): PR-A — ResumeHint/ResumeReject proto schema spec compliance

### DIFF
--- a/crates/hekadrop-core/src/capabilities.rs
+++ b/crates/hekadrop-core/src/capabilities.rs
@@ -216,6 +216,120 @@ mod tests {
     }
 
     #[test]
+    fn resume_hint_protobuf_roundtrip() {
+        // RFC-0004 §3.2 + docs/protocol/resume.md §3 — 6 field spec.
+        // Wire'da henüz emit edilmiyor; bu test schema'nın spec'e
+        // hizalı encode/decode ettiğini sabitler (PR-B'de emit/parse
+        // implementasyonu eklenince regression detector görevi).
+        use hekadrop_proto::hekadrop_ext::ResumeHint;
+
+        let original = ResumeHint {
+            session_id: 0x0123_4567_89AB_CDEF_i64,
+            payload_id: 42,
+            offset: 1_048_576,
+            partial_hash: vec![0xAA; 32].into(),
+            capabilities_version: 1,
+            last_chunk_tag: vec![0xBB; 32].into(),
+        };
+        let bytes = original.encode_to_vec();
+        let decoded = ResumeHint::decode(&*bytes).expect("valid wire encoding");
+        assert_eq!(decoded.session_id, original.session_id);
+        assert_eq!(decoded.payload_id, original.payload_id);
+        assert_eq!(decoded.offset, original.offset);
+        assert_eq!(decoded.partial_hash, original.partial_hash);
+        assert_eq!(decoded.capabilities_version, original.capabilities_version);
+        assert_eq!(decoded.last_chunk_tag, original.last_chunk_tag);
+    }
+
+    #[test]
+    fn resume_reject_all_reasons_roundtrip() {
+        // RFC-0004 §3.2 + docs/protocol/resume.md §3 — 7 reason variant.
+        // Tüm enum değerlerinin encode + decode round-trip'i korunduğunu
+        // sabitler (proto3 unknown variant fallback hata kaynağı olabilir).
+        use hekadrop_proto::hekadrop_ext::resume_reject::Reason;
+        use hekadrop_proto::hekadrop_ext::ResumeReject;
+
+        let reasons = [
+            Reason::Unspecified,
+            Reason::HashMismatch,
+            Reason::InvalidOffset,
+            Reason::VersionMismatch,
+            Reason::PayloadUnknown,
+            Reason::SessionMismatch,
+            Reason::InternalError,
+        ];
+        for r in reasons {
+            let original = ResumeReject {
+                payload_id: 7,
+                reason: i32::from(r),
+            };
+            let bytes = original.encode_to_vec();
+            let decoded = ResumeReject::decode(&*bytes).expect("valid wire encoding");
+            assert_eq!(decoded.payload_id, original.payload_id);
+            assert_eq!(decoded.reason, original.reason);
+            assert_eq!(Reason::try_from(decoded.reason).expect("known variant"), r);
+        }
+    }
+
+    #[test]
+    fn resume_hint_envelope_oneof_slot_12() {
+        // HekaDropFrame.payload oneof slot 12 = resume_hint (capabilities.md
+        // §3.1 slot policy). Dispatch'in doğru variant'ı seçtiğini sabitler.
+        use hekadrop_proto::hekadrop_ext::heka_drop_frame::Payload;
+        use hekadrop_proto::hekadrop_ext::ResumeHint;
+
+        let hint = ResumeHint {
+            session_id: 1,
+            payload_id: 2,
+            offset: 3,
+            partial_hash: vec![0; 32].into(),
+            capabilities_version: 1,
+            last_chunk_tag: vec![0; 32].into(),
+        };
+        let frame = HekaDropFrame {
+            version: ENVELOPE_VERSION,
+            payload: Some(Payload::ResumeHint(hint.clone())),
+        };
+        let bytes = frame.encode_to_vec();
+        let decoded = HekaDropFrame::decode(&*bytes).expect("valid wire encoding");
+        match decoded.payload {
+            Some(Payload::ResumeHint(h)) => {
+                assert_eq!(h.session_id, hint.session_id);
+                assert_eq!(h.payload_id, hint.payload_id);
+                assert_eq!(h.offset, hint.offset);
+            }
+            other => panic!("beklenen oneof slot 12 (resume_hint), bulundu: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resume_reject_envelope_oneof_slot_13() {
+        // HekaDropFrame.payload oneof slot 13 = resume_reject (capabilities.md
+        // §3.1 slot policy). Dispatch'in doğru variant'ı seçtiğini sabitler.
+        use hekadrop_proto::hekadrop_ext::heka_drop_frame::Payload;
+        use hekadrop_proto::hekadrop_ext::resume_reject::Reason;
+        use hekadrop_proto::hekadrop_ext::ResumeReject;
+
+        let reject = ResumeReject {
+            payload_id: 99,
+            reason: i32::from(Reason::SessionMismatch),
+        };
+        let frame = HekaDropFrame {
+            version: ENVELOPE_VERSION,
+            payload: Some(Payload::ResumeReject(reject)),
+        };
+        let bytes = frame.encode_to_vec();
+        let decoded = HekaDropFrame::decode(&*bytes).expect("valid wire encoding");
+        match decoded.payload {
+            Some(Payload::ResumeReject(r)) => {
+                assert_eq!(r.payload_id, reject.payload_id);
+                assert_eq!(r.reason, reject.reason);
+            }
+            other => panic!("beklenen oneof slot 13 (resume_reject), bulundu: {other:?}"),
+        }
+    }
+
+    #[test]
     fn all_supported_only_has_implemented_features() {
         // PR #103 review (Copilot): ALL_SUPPORTED yalnızca implementasyonu
         // hazır feature'ları içerir. RFC-0004 (RESUME_V1) ve RFC-0005

--- a/crates/hekadrop-core/src/connection.rs
+++ b/crates/hekadrop-core/src/connection.rs
@@ -1235,14 +1235,20 @@ async fn handle_hekadrop_frame(
                 }
             }
         }
-        // Forward-compat: ResumeHint/ResumeReject (RFC-0004) +
-        // FolderMft (RFC-0005) henüz implement edilmedi; placeholder
-        // varyantları log + skip ile drop'sızca geçilir.
-        Payload::ResumeHint(_) | Payload::ResumeReject(_) | Payload::FolderMft(_) => {
-            debug!(
-                "[{}] HekaDropFrame.Payload: v0.8.1+ varyantı — şu an stub, skip",
-                peer
-            );
+        // Forward-compat stub'ları RFC-bazında ayrı arm'lar — her birinin
+        // tam implementasyonu ayrı PR serisinde gelecek (RFC-0004 PR-B+,
+        // RFC-0005). Şimdilik sessizce drop, ama ayrı log satırlarıyla
+        // dispatch path'i debugging'de net görünür.
+        Payload::ResumeHint(_hint) => {
+            debug!("[{}] ResumeHint frame received (RFC-0004 stub)", peer);
+            Ok(())
+        }
+        Payload::ResumeReject(_reject) => {
+            debug!("[{}] ResumeReject frame received (RFC-0004 stub)", peer);
+            Ok(())
+        }
+        Payload::FolderMft(_mft) => {
+            debug!("[{}] FolderMft frame received (RFC-0005 stub)", peer);
             Ok(())
         }
     }

--- a/crates/hekadrop-proto/proto/hekadrop_extensions.proto
+++ b/crates/hekadrop-proto/proto/hekadrop_extensions.proto
@@ -61,30 +61,39 @@ message ChunkIntegrity {
   bytes  tag         = 5;     // HMAC-SHA256 = 32 bytes; başka uzunluk reject
 }
 
-// Transfer resume hint (RFC 0004 placeholder).
+// Transfer resume hint (RFC 0004).
 //
 // Receiver, Introduction frame'inde tanıdığı bir payload_id görüp
 // `~/.hekadrop/partial/<session_id>_<payload_id>.meta` ile eşleşen
 // partial dosyası varsa bu mesajla sender'a "şuradan devam" ipucu verir.
 //
-// **v0.8.0'da boş placeholder.** Tam tanım v0.8.1 implementation'ında
-// `docs/protocol/resume.md` byte-exact spec'inden indirilecek.
+// Wire-byte-exact spec: `docs/protocol/resume.md` §3.
+// Normative RFC:        `docs/rfcs/0004-transfer-resume.md` §3.2.
+//
+// `session_id` UKEY2 auth_key SHA-256[0..8] big-endian; sender bu değeri
+// kendi session'ı ile karşılaştırır, eşleşmezse `ResumeReject{
+// SESSION_MISMATCH }` döner.
 message ResumeHint {
-  int64  payload_id          = 1;
-  int64  offset              = 2;
-  bytes  partial_hash        = 3;   // SHA-256(bytes[0..offset])
-  bytes  last_chunk_tag      = 4;   // RFC-0003 fast-path (32 bytes)
+  int64  session_id           = 1;  // UKEY2 auth_key SHA-256[0..8] BE
+  int64  payload_id           = 2;
+  int64  offset               = 3;
+  bytes  partial_hash         = 4;  // SHA-256(bytes[0..offset])
   uint32 capabilities_version = 5;  // peer Capabilities.version mirror
+  bytes  last_chunk_tag       = 6;  // RFC-0003 fast-path (32 bytes)
 }
 
 // Resume reject reasons (RFC 0004).
+//
+// Wire-byte-exact spec: `docs/protocol/resume.md` §3.
 message ResumeReject {
   enum Reason {
-    UNKNOWN          = 0;
-    HASH_MISMATCH    = 1;
-    TTL_EXPIRED      = 2;
-    VERSION_MISMATCH = 3;
-    DISK_BUDGET      = 4;
+    REASON_UNSPECIFIED = 0;
+    HASH_MISMATCH      = 1;
+    INVALID_OFFSET     = 2;
+    VERSION_MISMATCH   = 3;
+    PAYLOAD_UNKNOWN    = 4;
+    SESSION_MISMATCH   = 5;
+    INTERNAL_ERROR     = 6;
   }
   int64  payload_id = 1;
   Reason reason     = 2;


### PR DESCRIPTION
## Özet

RFC-0004 6-PR serisinin başlangıç adımı (PR-A): `hekadrop_extensions.proto` içindeki `ResumeHint` ve `ResumeReject` placeholder tipleri RFC-0004 §3.2 + `docs/protocol/resume.md` §3 normative spec'ine hizalandı. Wire'da henüz emit edilmedikleri için **breaking change yok** — şu noktada hizalamak v0.8.1 implementasyon fazında (PR-B+) wire format sürprizini önler.

## Spec atıfları

- **RFC:** `docs/rfcs/0004-transfer-resume.md` §3.2 (ResumeHint/ResumeReject şeması)
- **Wire-byte spec:** `docs/protocol/resume.md` §3 (alan numaralandırması + enum değerleri)

## Schema değişiklikleri

### `ResumeHint` — 5 → 6 field

| Field | Eski tag | Yeni tag | Not |
|---|---|---|---|
| `session_id` | — | **1 (yeni)** | UKEY2 auth_key SHA-256[0..8] BE; PR-B'de SESSION_MISMATCH detection için kritik |
| `payload_id` | 1 | 2 | renumbered |
| `offset` | 2 | 3 | renumbered |
| `partial_hash` | 3 | 4 | renumbered |
| `capabilities_version` | 5 | 5 | sabit |
| `last_chunk_tag` | 4 | 6 | renumbered (sona alındı) |

### `ResumeReject.Reason` — 5 → 7 variant

| Eski | Yeni |
|---|---|
| UNKNOWN | REASON_UNSPECIFIED |
| HASH_MISMATCH | HASH_MISMATCH (sabit) |
| TTL_EXPIRED | INVALID_OFFSET |
| VERSION_MISMATCH | VERSION_MISMATCH (sabit) |
| DISK_BUDGET | PAYLOAD_UNKNOWN |
| — | SESSION_MISMATCH |
| — | INTERNAL_ERROR |

## Handler dispatch ayrımı

`connection.rs::handle_hekadrop_frame` içindeki birleşik
`Payload::ResumeHint | ResumeReject | FolderMft => debug! + Ok(())` arm'ı 3 ayrı arm'a bölündü. Her biri RFC-bazlı debug log + no-op kaldı (PR-B+ ile gerçek implementasyon). Bu, dispatch path'i debugging/tracing'de net görünür kılar — hangi mesaj tipinin alındığı log satırlarından okunur.

## Test plan

`crates/hekadrop-core/src/capabilities.rs` test modülüne 4 yeni test:

- [x] `resume_hint_protobuf_roundtrip` — 6 field encode + decode + field-by-field eşitlik
- [x] `resume_reject_all_reasons_roundtrip` — 7 reason variant'ın encode/decode + `Reason::try_from` validation
- [x] `resume_hint_envelope_oneof_slot_12` — `HekaDropFrame{resume_hint=...}` slot 12 dispatch
- [x] `resume_reject_envelope_oneof_slot_13` — `HekaDropFrame{resume_reject=...}` slot 13 dispatch

## Pre-commit

- [x] `cargo fmt --all -- --check` — temiz
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — temiz
- [x] `cargo test --workspace` — tüm testler yeşil (4 yeni test geçer)
- [x] `cargo machete --with-metadata` — temiz
- [x] `typos` — temiz

## CLAUDE.md uyumu

- [x] I-1 (R2): core'da app-only modül referansı yok
- [x] I-2: yeni `#[allow]` eklenmedi (ne crate-level ne item-level)
- [x] I-3: `map_err(|_e| ...)` bypass yok

## Sıradaki

PR-B (resume primitives modülü, ~300 satır + 8 test) bu PR merge olduktan sonra gelecek.

🤖 Generated with [Claude Code](https://claude.com/claude-code)