### PR TITLE
fix(rfc-0004): critical/high audit yorumları — capability gate + RESUME_V1 rollback

### DIFF
--- a/crates/hekadrop-core/src/capabilities.rs
+++ b/crates/hekadrop-core/src/capabilities.rs
@@ -43,9 +43,17 @@ pub mod features {
     ///
     /// `RESUME_V1` (RFC-0004) PR-A→PR-F zinciriyle merge oldu (proto schema +
     /// `resume.rs` primitives + receiver `.meta` persist + `ResumeHint` emit
-    /// + sender `wait_for_resume_hint_or_zero` verify + cleanup sweep) →
-    ///   PR-F'de bit `ALL_SUPPORTED`'a geri eklendi.
-    pub const ALL_SUPPORTED: u64 = CHUNK_HMAC_V1 | RESUME_V1;
+    /// + sender `wait_for_resume_hint_or_zero` verify + cleanup sweep).
+    ///
+    /// **PR #136 Gemini high yorumu sonrası geri kapatıldı:** envelope/sender/
+    /// receiver state machine'i hazır ama `PayloadAssembler::ingest_file`
+    /// dosyayı `OpenOptions::truncate(true)` ile her zaman sıfırlıyor
+    /// (`payload.rs:561`). Resume aktifken receiver `.part`'ı silip baştan
+    /// yazıyor → veri kaybı / korruption. Receiver append/seek orchestration
+    /// tamamlanana kadar bit advertise EDİLMEZ; sender + receiver state
+    /// machine kodu hazır kalır (envelope dispatch'i + opsiyonel resume hint
+    /// path testleri etkilenmez, capability gate'i kapalı).
+    pub const ALL_SUPPORTED: u64 = CHUNK_HMAC_V1;
 
     /// Bu build için reserved (henüz hiçbir RFC'nin sahip olmadığı) bit'ler.
     /// Test'lerde forward-compat akışını doğrulamak için kullanılır.
@@ -368,14 +376,13 @@ mod tests {
     #[test]
     fn all_supported_only_has_implemented_features() {
         // PR #103 review (Copilot): ALL_SUPPORTED yalnızca implementasyonu
-        // hazır feature'ları içerir. RFC-0004 (RESUME_V1) PR-F ile aktif edildi;
-        // RFC-0005 (FOLDER_STREAM_V1) hâlâ unimplemented → advertise edilmez.
-        assert_eq!(
-            features::ALL_SUPPORTED,
-            features::CHUNK_HMAC_V1 | features::RESUME_V1
-        );
+        // hazır feature'ları içerir. RFC-0004 (RESUME_V1) PR-F'de açıldı,
+        // **PR #136 high yorumu sonrası geri kapatıldı** (receiver
+        // truncate(true) → resume body sıfırlama riski). RFC-0005
+        // (FOLDER_STREAM_V1) hâlâ unimplemented → advertise edilmez.
+        assert_eq!(features::ALL_SUPPORTED, features::CHUNK_HMAC_V1);
         assert_ne!(features::ALL_SUPPORTED & features::CHUNK_HMAC_V1, 0);
-        assert_ne!(features::ALL_SUPPORTED & features::RESUME_V1, 0);
+        assert_eq!(features::ALL_SUPPORTED & features::RESUME_V1, 0);
         assert_eq!(features::ALL_SUPPORTED & features::FOLDER_STREAM_V1, 0);
     }
 }

--- a/crates/hekadrop-core/src/frame.rs
+++ b/crates/hekadrop-core/src/frame.rs
@@ -245,13 +245,11 @@ mod dispatcher_tests {
                 if let Some(Payload::Capabilities(c)) = frame.payload {
                     assert_eq!(c.features, 0x07);
                     let active = ActiveCapabilities::negotiate(features::ALL_SUPPORTED, c.features);
-                    // PR-F: ALL_SUPPORTED = CHUNK_HMAC_V1 | RESUME_V1 (RFC-0004
-                    // implementasyonu tamamlandı). Peer 0x07 (RESUME + FOLDER +
-                    // CHUNK) advertise etse de intersection sadece bizim build'imizin
-                    // bildiği bit'leri tutar — FOLDER_STREAM_V1 (RFC-0005) hâlâ
-                    // implementasyonsuz olduğundan forward-compat ile düşer.
+                    // PR #136 high sonrası RESUME_V1 ALL_SUPPORTED'dan çıktı
+                    // (receiver truncate(true) bug'ı). Şu an sadece CHUNK_HMAC_V1
+                    // aktif — peer 0x07 advertise etse bile intersection ona iner.
                     assert!(active.has(features::CHUNK_HMAC_V1));
-                    assert!(active.has(features::RESUME_V1));
+                    assert!(!active.has(features::RESUME_V1));
                     assert!(!active.has(features::FOLDER_STREAM_V1));
                 } else {
                     panic!("capabilities oneof beklendi");

--- a/crates/hekadrop-core/src/negotiation.rs
+++ b/crates/hekadrop-core/src/negotiation.rs
@@ -211,9 +211,9 @@ mod tests {
         assert_eq!(client_active.raw(), features::ALL_SUPPORTED);
         assert_eq!(server_active.raw(), features::ALL_SUPPORTED);
         assert!(client_active.has(features::CHUNK_HMAC_V1));
-        // PR-F: ALL_SUPPORTED = CHUNK_HMAC_V1 | RESUME_V1 (RFC-0004 tamam).
-        // FOLDER_STREAM_V1 (RFC-0005) hâlâ implementasyonsuz → advertise yok.
-        assert!(client_active.has(features::RESUME_V1));
+        // PR #136 high sonrası RESUME_V1 ALL_SUPPORTED'dan çıktı (receiver
+        // truncate(true) bug'ı). FOLDER_STREAM_V1 (RFC-0005) hâlâ implementasyonsuz.
+        assert!(!client_active.has(features::RESUME_V1));
         assert!(!client_active.has(features::FOLDER_STREAM_V1));
         assert!(!client_active.is_legacy());
         // Genuine HekaDrop path'inde leftover olmamalı.

--- a/crates/hekadrop-core/src/sender.rs
+++ b/crates/hekadrop-core/src/sender.rs
@@ -390,16 +390,25 @@ pub async fn send(req: SendRequest, state: Arc<AppState>) -> Result<()> {
                                 "[sender] gönderiliyor: {} ({} bayt) payload_id={}",
                                 plan.name, plan.size, plan.payload_id
                             );
-                            let start_offset = wait_for_resume_hint_or_zero(
-                                &mut socket,
-                                &mut ctx,
-                                plan,
-                                our_session_id,
-                                &known_payload_ids,
-                                chunk_hmac_key.as_ref(),
-                                RESUME_HINT_TIMEOUT,
-                            )
-                            .await;
+                            // PR #134 Gemini critical: capability gate ile sar.
+                            // RESUME_V1 inactive ise (legacy peer) `wait_for_resume_hint_or_zero`
+                            // 2 sn timeout bekliyor ve N dosyada N×2sn perf kaybı yaratıyordu.
+                            let start_offset = if active_capabilities
+                                .has(crate::capabilities::features::RESUME_V1)
+                            {
+                                wait_for_resume_hint_or_zero(
+                                    &mut socket,
+                                    &mut ctx,
+                                    plan,
+                                    our_session_id,
+                                    &known_payload_ids,
+                                    chunk_hmac_key.as_ref(),
+                                    RESUME_HINT_TIMEOUT,
+                                )
+                                .await
+                            } else {
+                                0
+                            };
                             send_file_chunks(
                                 &mut socket,
                                 &mut ctx,


### PR DESCRIPTION
## Summary

RFC-0004 zinciri (PR #131-136) sonrası AI review audit'inde tespit edilen 2 critical + 1 high finding'i ele alır.

## Kritik bug'lar

### 1. PR #134 sender.rs:401 — capability gate eksik (critical)

`wait_for_resume_hint_or_zero` her dosya döngüsünde capability check'siz çağrılıyordu. Legacy peer'lara N×2 sn gereksiz timeout. Fix: \`active_capabilities.has(RESUME_V1)\` koşulu, false ise \`start_offset=0\`.

### 2. PR #136 capabilities.rs:48 — \`RESUME_V1\` ALL_SUPPORTED → rollback (high)

\`PayloadAssembler::ingest_file\` \`OpenOptions::truncate(true)\` ile dosyayı her zaman sıfırlıyor (\`payload.rs:561\`). RESUME_V1 aktifken receiver \`.part\`'ı silip baştan yazıyor → veri kaybı / korruption riski.

**Defensif:** Capability bit'i \`ALL_SUPPORTED\`'dan geri çıkar; sender + receiver state machine kodu hazır kalır. Receiver append/seek orchestration follow-up PR'da entegre edilecek.

## Etkilenen testler (rollback)

- \`capabilities.rs::all_supported_only_has_implemented_features\`
- \`frame.rs::capabilities_kat_all_features_dispatch\`
- \`negotiation.rs::loopback_negotiate_all_features_active\`

## Diğer audit yorumları (follow-up)

11 medium yorum kalanı (caching, in_use_size budget, sequential hint window, etc.) ayrı PR'larda ele alınacak.

## Test plan

- [x] cargo test --workspace — tüm paketler yeşil
- [x] cargo clippy --workspace --all-targets --all-features -- -D warnings — temiz
- [x] cargo fmt --check — temiz

🤖 Generated with [Claude Code](https://claude.com/claude-code)