### PR TITLE
feat(rfc-0004): PR-G — receiver .part append/seek + RESUME_V1 re-enable

### DIFF
--- a/crates/hekadrop-app/tests/resume_e2e.rs
+++ b/crates/hekadrop-app/tests/resume_e2e.rs
@@ -847,6 +847,282 @@ async fn e2e_resume_chunk_hmac_fastpath_tag_persisted_in_meta() {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// PR-G — Receiver `.part` append/seek davranış testleri
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Test PR-G #1 — Resume `.part`'ı silmemeli, append moduna geçmeli.
+///
+/// 1. Fresh transfer 2 chunk yaz (cancel etmeden sink drop ile `BufWriter` flush).
+/// 2. İkinci `PayloadAssembler` instance — `enable_resume_with_offset` ile
+///    `received_bytes = 2 * chunk_len` set, ek 2 chunk gönder.
+/// 3. Final dosya tam 4 chunk değerinde olmalı; ilk 2 chunk korunmalı,
+///    son 2 chunk eklenmiş olmalı (içerik bit-bit eşit).
+///
+/// Spec gerekçesi: PR #136 / PR #137'de yakalanan bug — `truncate(true)` ile
+/// resume açılışı `.part`'ın ilk N byte'ını sıfırlıyordu. PR-G
+/// `truncate(false)` + `seek` ile düzeltir.
+#[tokio::test]
+async fn e2e_pr_g_receiver_append_preserves_existing_part() {
+    let _home = TempHome::new();
+
+    let auth_key = [0xA1u8; 32];
+    let session_id = session_id_i64(&auth_key);
+    let payload_id: i64 = 0xABCD_0010;
+    let peer_endpoint = "PEER-G1".to_string();
+    let file_name = "g1.bin".to_string();
+
+    // Fresh chunk (0xCC) ve resume chunk (0xDD) — birbirinden ayırt edilebilir.
+    let fresh_chunk = vec![0xCCu8; 64];
+    let resume_chunk = vec![0xDDu8; 64];
+    let total_chunks: i64 = 4;
+    let chunk_len = fresh_chunk.len() as i64;
+    let total_size = chunk_len * total_chunks;
+
+    let dest = std::env::temp_dir().join(unique_label("g1-dest"));
+    let _ = std::fs::remove_file(&dest);
+    // Placeholder yarat — `unique_downloads_path` davranışını taklit
+    // (PR-G `truncate(false)` resume açılışı `.part` mevcut bekler).
+    std::fs::write(&dest, b"").unwrap();
+
+    let key = derive_chunk_hmac_key(&[0x01u8; 32]);
+
+    // Session 1 — 2 chunk fresh yaz.
+    {
+        let mut asm = PayloadAssembler::new();
+        asm.set_chunk_hmac_key(key);
+        asm.register_file_destination(payload_id, dest.clone())
+            .unwrap();
+        asm.enable_resume(
+            payload_id,
+            session_id,
+            peer_endpoint.clone(),
+            file_name.clone(),
+        )
+        .unwrap();
+        let mut offset: i64 = 0;
+        for i in 0..2_i64 {
+            let f = make_chunk_frame(payload_id, &fresh_chunk, false, total_size, offset);
+            asm.ingest(&f).await.unwrap();
+            let tag = compute_tag(&key, payload_id, i, offset, &fresh_chunk).unwrap();
+            let ci = build_chunk_integrity(payload_id, i, offset, fresh_chunk.len(), tag).unwrap();
+            asm.verify_chunk_tag(&ci).await.unwrap();
+            offset += chunk_len;
+        }
+        drop(asm); // BufWriter::drop → flush
+    }
+
+    // Session 1 sonrası dosya boyutu tam 2 chunk; içerik 0xCC.
+    let mid_bytes = std::fs::read(&dest).unwrap();
+    assert_eq!(
+        mid_bytes.len() as i64,
+        2 * chunk_len,
+        "session 1 sonrası 2 chunk yazılmış olmalı"
+    );
+    assert!(
+        mid_bytes.iter().all(|&b| b == 0xCC),
+        "fresh chunk içerikleri 0xCC olmalı"
+    );
+
+    // Session 2 — RESUME path. enable_resume_with_offset(received_bytes=2*chunk).
+    {
+        let mut asm = PayloadAssembler::new();
+        asm.set_chunk_hmac_key(key);
+        asm.register_file_destination(payload_id, dest.clone())
+            .unwrap();
+        asm.enable_resume_with_offset(
+            payload_id,
+            session_id,
+            peer_endpoint.clone(),
+            file_name.clone(),
+            2 * chunk_len,
+            2, // next_chunk_index — 2 chunk verified, sender chunk_index=2'den devam
+            String::new(),
+        )
+        .unwrap();
+        // Sender resume sonrası chunk_index = 2'den devam eder; ilk gelen
+        // chunk offset = 2 * chunk_len.
+        let mut offset: i64 = 2 * chunk_len;
+        for i in 2_i64..4_i64 {
+            let last = i == 3;
+            let f = make_chunk_frame(payload_id, &resume_chunk, last, total_size, offset);
+            asm.ingest(&f).await.unwrap();
+            let tag = compute_tag(&key, payload_id, i, offset, &resume_chunk).unwrap();
+            let ci = build_chunk_integrity(payload_id, i, offset, resume_chunk.len(), tag).unwrap();
+            asm.verify_chunk_tag(&ci).await.unwrap();
+            offset += chunk_len;
+        }
+    }
+
+    // Final dosya 4 chunk; ilk 2 chunk = 0xCC (korunmuş), son 2 chunk = 0xDD.
+    let final_bytes = std::fs::read(&dest).unwrap();
+    assert_eq!(
+        final_bytes.len() as i64,
+        total_size,
+        "PR-G: resume sonrası dosya total_size'a ulaşmalı"
+    );
+    let half = (2 * chunk_len) as usize;
+    assert!(
+        final_bytes[..half].iter().all(|&b| b == 0xCC),
+        "ilk yarı korunmalı (0xCC) — truncate(false) çalıştı"
+    );
+    assert!(
+        final_bytes[half..].iter().all(|&b| b == 0xDD),
+        "ikinci yarı yeni eklenen 0xDD olmalı"
+    );
+
+    let _ = std::fs::remove_file(&dest);
+}
+
+/// Test PR-G #2 — `seek_to_received_bytes` doğru offset'e yazıyor.
+///
+/// `pending_resume.received_bytes = chunk_len` ile resume aktif edilir; ilk
+/// chunk gelir; `.part`'ın `chunk_len..2*chunk_len` aralığında yazılmış
+/// olmalı (üzerine değil — `[0..chunk_len]` korunur).
+#[tokio::test]
+async fn e2e_pr_g_receiver_seek_to_received_bytes() {
+    let _home = TempHome::new();
+
+    let auth_key = [0xA2u8; 32];
+    let session_id = session_id_i64(&auth_key);
+    let payload_id: i64 = 0xABCD_0011;
+
+    let prefix = vec![0x11u8; 64]; // diskte mevcut, korunmalı
+    let new_chunk = vec![0x22u8; 64]; // resume sonrası eklenecek
+    let chunk_len = prefix.len() as i64;
+    let total_size = chunk_len * 2;
+
+    let dest = std::env::temp_dir().join(unique_label("g2-dest"));
+    let _ = std::fs::remove_file(&dest);
+    // Önceki session'ın yarım dosyasını manuel yarat: prefix bytes diskte.
+    std::fs::write(&dest, &prefix).unwrap();
+
+    let key = derive_chunk_hmac_key(&[0x02u8; 32]);
+    {
+        let mut asm = PayloadAssembler::new();
+        asm.set_chunk_hmac_key(key);
+        asm.register_file_destination(payload_id, dest.clone())
+            .unwrap();
+        asm.enable_resume_with_offset(
+            payload_id,
+            session_id,
+            "PEER-G2".to_string(),
+            "g2.bin".to_string(),
+            chunk_len, // received_bytes = 1 chunk
+            1,         // next_chunk_index = 1
+            String::new(),
+        )
+        .unwrap();
+        // Sender chunk_index = 1, offset = chunk_len.
+        let f = make_chunk_frame(payload_id, &new_chunk, true, total_size, chunk_len);
+        asm.ingest(&f).await.unwrap();
+        let tag = compute_tag(&key, payload_id, 1, chunk_len, &new_chunk).unwrap();
+        let ci = build_chunk_integrity(payload_id, 1, chunk_len, new_chunk.len(), tag).unwrap();
+        let completed = asm.verify_chunk_tag(&ci).await.unwrap();
+        assert!(completed.is_some(), "last_chunk verify finalize etmeli");
+    }
+
+    let final_bytes = std::fs::read(&dest).unwrap();
+    assert_eq!(
+        final_bytes.len() as i64,
+        total_size,
+        "dosya tam total_size olmalı"
+    );
+    assert_eq!(
+        &final_bytes[..(chunk_len as usize)],
+        &prefix[..],
+        "prefix korunmalı (seek doğru offset'e gitti, baştan yazmadı)"
+    );
+    assert_eq!(
+        &final_bytes[(chunk_len as usize)..],
+        &new_chunk[..],
+        "yeni chunk doğru offset'e yazıldı"
+    );
+
+    let _ = std::fs::remove_file(&dest);
+}
+
+/// Test PR-G #3 — Resume sonrası final SHA-256 orijinal full-content hash
+/// ile bit-bit eşleşmeli (hasher chain pre-feed doğrulaması).
+///
+/// Receiver `truncate(false) + seek` öncesi `.part`'ın ilk `received_bytes`
+/// byte'ını hasher'a feed eder; bu yapılmazsa final SHA-256 yalnız resume
+/// sonrası gelen byte'ları hash'lerdi → orijinalle uyuşmazdı (sender-side
+/// `CompletedPayload::File.sha256` mismatch alarmı).
+#[tokio::test]
+async fn e2e_pr_g_resume_full_sha256_matches_original() {
+    let _home = TempHome::new();
+
+    let auth_key = [0xA3u8; 32];
+    let session_id = session_id_i64(&auth_key);
+    let payload_id: i64 = 0xABCD_0012;
+
+    // Birbirinden farklı pattern'ler: orijinal "ilk-yarı" + "ikinci-yarı".
+    let first_half = vec![0x55u8; 64];
+    let second_half = vec![0xAAu8; 64];
+    let chunk_len = first_half.len() as i64;
+    let total_size = chunk_len * 2;
+
+    // Beklenen orijinal full content + hash.
+    let mut full = Vec::with_capacity(total_size as usize);
+    full.extend_from_slice(&first_half);
+    full.extend_from_slice(&second_half);
+    let expected_sha = sha256_hex(&full);
+
+    let dest = std::env::temp_dir().join(unique_label("g3-dest"));
+    let _ = std::fs::remove_file(&dest);
+    // Önceki session'ın yazmış olacağı içeriği taklit — first_half diskte.
+    std::fs::write(&dest, &first_half).unwrap();
+
+    let key = derive_chunk_hmac_key(&[0x03u8; 32]);
+    let completed_sha;
+    {
+        let mut asm = PayloadAssembler::new();
+        asm.set_chunk_hmac_key(key);
+        asm.register_file_destination(payload_id, dest.clone())
+            .unwrap();
+        asm.enable_resume_with_offset(
+            payload_id,
+            session_id,
+            "PEER-G3".to_string(),
+            "g3.bin".to_string(),
+            chunk_len,
+            1, // next_chunk_index = 1
+            String::new(),
+        )
+        .unwrap();
+
+        let f = make_chunk_frame(payload_id, &second_half, true, total_size, chunk_len);
+        asm.ingest(&f).await.unwrap();
+        let tag = compute_tag(&key, payload_id, 1, chunk_len, &second_half).unwrap();
+        let ci = build_chunk_integrity(payload_id, 1, chunk_len, second_half.len(), tag).unwrap();
+        let completed = asm
+            .verify_chunk_tag(&ci)
+            .await
+            .unwrap()
+            .expect("last chunk verify finalize");
+        match completed {
+            hekadrop::payload::CompletedPayload::File { sha256, .. } => {
+                completed_sha = hex::encode(sha256);
+            }
+            _ => panic!("File completion bekleniyor"),
+        }
+    }
+
+    // 1. Disk içeriği doğru: first_half + second_half.
+    let final_bytes = std::fs::read(&dest).unwrap();
+    assert_eq!(final_bytes, full, "final dosya orijinal content ile aynı");
+
+    // 2. PayloadAssembler'ın hesapladığı sha256 = orijinal full hash.
+    //    Hasher pre-feed olmazsa bu yalnız second_half'in hash'i olurdu.
+    assert_eq!(
+        completed_sha, expected_sha,
+        "PR-G hasher pre-feed: streaming SHA-256 orijinal full-content hash ile eşleşmeli"
+    );
+
+    let _ = std::fs::remove_file(&dest);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Yardımcı: log_redact import'u kullanılmadığı uyarısını engelle (yer tutucu).
 // ─────────────────────────────────────────────────────────────────────────────
 

--- a/crates/hekadrop-app/tests/resume_meta_persist.rs
+++ b/crates/hekadrop-app/tests/resume_meta_persist.rs
@@ -419,6 +419,7 @@ async fn validate_resumability_invariants_total_size_and_ttl() {
         peer_endpoint_id: "peerY".to_string(),
         created_at: stale,
         updated_at: stale,
+        dest_path: String::new(),
     };
     meta.store_atomic(&dir).expect("store ok");
 

--- a/crates/hekadrop-core/src/capabilities.rs
+++ b/crates/hekadrop-core/src/capabilities.rs
@@ -45,15 +45,14 @@ pub mod features {
     /// `resume.rs` primitives + receiver `.meta` persist + `ResumeHint` emit
     /// + sender `wait_for_resume_hint_or_zero` verify + cleanup sweep).
     ///
-    /// **PR #136 Gemini high yorumu sonrası geri kapatıldı:** envelope/sender/
-    /// receiver state machine'i hazır ama `PayloadAssembler::ingest_file`
-    /// dosyayı `OpenOptions::truncate(true)` ile her zaman sıfırlıyor
-    /// (`payload.rs:561`). Resume aktifken receiver `.part`'ı silip baştan
-    /// yazıyor → veri kaybı / korruption. Receiver append/seek orchestration
-    /// tamamlanana kadar bit advertise EDİLMEZ; sender + receiver state
-    /// machine kodu hazır kalır (envelope dispatch'i + opsiyonel resume hint
-    /// path testleri etkilenmez, capability gate'i kapalı).
-    pub const ALL_SUPPORTED: u64 = CHUNK_HMAC_V1;
+    /// **PR #136 Gemini high yorumu sonrası geri kapatıldı** (receiver
+    /// `truncate(true)` → veri kaybı). **PR-G ile geri açıldı:**
+    /// `payload.rs::ingest_file` artık resume aktifken `truncate(false)` +
+    /// `seek(received_bytes)` ile mevcut `.part`'a devam eder; hasher önceki
+    /// byte'larla feed edilir (final SHA-256 chain tutarlı kalır);
+    /// `connection.rs::resolve_resume_path` Introduction handler'ında fresh
+    /// placeholder yerine `meta.dest_path`'i register eder.
+    pub const ALL_SUPPORTED: u64 = CHUNK_HMAC_V1 | RESUME_V1;
 
     /// Bu build için reserved (henüz hiçbir RFC'nin sahip olmadığı) bit'ler.
     /// Test'lerde forward-compat akışını doğrulamak için kullanılır.
@@ -377,12 +376,16 @@ mod tests {
     fn all_supported_only_has_implemented_features() {
         // PR #103 review (Copilot): ALL_SUPPORTED yalnızca implementasyonu
         // hazır feature'ları içerir. RFC-0004 (RESUME_V1) PR-F'de açıldı,
-        // **PR #136 high yorumu sonrası geri kapatıldı** (receiver
-        // truncate(true) → resume body sıfırlama riski). RFC-0005
-        // (FOLDER_STREAM_V1) hâlâ unimplemented → advertise edilmez.
-        assert_eq!(features::ALL_SUPPORTED, features::CHUNK_HMAC_V1);
+        // PR #136 high yorumu sonrası geri kapatıldı (receiver truncate(true)
+        // → resume body sıfırlama riski). **PR-G ile geri açıldı**: receiver
+        // append/seek + hasher feed entegre. RFC-0005 (FOLDER_STREAM_V1)
+        // hâlâ unimplemented → advertise edilmez.
+        assert_eq!(
+            features::ALL_SUPPORTED,
+            features::CHUNK_HMAC_V1 | features::RESUME_V1
+        );
         assert_ne!(features::ALL_SUPPORTED & features::CHUNK_HMAC_V1, 0);
-        assert_eq!(features::ALL_SUPPORTED & features::RESUME_V1, 0);
+        assert_ne!(features::ALL_SUPPORTED & features::RESUME_V1, 0);
         assert_eq!(features::ALL_SUPPORTED & features::FOLDER_STREAM_V1, 0);
     }
 }

--- a/crates/hekadrop-core/src/connection.rs
+++ b/crates/hekadrop-core/src/connection.rs
@@ -957,9 +957,40 @@ async fn handle_sharing_frame(
                 } else {
                     None
                 };
-                for (pid, path, display_name, announced_size) in planned_files {
+                for (pid, fresh_path, display_name, announced_size) in planned_files {
+                    // PR-G: RESUME_V1 + meta valid + meta.dest_path mevcut →
+                    // fresh placeholder'ı sil + meta.dest_path'i register et
+                    // (mevcut `.part` üstüne devam). Aksi halde fresh_path.
+                    let actual_path = if let Some(sid) = session_id {
+                        match resolve_resume_path(sid, pid, &display_name, announced_size) {
+                            Some(resume_path) => {
+                                // Fresh placeholder boş — sil, resume path'e geç.
+                                if let Err(e) = std::fs::remove_file(&fresh_path) {
+                                    if e.kind() != std::io::ErrorKind::NotFound {
+                                        tracing::debug!(
+                                            "[{}] resume swap: fresh placeholder silinemedi {}: {}",
+                                            peer,
+                                            crate::log_redact::path_basename(&fresh_path),
+                                            e
+                                        );
+                                    }
+                                }
+                                tracing::info!(
+                                    "[{}] resume aktif: payload_id={} → mevcut .part'a devam ({})",
+                                    peer,
+                                    pid,
+                                    crate::log_redact::path_basename(&resume_path)
+                                );
+                                resume_path
+                            }
+                            None => fresh_path,
+                        }
+                    } else {
+                        fresh_path
+                    };
+
                     assembler
-                        .register_file_destination(pid, path)
+                        .register_file_destination(pid, actual_path)
                         .context("dosya hedefi kaydı")?;
                     pending_names.insert(pid, display_name.clone());
 
@@ -1131,6 +1162,60 @@ fn human_size(bytes: i64) -> String {
     }
 }
 
+/// PR-G — Introduction handler'ı `unique_downloads_path`'le fresh placeholder
+/// rezerve ettikten sonra bu fonksiyonu çağırır. Eğer geçerli bir resume
+/// `.meta` varsa + `meta.dest_path` mevcut + dosya boyutu `received_bytes`
+/// ile eşleşiyorsa **mevcut `.part` path'i** döner; caller fresh placeholder'ı
+/// silip bu path'i register eder. Aksi halde `None` (fresh transfer).
+///
+/// Validate adımları (RFC §5'teki MUST'larla birebir):
+/// - `partial_dir` resolve OK
+/// - `.meta` load OK + `validate()` OK
+/// - `meta.file_name == announced display_name`
+/// - `meta.total_size == announced_total_size`
+/// - `meta.updated_at` TTL içinde
+/// - `meta.dest_path` non-empty + `Path::exists` + `metadata.len() ==
+///   meta.received_bytes` (disk doğrulaması)
+fn resolve_resume_path(
+    session_id: i64,
+    payload_id: i64,
+    announced_display_name: &str,
+    announced_total_size: i64,
+) -> Option<std::path::PathBuf> {
+    let dir = crate::resume::partial_dir().ok()?;
+    let meta = crate::resume::PartialMeta::load(&dir, session_id, payload_id)
+        .ok()
+        .flatten()?;
+    if meta.dest_path.is_empty() {
+        return None;
+    }
+    if meta.file_name != announced_display_name {
+        return None;
+    }
+    if meta.total_size != announced_total_size {
+        return None;
+    }
+    let age_days = (chrono::Utc::now() - meta.updated_at).num_days();
+    if age_days > crate::resume::RESUME_TTL_DAYS {
+        return None;
+    }
+    let path = std::path::PathBuf::from(&meta.dest_path);
+    let md = std::fs::metadata(&path).ok()?;
+    if !md.is_file() {
+        return None;
+    }
+    // SECURITY: untrusted-disk size — `meta.received_bytes` ile eşleşmesi
+    // resume offset semantiğinin disk gerçeğine oturduğunu garanti eder.
+    // `as u64` bit-cast (u64 rendering); validate() received_bytes >= 0
+    // garantilediği için sign loss yok.
+    #[allow(clippy::cast_sign_loss)] // INVARIANT: validate() guards received_bytes >= 0
+    let expected = meta.received_bytes as u64;
+    if md.len() != expected {
+        return None;
+    }
+    Some(path)
+}
+
 /// RFC-0004 §3.3 + §5 — Introduction sonrası bir dosya için resume
 /// orchestration:
 ///
@@ -1169,22 +1254,10 @@ async fn handle_resume_for_file(
     // 1. partial_dir resolve. HOME yoksa silently skip → fresh transfer.
     let dir = crate::resume::partial_dir().context("resume: partial_dir resolve")?;
 
-    // 2. Resume state'i her durumda enable et — fresh transfer de checkpoint
-    //    yazsın. Hata yutulur, fresh hâli devam eder.
-    if let Err(e) = assembler.enable_resume(
-        payload_id,
-        session_id,
-        peer_endpoint_id.to_string(),
-        file_name.to_string(),
-    ) {
-        tracing::debug!(
-            "resume enable failed (payload_id={}): {} — checkpoint kapalı, fresh devam",
-            payload_id,
-            e
-        );
-    }
-
-    // 3. `.meta` lookup. NotFound → fresh; load Err → silently skip.
+    // 2. `.meta` lookup. NotFound → fresh; load Err → silently skip.
+    //    PR-G: meta validate sonucuna göre `enable_resume_with_offset` ya da
+    //    `enable_resume` (fresh) çağrılır — resume aktivasyonu meta sonrasına
+    //    ertelendi ki `received_bytes` doğru injected olsun.
     let maybe_meta = match crate::resume::PartialMeta::load(&dir, session_id, payload_id) {
         Ok(opt) => opt,
         Err(e) => {
@@ -1193,15 +1266,29 @@ async fn handle_resume_for_file(
                 payload_id,
                 e
             );
+            // Fresh enable — `.meta` yazsın ki sonraki kesintide resume
+            // şansı doğsun.
+            let _ = assembler.enable_resume(
+                payload_id,
+                session_id,
+                peer_endpoint_id.to_string(),
+                file_name.to_string(),
+            );
             return Ok(());
         }
     };
     let Some(meta) = maybe_meta else {
-        // Eşleşen meta yok → ResumeHint emit etme; fresh devam.
+        // Eşleşen meta yok → fresh enable + ResumeHint emit etme.
+        let _ = assembler.enable_resume(
+            payload_id,
+            session_id,
+            peer_endpoint_id.to_string(),
+            file_name.to_string(),
+        );
         return Ok(());
     };
 
-    // 4. Receiver MUST invariant validate (RFC §5).
+    // 3. Receiver MUST invariant validate (RFC §5).
     let now = chrono::Utc::now();
     let age_days = (now - meta.updated_at).num_days();
     let stale = age_days > crate::resume::RESUME_TTL_DAYS
@@ -1219,29 +1306,90 @@ async fn handle_resume_for_file(
         );
         let path = dir.join(crate::resume::meta_filename(session_id, payload_id));
         let _ = std::fs::remove_file(&path);
+        // Fresh enable — sonraki kesintide yeni `.meta` yazılır.
+        let _ = assembler.enable_resume(
+            payload_id,
+            session_id,
+            peer_endpoint_id.to_string(),
+            file_name.to_string(),
+        );
+        return Ok(());
+    }
+
+    // 4. Meta valid + RESUME_V1 aktif → resume offset ile enable et.
+    //    PR-G: `enable_resume_with_offset` `received_bytes` + chunk_index +
+    //    `last_chunk_tag_b64` inject eder; ingest_file ilk chunk'ta `.part`'ı
+    //    `truncate(false)` + `seek(received_bytes)` ile açar, hasher önceki
+    //    bytes ile feed edilir. `next_chunk_index = received_bytes /
+    //    chunk_size` — `validate()` chunk_size == CHUNK_SIZE garantili.
+    let chunk_size_i64 = i64::from(meta.chunk_size);
+    let next_chunk_idx = if chunk_size_i64 == 0 {
+        0
+    } else {
+        meta.received_bytes / chunk_size_i64
+    };
+    if let Err(e) = assembler.enable_resume_with_offset(
+        payload_id,
+        session_id,
+        peer_endpoint_id.to_string(),
+        file_name.to_string(),
+        meta.received_bytes,
+        next_chunk_idx,
+        meta.chunk_hmac_chain_b64.clone(),
+    ) {
+        tracing::debug!(
+            "resume enable_with_offset failed (payload_id={}, offset={}): {} — fresh devam",
+            payload_id,
+            meta.received_bytes,
+            e
+        );
+        // Fresh fallback.
+        let _ = assembler.enable_resume(
+            payload_id,
+            session_id,
+            peer_endpoint_id.to_string(),
+            file_name.to_string(),
+        );
         return Ok(());
     }
 
     // 5. partial_hash recompute (defense-in-depth — disk corruption /
-    //    concurrent edit). `.part` yoksa veya kısaysa Err döner → fresh.
-    //    Bu PR'da `.part` path'ini caller bilmiyor (register henüz pending);
-    //    PR-E'de receiver `.part` re-open + base_offset semantiği eklenince
-    //    burada gerçek hash hesaplanacak. Şimdilik `.meta`'da kayıtlı son
-    //    chunk tag'i ResumeHint'e taşınır (sender PR-D fast-path'e karar
-    //    verir; full hash recompute olmazsa zaten reject döner).
+    //    concurrent edit). PR-G: `meta.dest_path` mevcut → gerçek hash
+    //    hesaplanır. Hash hesaplanamazsa (path empty / yok / kısa) hint
+    //    yine emit edilir ama `partial_hash = []` (sender boşa REJECT döner;
+    //    receiver fresh restart'a düşer — best-effort).
     let last_tag_bytes = BASE64_STD
         .decode(&meta.chunk_hmac_chain_b64)
         .unwrap_or_default();
+
+    let partial_hash_bytes: Vec<u8> = if meta.dest_path.is_empty() {
+        Vec::new()
+    } else {
+        // SECURITY: receiver tarafı kendi diskindeki `.part`'ı doğruluyor —
+        // `meta.received_bytes` validate'lı. `as u64` bit-cast (validate
+        // received_bytes >= 0 garantili).
+        #[allow(clippy::cast_sign_loss)] // INVARIANT: validate() guards received_bytes >= 0
+        let off_u = meta.received_bytes as u64;
+        let dest_path = std::path::Path::new(&meta.dest_path);
+        match crate::resume::partial_hash_streaming(dest_path, off_u) {
+            Ok(h) => h.to_vec(),
+            Err(e) => {
+                tracing::debug!(
+                    "resume partial_hash compute failed (payload_id={}, path={}): {} — fresh fallback",
+                    payload_id,
+                    crate::log_redact::path_basename(dest_path),
+                    e
+                );
+                Vec::new()
+            }
+        }
+    };
 
     let hint = ResumeHint {
         session_id,
         payload_id,
         offset: meta.received_bytes,
-        // PR-E: `.part` üstünde recompute edilen full SHA-256. Bu PR'da
-        // `.part` re-open semantiği yok → boş (sender PR-D'de boş hash'i
-        // mismatch sayar; ALL_SUPPORTED `RESUME_V1` aktif olmadığı sürece
-        // bu kod path'i pratikte ölü).
-        partial_hash: Vec::new().into(),
+        partial_hash: partial_hash_bytes.into(),
         capabilities_version: crate::capabilities::CAPABILITIES_VERSION,
         last_chunk_tag: last_tag_bytes.into(),
     };

--- a/crates/hekadrop-core/src/frame.rs
+++ b/crates/hekadrop-core/src/frame.rs
@@ -245,11 +245,12 @@ mod dispatcher_tests {
                 if let Some(Payload::Capabilities(c)) = frame.payload {
                     assert_eq!(c.features, 0x07);
                     let active = ActiveCapabilities::negotiate(features::ALL_SUPPORTED, c.features);
-                    // PR #136 high sonrası RESUME_V1 ALL_SUPPORTED'dan çıktı
-                    // (receiver truncate(true) bug'ı). Şu an sadece CHUNK_HMAC_V1
-                    // aktif — peer 0x07 advertise etse bile intersection ona iner.
+                    // PR-G: RESUME_V1 ALL_SUPPORTED'a geri eklendi (receiver
+                    // append/seek tamamlandı). Peer 0x07 advertise edince
+                    // intersection CHUNK_HMAC + RESUME_V1; FOLDER_STREAM_V1
+                    // bizim build'imizde yok → düşer.
                     assert!(active.has(features::CHUNK_HMAC_V1));
-                    assert!(!active.has(features::RESUME_V1));
+                    assert!(active.has(features::RESUME_V1));
                     assert!(!active.has(features::FOLDER_STREAM_V1));
                 } else {
                     panic!("capabilities oneof beklendi");

--- a/crates/hekadrop-core/src/negotiation.rs
+++ b/crates/hekadrop-core/src/negotiation.rs
@@ -211,9 +211,9 @@ mod tests {
         assert_eq!(client_active.raw(), features::ALL_SUPPORTED);
         assert_eq!(server_active.raw(), features::ALL_SUPPORTED);
         assert!(client_active.has(features::CHUNK_HMAC_V1));
-        // PR #136 high sonrası RESUME_V1 ALL_SUPPORTED'dan çıktı (receiver
-        // truncate(true) bug'ı). FOLDER_STREAM_V1 (RFC-0005) hâlâ implementasyonsuz.
-        assert!(!client_active.has(features::RESUME_V1));
+        // PR-G: RESUME_V1 ALL_SUPPORTED'a geri eklendi. FOLDER_STREAM_V1
+        // (RFC-0005) hâlâ implementasyonsuz → advertise edilmez.
+        assert!(client_active.has(features::RESUME_V1));
         assert!(!client_active.has(features::FOLDER_STREAM_V1));
         assert!(!client_active.is_legacy());
         // Genuine HekaDrop path'inde leftover olmamalı.

--- a/crates/hekadrop-core/src/payload.rs
+++ b/crates/hekadrop-core/src/payload.rs
@@ -194,6 +194,22 @@ struct PendingResume {
     session_id: i64,
     peer_endpoint_id: String,
     file_name: String,
+    /// PR-G: receiver bu transfer için resume offset; `0` → fresh start
+    /// (mevcut davranış), `>0` → `ingest_file` bu offset'ten başlayarak
+    /// append modunda dosyayı açar (truncate yok, seek + hasher feed önceki
+    /// bytes). Caller değer geçmediyse default `0` (fresh).
+    received_bytes: i64,
+    /// PR-G: resume sonrası ilk gelen chunk için beklenen `chunk_index`.
+    /// Sender `received_bytes / sender_chunk_size` üzerinden bu değeri seçer;
+    /// receiver `verify_chunk_tag`'da `ci.chunk_index == sink.next_chunk_index`
+    /// kontrolü yapacağı için aynı değeri burada init etmek zorunlu.
+    /// Production: caller `meta.received_bytes / meta.chunk_size`
+    /// (= `CHUNK_SIZE`) hesaplar.
+    next_chunk_index: i64,
+    /// PR-G: resume durumunda receiver bu tag ile checkpoint'ten devam
+    /// etsin (chunk-HMAC fast-path semantiği). `.meta`'dan yüklenen son tag
+    /// — boşsa fast-path yok / fresh.
+    last_chunk_tag_b64: String,
 }
 
 #[derive(Default)]
@@ -259,8 +275,58 @@ impl PayloadAssembler {
         peer_endpoint_id: String,
         file_name: String,
     ) -> Result<()> {
+        // Fresh enable — offset 0, chunk_index 0, last_chunk_tag boş. PR-G
+        // öncesi tek API imzası buydu; mevcut çağrı yerleri dokunulmadan
+        // derlensin.
+        self.enable_resume_with_offset(
+            payload_id,
+            session_id,
+            peer_endpoint_id,
+            file_name,
+            0,
+            0,
+            String::new(),
+        )
+    }
+
+    /// PR-G: `enable_resume` + receiver-side offset/tag injection.
+    ///
+    /// Pozitif `received_bytes` durumunda `ingest_file` mevcut `.part`
+    /// dosyasını `truncate(false)` + `seek(received_bytes)` ile açar;
+    /// `FileSink.written` + hasher state buna göre kurulur (önceki byte'lar
+    /// hasher'a feed edilir). `next_chunk_index` resume sonrası ilk beklenen
+    /// chunk index'idir (sender `received_bytes / its_chunk_size`'den
+    /// türetir). `last_chunk_tag_b64` chunk-HMAC fast-path içindir (boşsa
+    /// slow-path).
+    ///
+    /// Caller (`connection.rs::handle_resume_for_file`) `.meta` valid + `.part`
+    /// hazır olduğunda bu varyantı çağırır; aksi halde [`Self::enable_resume`].
+    // INVARIANT: 8 argüman — production caller tek nokta (handle_resume_for_file).
+    // Builder pattern overkill; receiver-side resume injection field'ları (4 yeni)
+    // organik olarak biriktirildi, struct-arg refactor scope dışı.
+    #[allow(clippy::too_many_arguments)] // INVARIANT: tek production caller, struct-arg refactor scope dışı
+    pub fn enable_resume_with_offset(
+        &mut self,
+        payload_id: i64,
+        session_id: i64,
+        peer_endpoint_id: String,
+        file_name: String,
+        received_bytes: i64,
+        next_chunk_index: i64,
+        last_chunk_tag_b64: String,
+    ) -> Result<()> {
         let partial_dir = resume::partial_dir()
             .with_context(|| "resume: partial_dir() resolve hatası — fresh transfer")?;
+        if received_bytes < 0 {
+            return Err(anyhow!(
+                "enable_resume_with_offset: negatif received_bytes={received_bytes}"
+            ));
+        }
+        if next_chunk_index < 0 {
+            return Err(anyhow!(
+                "enable_resume_with_offset: negatif next_chunk_index={next_chunk_index}"
+            ));
+        }
         self.pending_resume.insert(
             payload_id,
             PendingResume {
@@ -268,6 +334,9 @@ impl PayloadAssembler {
                 session_id,
                 peer_endpoint_id,
                 file_name,
+                received_bytes,
+                next_chunk_index,
+                last_chunk_tag_b64,
             },
         );
         Ok(())
@@ -555,21 +624,137 @@ impl PayloadAssembler {
                     });
                 }
             }
-            let file = std::fs::OpenOptions::new()
-                .write(true)
-                .create(true)
-                .truncate(true)
-                .open(&dest.path)
-                .with_context(|| format!("dosya açılamadı: {}", dest.path.display()))?;
+            // PR-G: pending_resume varsa **önce** çek (payload_id başına tek
+            // varlık) — `received_bytes > 0` ise resume açılış path'i, `== 0`
+            // ise fresh path. Hata durumunda da remove'lanır ki Tükenmiş state
+            // bir sonraki retry'ı bulandırmasın.
+            let pending_resume = self.pending_resume.remove(&id);
+            let is_resume = pending_resume
+                .as_ref()
+                .is_some_and(|pr| pr.received_bytes > 0);
+
+            // SECURITY: resume aktifken `received_bytes`'ın disk üstündeki
+            // dosya boyutunu aşmaması ve `total_size`'a sığması gerekir.
+            // Aksi halde (a) `seek` past-end → sparse hole + future chunk'lar
+            // yanlış offset'e yazılır, (b) hasher feed `.part`'ın olmayan
+            // byte'larını okur → mismatch + truncated final.
+            if let Some(pr) = pending_resume.as_ref() {
+                if pr.received_bytes > total_size {
+                    return Err(anyhow!(
+                        "resume received_bytes ({}) > total_size ({}); fresh düşülmeli",
+                        pr.received_bytes,
+                        total_size
+                    ));
+                }
+            }
+
+            let file = if is_resume {
+                // PR-G resume path: `.part` dest.path'te mevcut olmalı (önceki
+                // session yazdı). `read(true)` zorunlu — hasher pre-feed önceki
+                // bytes'ları okumalı. `truncate(false)` + `create(false)` —
+                // varolan inode'a aç; yoksa fresh düşmek için Err döner ve
+                // caller `.meta` cleanup'a gider.
+                std::fs::OpenOptions::new()
+                    .read(true)
+                    .write(true)
+                    .create(false)
+                    .truncate(false)
+                    .open(&dest.path)
+                    .with_context(|| {
+                        format!(
+                            "resume için .part açılamadı: {} (received_bytes={})",
+                            dest.path.display(),
+                            pending_resume.as_ref().map_or(0, |pr| pr.received_bytes)
+                        )
+                    })?
+            } else {
+                // Fresh path (mevcut davranış — placeholder var, sıfırdan yaz).
+                std::fs::OpenOptions::new()
+                    .write(true)
+                    .create(true)
+                    .truncate(true)
+                    .open(&dest.path)
+                    .with_context(|| format!("dosya açılamadı: {}", dest.path.display()))?
+            };
+
+            // PR-G: resume açılış post-processing — seek + hasher feed.
+            // BufWriter wrap'inden ÖNCE yapılır (BufWriter'ın iç pozisyonu
+            // 0 olarak başlar; underlying File'ın gerçek pozisyonu seek
+            // ettiğimiz yerdir). seek_write semantiği: sonraki write_all
+            // mutlak offset'ten yazar.
+            let mut hasher = Sha256::new();
+            let initial_written = if let Some(pr) = pending_resume.as_ref() {
+                pr.received_bytes
+            } else {
+                0
+            };
+            let mut file = file;
+            if is_resume {
+                use std::io::{Read as _, Seek as _, SeekFrom};
+                // Hasher state recompute: `.part`'ın ilk `received_bytes`
+                // byte'ını feed et. ~10-50 ms / 100 MB; final SHA-256 chain
+                // tutarlı kalır (aksi halde chunk-HMAC verify başarılı olsa
+                // bile receiver'ın final hash'i sender'ınki ile uyuşmaz).
+                let received_u64 = u64::try_from(initial_written)
+                    .with_context(|| format!("received_bytes negatif: {initial_written}"))?;
+                file.seek(SeekFrom::Start(0)).with_context(|| {
+                    format!(
+                        "resume hasher pre-feed seek(0) hata: {}",
+                        dest.path.display()
+                    )
+                })?;
+                let mut buf = vec![0u8; 64 * 1024];
+                let mut remaining = received_u64;
+                while remaining > 0 {
+                    // INVARIANT: buf.len() = 64 KiB; remaining caller-bounded
+                    // (received_bytes <= total_size <= MAX_FILE_BYTES = 1 TiB).
+                    #[allow(clippy::cast_possible_truncation)]
+                    let want = remaining.min(buf.len() as u64) as usize;
+                    let n = file.read(&mut buf[..want]).with_context(|| {
+                        format!(
+                            "resume hasher pre-feed read hata: {} (remaining={})",
+                            dest.path.display(),
+                            remaining
+                        )
+                    })?;
+                    if n == 0 {
+                        return Err(anyhow!(
+                            "resume .part beklenen byte sayısından kısa (path={}, beklenen={}, kalan={})",
+                            dest.path.display(),
+                            received_u64,
+                            remaining
+                        ));
+                    }
+                    hasher.update(&buf[..n]);
+                    remaining = remaining.saturating_sub(n as u64);
+                }
+                file.seek(SeekFrom::Start(received_u64)).with_context(|| {
+                    format!(
+                        "resume seek-to-offset hata: {} (offset={})",
+                        dest.path.display(),
+                        received_u64
+                    )
+                })?;
+            }
             let writer = BufWriter::with_capacity(FILE_WRITE_BUF_CAPACITY, file);
+
+            // PR-G: resume sonrası `next_chunk_index` caller-supplied. Sender
+            // `received_bytes / its_chunk_size`'den türetir; receiver
+            // verify_chunk_tag'da `ci.chunk_index == sink.next_chunk_index`
+            // kontrolü yapacağı için aynı değer kullanılır. Production yolunda
+            // bu `meta.received_bytes / meta.chunk_size` ile eşittir.
+            // `pending_resume` map() ile move edileceği için chunk_index'i
+            // ÖNCE kopyala (i64 trivially copy).
+            let initial_chunk_index: i64 =
+                pending_resume.as_ref().map_or(0, |pr| pr.next_chunk_index);
             // RFC-0004 §3.3: pending_resume varsa state'i FileSink'e taşı.
             // Aksi halde resume_state = None — `.meta` yazılmaz.
-            let resume_state = self.pending_resume.remove(&id).map(|pr| ResumeState {
+            let resume_state = pending_resume.map(|pr| ResumeState {
                 partial_dir: pr.partial_dir,
                 session_id: pr.session_id,
                 file_name: pr.file_name,
                 peer_endpoint_id: pr.peer_endpoint_id,
-                last_chunk_tag_b64: String::new(),
+                last_chunk_tag_b64: pr.last_chunk_tag_b64,
                 chunks_since_checkpoint: 0,
                 created_at: None,
             });
@@ -577,11 +762,11 @@ impl PayloadAssembler {
                 writer,
                 path: dest.path,
                 total_size,
-                written: 0,
-                hasher: Sha256::new(),
+                written: initial_written,
+                hasher,
                 last_chunk_at: Instant::now(),
                 pending_chunk: None,
-                next_chunk_index: 0,
+                next_chunk_index: initial_chunk_index,
                 resume_state,
             });
         }
@@ -939,6 +1124,11 @@ fn write_resume_checkpoint(payload_id: i64, sink: &mut FileSink, is_final: bool)
         peer_endpoint_id: rs.peer_endpoint_id.clone(),
         created_at,
         updated_at: now,
+        // PR-G: dest_path persist edilir → re-handshake'te receiver bu path'i
+        // bulur ve `unique_downloads_path` placeholder yerine mevcut `.part`'ı
+        // yeniden açar. `to_string_lossy()` non-UTF8 path'lerde lossy ama
+        // resume best-effort (lossy → mismatch → fresh transfer; veri kaybı yok).
+        dest_path: sink.path.to_string_lossy().into_owned(),
     };
     if let Err(e) = meta.store_atomic(&rs.partial_dir) {
         debug!(

--- a/crates/hekadrop-core/src/resume.rs
+++ b/crates/hekadrop-core/src/resume.rs
@@ -217,6 +217,16 @@ pub struct PartialMeta {
     pub peer_endpoint_id: String,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
+    /// PR-G: receiver-side absolute path of the partial download file. When
+    /// non-empty, [`connection`] resume orchestration reuses this exact path
+    /// (skipping fresh `unique_downloads_path` placeholder allocation) so the
+    /// existing `.part` bytes survive the second handshake.
+    ///
+    /// Optional (`#[serde(default)]`) — backward-compatible with older `.meta`
+    /// files that predate the field; on absence caller falls back to the
+    /// fresh placeholder path (resume effectively no-op).
+    #[serde(default)]
+    pub dest_path: String,
 }
 
 #[derive(Debug, Error)]
@@ -658,6 +668,7 @@ mod tests {
             peer_endpoint_id: "ABCD".to_string(),
             created_at: now,
             updated_at: now,
+            dest_path: String::new(),
         }
     }
 
@@ -826,6 +837,7 @@ mod tests {
             peer_endpoint_id: "PEER".to_string(),
             created_at: updated_at,
             updated_at,
+            dest_path: String::new(),
         };
         // store_atomic validate eder; total/received eşit + valid → OK.
         meta.store_atomic(dir).unwrap();


### PR DESCRIPTION
## Bağlam — PR #137 rollback

PR #136 (RESUME_V1 capability gate) sonrası Gemini high yorumu kritik bir
regresyonu yakaladı: `payload.rs::ingest_file` dosyayı her açtığında
`OpenOptions::truncate(true)` zincirini kullanıyor. Resume aktifken receiver
mevcut `.part` dosyasını silip baştan yazıyor → veri kaybı.

PR #137 quick-fix olarak `RESUME_V1`'i `ALL_SUPPORTED`'tan geri çıkardı (sender
+ receiver state machine kodu hazır kalır, sadece advertise edilmez). Bu PR
**gerçek tamamlanmayı** (production-ready resume) getirir.

## Değişiklikler

### 1. Receiver-side append/seek (`payload.rs`)

- `PendingResume` struct'ına `received_bytes`, `next_chunk_index`,
  `last_chunk_tag_b64` alanları eklendi.
- Yeni public API: `enable_resume_with_offset(...)` — caller resume offset,
  beklenen chunk_index ve fast-path tag inject edebilir. Eski
  `enable_resume(...)` bunu `0/0/""` ile çağırıp arka uyumlu kalır.
- `ingest_file`:
  - `received_bytes > 0` → `OpenOptions::read+write+truncate(false)+create(false)`
    ile mevcut `.part`'a açar (fresh path: `truncate(true)+create(true)`).
  - **Hasher pre-feed**: dosyanın ilk `received_bytes` byte'ı `Sha256::new()`'e
    beslenir → `CompletedPayload.sha256` orijinal full-content hash ile bit-bit
    eşleşir (aksi halde sadece resume sonrası bytes hash'lenirdi).
  - `seek(SeekFrom::Start(received_bytes))` sonrası `BufWriter` wrap.
  - Defensive guard: `received_bytes > total_size` → fresh fallback hatası.

### 2. Path persistence (`resume.rs`)

`PartialMeta`'ya `dest_path: String` alanı (`#[serde(default)]`) eklendi.
Backward-compat: eski `.meta`'larda yok → boş string → fresh fallback. Yeni
`.meta`'lar receiver dosya yolunu persist eder; re-handshake'te
`resolve_resume_path` bu path'i bulup register eder.

### 3. Path swap orkestrasyonu (`connection.rs`)

- Yeni helper: `resolve_resume_path(...)` — Introduction handler fresh
  placeholder reserve ettikten sonra `.meta` valid + `dest_path` file mevcut +
  size eşit ise fresh placeholder'ı silip mevcut `.part` path'ini döndürür.
- Introduction loop: `resume_active` iken her dosya için `resolve_resume_path`
  çağrılır; var ise placeholder swap + `register_file_destination` resume
  path'iyle yapılır.
- `handle_resume_for_file`: meta valid iken `enable_resume_with_offset`
  çağrılır; meta yoksa veya stale ise fresh `enable_resume`.
- `ResumeHint.partial_hash` artık `meta.dest_path` üzerinde
  `partial_hash_streaming` hesaplanarak doldurulur. Önceden boş gönderiliyordu
  → sender PR-D verify pipeline'ı pratik test'te REJECT döndürürdü.

### 4. Capability gate re-enable (`capabilities.rs`)

- `ALL_SUPPORTED = CHUNK_HMAC_V1 | RESUME_V1`.
- `all_supported_only_has_implemented_features` test assertion'ı RESUME_V1
  aktif duruma rollback edildi.
- `frame.rs::capabilities_kat_all_features_dispatch` ve
  `negotiation.rs::loopback_negotiate_all_features_active` test
  assertion'ları paralel güncellendi.

### 5. Yeni E2E testleri (`resume_e2e.rs`, +3 test, toplam 7)

| Test | Doğruladığı invariant |
|---|---|
| `e2e_pr_g_receiver_append_preserves_existing_part` | Fresh 2 chunk + resume 2 chunk → final dosya 4 chunk; ilk yarı `0xCC` korunmuş, ikinci yarı `0xDD` eklenmiş (`truncate(false)` çalıştığını kanıtlar) |
| `e2e_pr_g_receiver_seek_to_received_bytes` | Diskte prefix; resume `received_bytes=chunk_len`; ilk chunk `offset=chunk_len`'e yazılır; prefix korunur (seek doğru offset'e gitti) |
| `e2e_pr_g_resume_full_sha256_matches_original` | Hasher pre-feed: resume sonrası `CompletedPayload::File.sha256` orijinal full-content hash ile eşleşir |

## CLAUDE.md uyumu

- **I-1** (R2 — core'da app-only modül yasağı): yeni `crate::*` referansları
  yok; sadece mevcut `crate::resume`, `crate::log_redact`, `crate::capabilities`
  — hepsi core içi.
- **I-2** (`#[allow]` scoped + yorumlu): yeni `#[allow]`'lar item-level +
  INVARIANT yorumlu (`cast_possible_truncation` hasher buf'ta,
  `cast_sign_loss` validate-guarded `received_bytes` cast'inde,
  `too_many_arguments` `enable_resume_with_offset`'in tek production caller'ı
  + struct-arg refactor scope dışı).
- **I-3** (`with_context` zorunluluğu): tüm I/O fail path'lerinde
  `with_context`; `map_err(|_e| ...)` bypass yok.
- **I-5** (untrusted input checked aritmetik): `received_bytes > total_size`
  guard, `u64::try_from(received_bytes)` ile negative koruma.
- **I-6** (hidden global state yok): yeni `static`/`OnceLock`/`Lazy` yok.

## Test plan

- [x] `cargo fmt --all -- --check` — temiz
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — temiz
- [x] `cargo test --workspace` — **413 passed / 0 failed** (yeni 3 PR-G testi dahil)
- [x] `cargo machete --with-metadata` — temiz
- [x] `typos` — temiz
- [ ] CI'da Linux + Windows clippy doğrulaması (cross-platform-gated kod
      lokal macOS taramasında değil; CLAUDE.md "bilinen gap" maddesi —
      gerekirse 1 fix iterasyonu beklenir)

## RFC-0004 implementasyon TAMAM

| PR | Kapsam | Durum |
|---|---|---|
| PR-A | `ResumeHint`/`ResumeReject` proto schema | ✓ #131 |
| PR-B | `resume.rs` primitives | ✓ #132 |
| PR-C | Receiver `.meta` persist + emit | ✓ #133 |
| PR-D | Sender consume + verify + seek | ✓ #134 |
| PR-E | Cleanup sweep (TTL + LRU) | ✓ #135 |
| PR-F | `RESUME_V1` capability gate açma | ✓ #136 (PR #137 rollback) |
| **PR-G** | **Receiver append/seek + capability re-enable** | **bu PR** |

PR-G merge sonrası RFC-0004 (transfer resume) production-ready olarak
tamamlanır. Bir sonraki RFC döngüsüne (RFC-0005 folder stream veya v0.8.1
strictness sweep'leri) geçilebilir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)