### PR TITLE
chore(payload): resume error context — payload_id ekle (PR #138 medium)

### DIFF
--- a/crates/hekadrop-core/src/payload.rs
+++ b/crates/hekadrop-core/src/payload.rs
@@ -712,7 +712,7 @@ impl PayloadAssembler {
                     let want = remaining.min(buf.len() as u64) as usize;
                     let n = file.read(&mut buf[..want]).with_context(|| {
                         format!(
-                            "resume hasher pre-feed read hata: {} (remaining={})",
+                            "resume hasher pre-feed read hata: id={id} {} (remaining={})",
                             dest.path.display(),
                             remaining
                         )
@@ -730,7 +730,7 @@ impl PayloadAssembler {
                 }
                 file.seek(SeekFrom::Start(received_u64)).with_context(|| {
                     format!(
-                        "resume seek-to-offset hata: {} (offset={})",
+                        "resume seek-to-offset hata: id={id} {} (offset={})",
                         dest.path.display(),
                         received_u64
                     )


### PR DESCRIPTION
PR #138 Gemini medium yorumları — resume error mesajlarına `id=` eklendi. Log debug'da hangi transferin fail ettiği görünür.

🤖 Generated with [Claude Code](https://claude.com/claude-code)