### PR TITLE
chore(post-rfc-0004): proto session_id sfixed64 + cleanup_sweep error log

### DIFF
--- a/crates/hekadrop-core/src/resume.rs
+++ b/crates/hekadrop-core/src/resume.rs
@@ -484,7 +484,17 @@ pub fn cleanup_sweep(
     // (budget hesabını bozmasın). I/O error → skip + warn.
     let mut candidates: Vec<Candidate> = Vec::new();
 
-    for entry in entries.flatten() {
+    // PR #135 Gemini medium: `flatten()` I/O hatalarını sessizce yutar; hatalı
+    // entry'yi `tracing::warn` ile loglayıp skip et — silent data corruption riskini
+    // ortadan kaldırır.
+    for entry in entries {
+        let entry = match entry {
+            Ok(e) => e,
+            Err(err) => {
+                tracing::warn!("[resume cleanup] dizin okuma hatası: {err}");
+                continue;
+            }
+        };
         let meta_path = entry.path();
         // Yalnızca `.meta` ile bitenleri işle; `.tmp`/`.part` skip.
         if meta_path.extension().is_none_or(|ext| ext != "meta") {

--- a/crates/hekadrop-proto/proto/hekadrop_extensions.proto
+++ b/crates/hekadrop-proto/proto/hekadrop_extensions.proto
@@ -74,7 +74,11 @@ message ChunkIntegrity {
 // kendi session'ı ile karşılaştırır, eşleşmezse `ResumeReject{
 // SESSION_MISMATCH }` döner.
 message ResumeHint {
-  int64  session_id           = 1;  // UKEY2 auth_key SHA-256[0..8] BE
+  // PR #131 Gemini medium: `sfixed64` (8 byte sabit, varint compression yok)
+  // — session_id rastgele 64-bit hash bit'lerinden türetildiği için varint
+  // ortalama ~9 byte yer kaplardı. Wire kilidi henüz üretim peer'ı yok
+  // (RESUME_V1 PR-G'de aktive edildi).
+  sfixed64 session_id         = 1;  // UKEY2 auth_key SHA-256[0..8] BE
   int64  payload_id           = 2;
   int64  offset               = 3;
   bytes  partial_hash         = 4;  // SHA-256(bytes[0..offset])


### PR DESCRIPTION
İki post-RFC-0004 medium yorumu:

| PR | Konu |
|---|---|
| #131 proto/hekadrop_extensions.proto:77 | `int64 session_id` → `sfixed64` (varint compression bypass, sabit 8 byte) |
| #135 resume.rs:487 | `entries.flatten()` → `match entry` (I/O hatalarını warn loglayıp skip; silent data corruption yok) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)