### PR TITLE
chore(rfc-0004): tier-2 medium cleanup — partial_dir cache + in_use_size budget

### DIFF
--- a/crates/hekadrop-core/src/connection.rs
+++ b/crates/hekadrop-core/src/connection.rs
@@ -957,12 +957,23 @@ async fn handle_sharing_frame(
                 } else {
                     None
                 };
+                // PR #133 medium: `partial_dir()` her dosya için ayrı çağrılıyordu
+                // (`resolve_resume_path` + `handle_resume_for_file`). Loop ÖNCESİ
+                // tek sefer hesapla — N dosya için 2N→1 dizin ensure I/O. None →
+                // HOME yok / mkdir başarısız → resume tamamen skip (fresh transfer).
+                let cached_partial_dir: Option<std::path::PathBuf> = if session_id.is_some() {
+                    crate::resume::partial_dir().ok()
+                } else {
+                    None
+                };
                 for (pid, fresh_path, display_name, announced_size) in planned_files {
                     // PR-G: RESUME_V1 + meta valid + meta.dest_path mevcut →
                     // fresh placeholder'ı sil + meta.dest_path'i register et
                     // (mevcut `.part` üstüne devam). Aksi halde fresh_path.
-                    let actual_path = if let Some(sid) = session_id {
-                        match resolve_resume_path(sid, pid, &display_name, announced_size) {
+                    let actual_path = if let (Some(sid), Some(dir)) =
+                        (session_id, cached_partial_dir.as_deref())
+                    {
+                        match resolve_resume_path(dir, sid, pid, &display_name, announced_size) {
                             Some(resume_path) => {
                                 // Fresh placeholder boş — sil, resume path'e geç.
                                 if let Err(e) = std::fs::remove_file(&fresh_path) {
@@ -997,11 +1008,12 @@ async fn handle_sharing_frame(
                     // RFC-0004 §3.3 — Introduction sonrası `.meta` lookup
                     // + (matching ise) `ResumeHint` emit. Hata yutulur:
                     // resume best-effort, fresh transfer her zaman OK.
-                    if let Some(sid) = session_id {
+                    if let (Some(sid), Some(dir)) = (session_id, cached_partial_dir.as_deref()) {
                         if let Err(e) = handle_resume_for_file(
                             socket,
                             ctx,
                             assembler,
+                            dir,
                             sid,
                             pid,
                             &display_name,
@@ -1169,21 +1181,23 @@ fn human_size(bytes: i64) -> String {
 /// silip bu path'i register eder. Aksi halde `None` (fresh transfer).
 ///
 /// Validate adımları (RFC §5'teki MUST'larla birebir):
-/// - `partial_dir` resolve OK
 /// - `.meta` load OK + `validate()` OK
 /// - `meta.file_name == announced display_name`
 /// - `meta.total_size == announced_total_size`
 /// - `meta.updated_at` TTL içinde
 /// - `meta.dest_path` non-empty + `Path::exists` + `metadata.len() ==
 ///   meta.received_bytes` (disk doğrulaması)
+///
+/// `dir` caller-cached `partial_dir()` — Introduction loop ÖNCESİ tek sefer
+/// hesaplanıp tüm dosyalar için reuse edilir (PR #133 medium follow-up).
 fn resolve_resume_path(
+    dir: &std::path::Path,
     session_id: i64,
     payload_id: i64,
     announced_display_name: &str,
     announced_total_size: i64,
 ) -> Option<std::path::PathBuf> {
-    let dir = crate::resume::partial_dir().ok()?;
-    let meta = crate::resume::PartialMeta::load(&dir, session_id, payload_id)
+    let meta = crate::resume::PartialMeta::load(dir, session_id, payload_id)
         .ok()
         .flatten()?;
     if meta.dest_path.is_empty() {
@@ -1241,6 +1255,7 @@ async fn handle_resume_for_file(
     socket: &mut TcpStream,
     ctx: &mut SecureCtx,
     assembler: &mut PayloadAssembler,
+    dir: &std::path::Path,
     session_id: i64,
     payload_id: i64,
     file_name: &str,
@@ -1251,14 +1266,15 @@ async fn handle_resume_for_file(
     use base64::Engine;
     use hekadrop_proto::hekadrop_ext::ResumeHint;
 
-    // 1. partial_dir resolve. HOME yoksa silently skip → fresh transfer.
-    let dir = crate::resume::partial_dir().context("resume: partial_dir resolve")?;
+    // PR #133 medium: `dir` caller-cached `partial_dir()`. Introduction loop'u
+    // tek sefer hesaplar, N dosya için reuse — N×`partial_dir()` mkdir I/O
+    // bedeli elimine.
 
-    // 2. `.meta` lookup. NotFound → fresh; load Err → silently skip.
-    //    PR-G: meta validate sonucuna göre `enable_resume_with_offset` ya da
-    //    `enable_resume` (fresh) çağrılır — resume aktivasyonu meta sonrasına
-    //    ertelendi ki `received_bytes` doğru injected olsun.
-    let maybe_meta = match crate::resume::PartialMeta::load(&dir, session_id, payload_id) {
+    // `.meta` lookup. NotFound → fresh; load Err → silently skip.
+    // PR-G: meta validate sonucuna göre `enable_resume_with_offset` ya da
+    // `enable_resume` (fresh) çağrılır — resume aktivasyonu meta sonrasına
+    // ertelendi ki `received_bytes` doğru injected olsun.
+    let maybe_meta = match crate::resume::PartialMeta::load(dir, session_id, payload_id) {
         Ok(opt) => opt,
         Err(e) => {
             tracing::debug!(

--- a/crates/hekadrop-core/src/resume.rs
+++ b/crates/hekadrop-core/src/resume.rs
@@ -561,11 +561,20 @@ pub fn cleanup_sweep(
     let now = Utc::now();
     let ttl = chrono::Duration::days(ttl_days);
     let mut survivors: Vec<Candidate> = Vec::with_capacity(candidates.len());
+    // PR #135 medium (3 yorum birleşik): aktif transferlerin `.part` boyutu
+    // budget hesabından dışarı bırakılırsa overshoot oluşur (in_use 4 GiB +
+    // survivors 1 GiB, budget 5 GiB → sweep "1 GiB ≤ 5 GiB OK" der ama disk
+    // gerçek 5 GiB sınırını zaten aşmış). `in_use_size` ayrı topla, budget
+    // karşılaştırmasında ekle; LRU evict yine yalnız survivors üstünde döner
+    // (in_use dosyalar dokunulmaz). `bytes_remaining` final disk truth'unu
+    // yansıtır (in_use + survivors).
+    let mut in_use_size: u64 = 0;
 
     for cand in candidates {
         if in_use.contains(&(cand.session_id, cand.payload_id)) {
-            // Aktif transfer — dokunma; budget hesabına da girmesin (caller
-            // sweep çıktıktan sonra hâlâ yazmayı sürdürebilir).
+            // Aktif transfer — dokunma + LRU adayı değil; ancak boyutu disk
+            // gerçeğine dahil → budget hesabında say.
+            in_use_size = in_use_size.saturating_add(cand.part_size);
             report.kept_in_use = report.kept_in_use.saturating_add(1);
             continue;
         }
@@ -580,14 +589,15 @@ pub fn cleanup_sweep(
         survivors.push(cand);
     }
 
-    // Aşama 2: Budget LRU pass.
-    let total: u64 = survivors
+    // Aşama 2: Budget LRU pass — `in_use_size`'ı dahil ederek karşılaştır.
+    let survivor_total: u64 = survivors
         .iter()
         .map(|c| c.part_size)
         .fold(0u64, u64::saturating_add);
+    let total = survivor_total.saturating_add(in_use_size);
 
     if total > budget_bytes {
-        // Eski-ilk sırala (ascending updated_at).
+        // Eski-ilk sırala (ascending updated_at) — yalnız survivors evict edilebilir.
         survivors.sort_by_key(|c| c.updated_at);
         let mut current = total;
         let mut idx = 0;
@@ -600,6 +610,9 @@ pub fn cleanup_sweep(
             current = current.saturating_sub(freed);
             idx += 1;
         }
+        // INVARIANT: `current` >= `in_use_size` her zaman (yalnız survivors evict
+        // edilir). `current > budget_bytes` hâlâ true ise budget overshoot
+        // in_use dosyaları yüzünden kaçınılmaz — caller log/metric ile farkında.
         report.bytes_remaining = current;
     } else {
         report.bytes_remaining = total;
@@ -881,10 +894,73 @@ mod tests {
 
         assert_eq!(report.kept_in_use, 2, "in_use çiftleri korunmalı");
         assert_eq!(report.removed_ttl, 1, "TTL aşan tek çift silinmeli");
+        // PR #135 medium: in_use boyutu `bytes_remaining`'e dahil — disk
+        // gerçeği = 2 × 1024 (in_use) + 0 survivor = 2048.
+        assert_eq!(report.bytes_remaining, 2048);
         // in_use çiftleri hâlâ yerinde olmalı (.meta + .part).
         assert!(dir.join(meta_filename(1, 100)).exists());
         assert!(dir.join(meta_filename(2, 200)).exists());
         assert!(!dir.join(meta_filename(3, 300)).exists());
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn cleanup_in_use_counts_toward_budget() {
+        // PR #135 medium (3 yorum birleşik): aktif transferin `.part` boyutu
+        // budget hesabına girmeli — yoksa in_use 4 GiB + survivors 1 GiB +
+        // budget 5 GiB durumunda sweep "OK" der ama disk gerçek 5 GiB +
+        // sonraki write → 5 GiB sınırı aşılır.
+        //
+        // Test scale: in_use 3 MiB + 2 survivor × 2 MiB = 7 MiB total.
+        // Budget 5 MiB → in_use dahil edildiği için survivors üstünden 2 MiB
+        // (en eski) evict edilmeli. Edilmezse (eski davranış) 4 MiB ≤ 5 MiB
+        // OK görünür ve LRU tetiklenmez.
+        let dir = unique_tmp_dir("cleanup-in-use-budget");
+        let now = Utc::now();
+        let three_mib = 3 * 1024 * 1024;
+        let two_mib = 2 * 1024 * 1024;
+
+        // in_use: 3 MiB.
+        write_pair(&dir, 1, 100, now, Some(three_mib));
+        // Survivors: 2 MiB her biri, ikincisi yeni.
+        write_pair(
+            &dir,
+            2,
+            200,
+            now - chrono::Duration::hours(2),
+            Some(two_mib),
+        ); // en eski
+        write_pair(
+            &dir,
+            3,
+            300,
+            now - chrono::Duration::hours(1),
+            Some(two_mib),
+        );
+
+        let mut in_use = HashSet::new();
+        in_use.insert((1i64, 100i64));
+
+        let budget: u64 = 5 * 1024 * 1024;
+        let report = cleanup_sweep(&dir, RESUME_TTL_DAYS, budget, &in_use);
+
+        assert_eq!(report.kept_in_use, 1);
+        assert_eq!(report.removed_ttl, 0);
+        assert_eq!(
+            report.removed_budget, 1,
+            "in_use boyutu (3 MiB) dahil edildiği için en eski survivor evict edilmeli"
+        );
+        assert_eq!(report.bytes_freed as usize, two_mib);
+        // En eski survivor (2,200) evict; (1,100) in_use korundu; (3,300) survivor.
+        assert!(dir.join(meta_filename(1, 100)).exists(), "in_use korunmalı");
+        assert!(
+            !dir.join(meta_filename(2, 200)).exists(),
+            "en eski survivor evict"
+        );
+        assert!(dir.join(meta_filename(3, 300)).exists());
+        // bytes_remaining = in_use (3 MiB) + survivor (2 MiB) = 5 MiB.
+        assert_eq!(report.bytes_remaining as usize, 5 * 1024 * 1024);
 
         let _ = fs::remove_dir_all(&dir);
     }


### PR DESCRIPTION
## Why

PR-A→PR-G zincirinin (#131-#138) post-merge AI review yorumlarından kalan **tier-2 medium**'ları tek küçük cleanup PR'ında topla. Üç tema: `partial_dir()` redundant call, `cleanup_sweep` budget tutarsızlığı, defer'lı iki yorum için spec referansı.

## Yorum → aksiyon mapping

| PR | Konum | Tema | Aksiyon |
|---|---|---|---|
| #133 | `connection.rs:1170` | Loop içinde her dosya için ayrı `partial_dir()` | **Fix**: cache + `&Path` parametre |
| #133 | `connection.rs:1221` | `spawn_blocking` ile async I/O | **Defer + cevap**: ResumeHint emit < 100 ms; spec §1 sequential I/O |
| #133 | `payload.rs:574` | `created_at` preservation | **Already fixed**: PR-G `payload.rs:1109` `get_or_insert(now)` |
| #134 | `sender.rs:1113` | Per-file 2 sn bekleme penceresi sıralı | **Defer + cevap**: RFC §1 normative; v0.8.1 pipeline opt |
| #135 | `resume.rs:463+550+586` | `in_use_size` budget hesabı | **Fix**: tek değişiklik (üç yorum tek tema) |

## Fix detayı

### 1. `partial_dir()` cache (connection.rs)

`Introduction` handler her dosya için iki kere `crate::resume::partial_dir()` çağırıyordu (`resolve_resume_path` + `handle_resume_for_file`). Loop ÖNCESİ tek sefer hesapla, helper'lara `&Path` geç → N dosya için **2N→1** mkdir + chmod I/O.

### 2. `in_use_size` budget hesabı (resume.rs)

`cleanup_sweep` `in_use` çiftleri inventory'den tamamen atıyordu — aktif transferin `.part` boyutu budget'a girmeyince:

```
in_use 4 GiB + survivor 1 GiB + budget 5 GiB
→ sweep "1 ≤ 5 OK" der → disk gerçek 5 GiB'ı zaten aşmış → overshoot
```

Fix: `in_use_size` ayrı topla, `total = survivor + in_use` ile karşılaştır. LRU evict yine yalnız survivors üstünde döner (in_use dokunulmaz semantiği korundu). `bytes_remaining` artık disk truth'unu yansıtır (in_use + survivor).

### 3. `created_at` (defer-tipi: NO-OP)

PR-G zaten `payload.rs:1109::write_resume_checkpoint` içinde `*rs.created_at.get_or_insert(now)` ile resume'da eski timestamp'i koruyor. Ek aksiyon yok.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace` — 253 → 254 test (yeni: `cleanup_in_use_counts_toward_budget`)
- [x] 5 `cleanup_*` test yeşil; `cleanup_skips_in_use`'a `bytes_remaining=2048` assert eklendi
- [x] I-1/I-2/I-3 invariant grep temiz

## Defer cevap yorumları

PR #133 (#1221) ve PR #134 (#1113) için spec referanslı cevap yorumu ayrıca eklenecek (review-comment reply).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>