### PR TITLE
feat(rfc-0005): PR-B — HEKABUND encoder/decoder primitives + manifest + sanitize

### DIFF
--- a/crates/hekadrop-core/src/folder/bundle.rs
+++ b/crates/hekadrop-core/src/folder/bundle.rs
@@ -1,0 +1,656 @@
+//! RFC-0005 §2 — `HEKABUND` v1 wire-byte container.
+//!
+//! Stateless encoder/decoder primitives. Sender bu modülü `BundleWriter` ile
+//! header + manifest + chunked body bytes üretmek için kullanır; receiver
+//! `BundleReader` ile temp `.bundle` file'ını parse + trailer verify eder.
+//!
+//! Bu modül **disk I/O policy'si tanımlamaz** — `BundleWriter` saf hash chain
+//! ile header/trailer encoder işidir; caller (sender pipeline) byte'ları
+//! nereye yazacağını seçer (TCP socket veya `FileSink`). `BundleReader`
+//! `std::fs::File` üzerinden çalışır çünkü receiver per-file extract için
+//! seek/random read ihtiyacı duyar.
+//!
+//! Wire layout (`docs/protocol/folder-payload.md` §2):
+//! ```text
+//! offset           size       field
+//! ---------------  ---------  -------------------
+//! 0                8          magic = b"HEKABUND"
+//! 8                4          version (BE u32; v1 = 1)
+//! 12               4          manifest_len (BE u32; ≤ 8 MiB)
+//! 16               N          manifest_json (UTF-8)
+//! 16+N             M          concat_data
+//! 16+N+M           32         trailer_sha256
+//! ```
+
+use crate::folder::manifest::ManifestError;
+use sha2::{Digest, Sha256};
+use std::fs::File;
+use std::io::{self, Read, Seek, SeekFrom};
+use subtle::ConstantTimeEq;
+
+/// `HEKABUND` magic — bundle'ın ilk 8 byte'ı (ASCII).
+pub const HEKABUND_MAGIC: [u8; 8] = *b"HEKABUND";
+
+/// `HEKABUND` v1 wire sürümü (BE u32).
+pub const HEKABUND_VERSION: u32 = 1;
+
+/// Trailer SHA-256 uzunluğu (sabit).
+pub const TRAILER_LEN: usize = 32;
+
+/// `manifest_len` üst sınırı: 8 MiB (`docs/.../folder-payload.md` §2.3).
+pub const MAX_MANIFEST_LEN: u32 = 8 * 1024 * 1024;
+
+/// Header uzunluğu: magic (8) + version (4) + `manifest_len` (4) = 16 byte.
+pub const HEADER_LEN: usize = 8 + 4 + 4;
+
+/// `HEKABUND` header — 16 byte sabit.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BundleHeader {
+    /// Wire sürümü; v1 boyunca `HEKABUND_VERSION` (== 1).
+    pub version: u32,
+    /// Manifest JSON byte uzunluğu (≤ `MAX_MANIFEST_LEN`).
+    pub manifest_len: u32,
+}
+
+impl BundleHeader {
+    /// Header'ı 16-byte fixed-size buffer'a encode et (magic + version BE +
+    /// `manifest_len` BE).
+    #[must_use]
+    pub fn encode(&self) -> [u8; HEADER_LEN] {
+        let mut out = [0u8; HEADER_LEN];
+        out[0..8].copy_from_slice(&HEKABUND_MAGIC);
+        out[8..12].copy_from_slice(&self.version.to_be_bytes());
+        out[12..16].copy_from_slice(&self.manifest_len.to_be_bytes());
+        out
+    }
+
+    /// Header'ı slice'tan parse et — magic gate, version check, `manifest_len`
+    /// cap.
+    ///
+    /// Sıra (`docs/.../folder-payload.md` §2.2 / §2.3):
+    /// 1. uzunluk en az `HEADER_LEN`
+    /// 2. magic `HEKABUND`
+    /// 3. `version == HEKABUND_VERSION`
+    /// 4. `manifest_len ≤ MAX_MANIFEST_LEN` (denial-of-service guard)
+    /// 5. `manifest_len > 0` (en az `version` + `root_name` + `total_entries`
+    ///    + `entries`)
+    pub fn decode(bytes: &[u8]) -> Result<Self, BundleError> {
+        if bytes.len() < HEADER_LEN {
+            return Err(BundleError::HeaderTooShort {
+                got: bytes.len(),
+                need: HEADER_LEN,
+            });
+        }
+
+        // INVARIANT: slice uzunluğu ≥ 16 yukarıda doğrulandı; aşağıdaki
+        // try_into'lar sabit-array slice → array, infallible.
+        #[allow(clippy::expect_used)] // INVARIANT: 8-byte slice → [u8; 8] sonsuz.
+        let magic: [u8; 8] = bytes[0..8].try_into().expect("8-byte slice");
+        if magic != HEKABUND_MAGIC {
+            return Err(BundleError::MagicMismatch(magic));
+        }
+
+        #[allow(clippy::expect_used)] // INVARIANT: 4-byte slice → [u8; 4] sonsuz.
+        let version_bytes: [u8; 4] = bytes[8..12].try_into().expect("4-byte slice");
+        let version = u32::from_be_bytes(version_bytes);
+        if version != HEKABUND_VERSION {
+            return Err(BundleError::UnsupportedVersion(version));
+        }
+
+        #[allow(clippy::expect_used)] // INVARIANT: 4-byte slice → [u8; 4] sonsuz.
+        let manifest_len_bytes: [u8; 4] = bytes[12..16].try_into().expect("4-byte slice");
+        let manifest_len = u32::from_be_bytes(manifest_len_bytes);
+        if manifest_len == 0 {
+            return Err(BundleError::ManifestLenZero);
+        }
+        if manifest_len > MAX_MANIFEST_LEN {
+            return Err(BundleError::ManifestLenExceeded {
+                len: manifest_len,
+                limit: MAX_MANIFEST_LEN,
+            });
+        }
+
+        Ok(Self {
+            version,
+            manifest_len,
+        })
+    }
+}
+
+/// Streaming bundle writer — sender pipeline'ı kullanır.
+///
+/// Yaşam döngüsü:
+/// 1. `BundleWriter::new(&manifest_json)` → header (16 byte) + `manifest_json`
+///    bytes hash chain'e push edilir; ilk frame caller'a header + manifest
+///    bytes'ı socket'e yazsın diye `header_bytes()` + `manifest_json` döner.
+/// 2. her file body chunk'ı için `update(chunk)` → SHA-256 hasher'a feed.
+/// 3. `finalize()` → trailer 32 byte döner; caller bunu socket'e yazar
+///    bundle'ın sonunu mühürler.
+///
+/// **Caller sözleşmesi:** `update`'e geçirilen bayt sırası ve uzunluğu
+/// `manifest.entries` içindeki file order ile **byte-exact** olmalı; aksi
+/// halde receiver trailer fail eder. Writer bu sırayı kontrol etmez (caller
+/// state machine'in işi).
+#[derive(Debug)]
+pub struct BundleWriter {
+    hasher: Sha256,
+    header_bytes: [u8; HEADER_LEN],
+    /// Hash chain için tutulan stat (header + manifest + body toplamı).
+    /// İleri PR'larda progress raporlama için public accessor düşünülebilir.
+    written_so_far: u64,
+}
+
+impl BundleWriter {
+    /// Yeni writer — header üret, header + `manifest_json` hash chain'e
+    /// commit.
+    ///
+    /// Hatalar:
+    /// - `manifest_json` boş → `ManifestLenZero`
+    /// - `manifest_json.len() > MAX_MANIFEST_LEN` → `ManifestLenExceeded`
+    /// - `manifest_json.len() > u32::MAX` (32-bit hedef): bu fonksiyon
+    ///   doğrudan check eder, panic yok.
+    pub fn new(manifest_json: &[u8]) -> Result<Self, BundleError> {
+        if manifest_json.is_empty() {
+            return Err(BundleError::ManifestLenZero);
+        }
+        // CLAUDE.md I-5: peer-controlled length; checked downcast.
+        // 32-bit hedeflerde usize == u32 → try_from infallible. 64-bit
+        // hedeflerde usize > u32::MAX olabilir (4 GiB+ manifest_json).
+        // try_from None ise zaten MAX_MANIFEST_LEN (8 MiB) sınırının çok
+        // üstünde — `len: u32::MAX` rapor.
+        let manifest_len: u32 = match u32::try_from(manifest_json.len()) {
+            Ok(n) => n,
+            Err(_) => {
+                // INVARIANT (CLAUDE.md I-3): TryFromIntError taşıyacak ek
+                // bilgi yok; `BundleError::ManifestLenExceeded.len` field'ı
+                // canonical reporting yeri. `_` discard pattern (NOT `_e`)
+                // — workspace clippy::map_err_ignore lint kuralının
+                // BYPASS değil, gerçek discard.
+                return Err(BundleError::ManifestLenExceeded {
+                    len: u32::MAX,
+                    limit: MAX_MANIFEST_LEN,
+                });
+            }
+        };
+        if manifest_len > MAX_MANIFEST_LEN {
+            return Err(BundleError::ManifestLenExceeded {
+                len: manifest_len,
+                limit: MAX_MANIFEST_LEN,
+            });
+        }
+
+        let header = BundleHeader {
+            version: HEKABUND_VERSION,
+            manifest_len,
+        };
+        let header_bytes = header.encode();
+
+        let mut hasher = Sha256::new();
+        hasher.update(header_bytes);
+        hasher.update(manifest_json);
+
+        let written_so_far = (HEADER_LEN as u64) + u64::from(manifest_len);
+
+        Ok(Self {
+            hasher,
+            header_bytes,
+            written_so_far,
+        })
+    }
+
+    /// Header bytes'ı döndür — caller socket'e yazar.
+    #[must_use]
+    pub fn header_bytes(&self) -> [u8; HEADER_LEN] {
+        self.header_bytes
+    }
+
+    /// Dosya body chunk'ı hash chain'e feed et.
+    pub fn update(&mut self, body_chunk: &[u8]) {
+        self.hasher.update(body_chunk);
+        // INVARIANT (CLAUDE.md I-5): `written_so_far` u64; chunk len usize.
+        // saturating_add ile overflow defensive — pratikte u64 sınırına
+        // (16 EiB) ulaşmadan diskler dolar.
+        let chunk_len = u64::try_from(body_chunk.len()).unwrap_or(u64::MAX);
+        self.written_so_far = self.written_so_far.saturating_add(chunk_len);
+    }
+
+    /// Şimdiye kadar hash'lenen byte sayısı (header + manifest + body).
+    #[must_use]
+    pub fn written_so_far(&self) -> u64 {
+        self.written_so_far
+    }
+
+    /// Trailer üret — 32-byte SHA-256 digest.
+    ///
+    /// **Önemli:** finalize sonrası writer kullanılamaz hale gelir; tek-shot
+    /// sözleşmesi.
+    #[must_use]
+    pub fn finalize(self) -> [u8; TRAILER_LEN] {
+        self.hasher.finalize().into()
+    }
+}
+
+/// Streaming bundle reader — receiver temp `.bundle` file'ını parse eder.
+///
+/// `open` çağrısı:
+/// 1. Header (16 byte) read + decode (magic / version / `manifest_len` cap)
+/// 2. Manifest JSON read (`manifest_len` byte; UTF-8 sınama caller'a — JSON
+///    parser zaten UTF-8 enforce eder)
+/// 3. Trailer offset hesabı: `bundle_len - 32`
+/// 4. Trailer SHA-256 verify: `[0 .. bundle_len-32]` üzerinden hash hesapla,
+///    constant-time karşılaştır.
+///
+/// Verify başarısızsa `BundleError::TrailerMismatch`. Verify OK ise reader
+/// state'inde `manifest_json` bytes + header + `bundle_len` tutulur; PR-D'de
+/// `into_extractor()` API'si entries iterate eder.
+#[derive(Debug)]
+pub struct BundleReader {
+    file: File,
+    header: BundleHeader,
+    manifest_json: Vec<u8>,
+    /// Toplam bundle boyutu (header + manifest + body + trailer).
+    bundle_len: u64,
+}
+
+impl BundleReader {
+    /// Bundle file'ını aç + header / manifest / trailer parse + verify.
+    pub fn open(path: &std::path::Path) -> Result<Self, BundleError> {
+        let mut file = File::open(path)?;
+        let bundle_len = file.metadata()?.len();
+        if bundle_len < (HEADER_LEN as u64).saturating_add(TRAILER_LEN as u64) {
+            return Err(BundleError::BundleTooShort {
+                got: bundle_len,
+                need: (HEADER_LEN as u64).saturating_add(TRAILER_LEN as u64),
+            });
+        }
+
+        // 1. Header
+        let mut header_buf = [0u8; HEADER_LEN];
+        file.read_exact(&mut header_buf)?;
+        let header = BundleHeader::decode(&header_buf)?;
+
+        // 2. manifest_len consistency: manifest + trailer payload sığmalı
+        let manifest_end = (HEADER_LEN as u64).saturating_add(u64::from(header.manifest_len));
+        let trailer_start = bundle_len.saturating_sub(TRAILER_LEN as u64);
+        if manifest_end > trailer_start {
+            return Err(BundleError::ManifestOverflowsBundle {
+                manifest_len: header.manifest_len,
+                bundle_len,
+            });
+        }
+
+        // 3. Manifest JSON
+        // INVARIANT (CLAUDE.md I-5): manifest_len ≤ MAX_MANIFEST_LEN (8 MiB)
+        // BundleHeader::decode'da zaten doğrulandı; usize allocation güvenli.
+        let mut manifest_json = vec![0u8; header.manifest_len as usize];
+        file.read_exact(&mut manifest_json)?;
+
+        // 4. Trailer + concat_data toplu hash
+        // Hashlemek için file'ı baştan tekrar oku — header + manifest +
+        // concat_data. Trailer'ı dışla.
+        file.seek(SeekFrom::Start(0))?;
+        let mut hasher = Sha256::new();
+        let mut remaining = trailer_start;
+        let mut buf = vec![0u8; 64 * 1024];
+        while remaining > 0 {
+            let want = u64::min(remaining, buf.len() as u64);
+            // INVARIANT: want ≤ buf.len() ≤ usize::MAX; downcast güvenli.
+            let want_us = usize::try_from(want).unwrap_or(buf.len());
+            let n = file.read(&mut buf[..want_us])?;
+            if n == 0 {
+                return Err(BundleError::Io(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    "bundle truncated during trailer verify",
+                )));
+            }
+            hasher.update(&buf[..n]);
+            // n ≤ remaining (want_us ≤ remaining; read returns ≤ buf len)
+            remaining = remaining.saturating_sub(n as u64);
+        }
+        let computed: [u8; TRAILER_LEN] = hasher.finalize().into();
+
+        // Trailer bytes
+        let mut trailer = [0u8; TRAILER_LEN];
+        file.read_exact(&mut trailer)?;
+
+        // Constant-time compare (ConstantTimeEq module-top'tan).
+        if !bool::from(computed.ct_eq(&trailer)) {
+            return Err(BundleError::TrailerMismatch);
+        }
+
+        Ok(Self {
+            file,
+            header,
+            manifest_json,
+            bundle_len,
+        })
+    }
+
+    /// Header accessor.
+    #[must_use]
+    pub fn header(&self) -> BundleHeader {
+        self.header
+    }
+
+    /// Manifest JSON byte slice.
+    #[must_use]
+    pub fn manifest_json(&self) -> &[u8] {
+        &self.manifest_json
+    }
+
+    /// Toplam bundle byte boyutu.
+    #[must_use]
+    pub fn bundle_len(&self) -> u64 {
+        self.bundle_len
+    }
+
+    /// Concat-data byte boyutu (header + manifest + trailer çıkartılmış).
+    #[must_use]
+    pub fn concat_data_len(&self) -> u64 {
+        self.bundle_len
+            .saturating_sub(HEADER_LEN as u64)
+            .saturating_sub(u64::from(self.header.manifest_len))
+            .saturating_sub(TRAILER_LEN as u64)
+    }
+
+    /// File handle'ı consume + döndür (PR-D extractor için seek/read
+    /// ihtiyacı). Caller offset'i `HEADER_LEN + manifest_len`'e seek etmeli.
+    #[must_use]
+    pub fn into_file(self) -> File {
+        self.file
+    }
+}
+
+/// `BundleWriter` / `BundleReader` hata kategorileri.
+#[derive(Debug, thiserror::Error)]
+pub enum BundleError {
+    /// Magic 8 byte `HEKABUND` değil — corrupt bundle veya wrong-format file.
+    #[error("magic mismatch (expected HEKABUND, got {0:?})")]
+    MagicMismatch([u8; 8]),
+
+    /// `version` field'ı `HEKABUND_VERSION` değil — peer schema-bumped
+    /// (`FOLDER_STREAM_V2`+) veya corrupt.
+    #[error("unsupported version {0}")]
+    UnsupportedVersion(u32),
+
+    /// `manifest_len > MAX_MANIFEST_LEN` (8 MiB) — denial-of-service guard.
+    #[error("manifest_len {len} exceeds limit {limit}")]
+    ManifestLenExceeded { len: u32, limit: u32 },
+
+    /// `manifest_len == 0` — schema gereği version + `root_name` + …
+    /// minimum yer tutmalı.
+    #[error("manifest_len is zero")]
+    ManifestLenZero,
+
+    /// `manifest_len` payload sınırını aşıyor (header + manifest > `bundle_len`
+    /// - trailer).
+    #[error("manifest_len {manifest_len} overflows bundle (bundle_len = {bundle_len})")]
+    ManifestOverflowsBundle { manifest_len: u32, bundle_len: u64 },
+
+    /// Header read için en az `HEADER_LEN` byte gerekiyor.
+    #[error("header too short: got {got} bytes, need {need}")]
+    HeaderTooShort { got: usize, need: usize },
+
+    /// Bundle dosyası header + trailer minimumundan kısa.
+    #[error("bundle file too short: got {got} bytes, need at least {need}")]
+    BundleTooShort { got: u64, need: u64 },
+
+    /// Trailer SHA-256 hesabı bundle'daki son 32 byte ile eşleşmiyor —
+    /// tampering veya disk corruption.
+    #[error("trailer SHA-256 mismatch")]
+    TrailerMismatch,
+
+    /// Manifest JSON parse hatası (UTF-8, sözdizimi).
+    #[error("manifest JSON parse error: {0}")]
+    ManifestJson(#[from] serde_json::Error),
+
+    /// Manifest schema-level validate hatası.
+    #[error("manifest validation: {0}")]
+    Manifest(#[from] ManifestError),
+
+    /// I/O hatası (file read/write/seek).
+    #[error("I/O error: {0}")]
+    Io(#[from] io::Error),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    fn write_bundle_to_temp(manifest_json: &[u8], bodies: &[&[u8]]) -> NamedTempFile {
+        let mut writer = BundleWriter::new(manifest_json).unwrap();
+        let header_bytes = writer.header_bytes();
+
+        let mut tmp = NamedTempFile::new().unwrap();
+        tmp.write_all(&header_bytes).unwrap();
+        tmp.write_all(manifest_json).unwrap();
+        for body in bodies {
+            tmp.write_all(body).unwrap();
+            writer.update(body);
+        }
+        let trailer = writer.finalize();
+        tmp.write_all(&trailer).unwrap();
+        tmp.flush().unwrap();
+        tmp
+    }
+
+    // ------------------------------------------------------------------
+    // BundleHeader tests
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn bundle_header_constants() {
+        assert_eq!(HEKABUND_MAGIC, *b"HEKABUND");
+        assert_eq!(HEKABUND_VERSION, 1);
+        assert_eq!(HEADER_LEN, 16);
+        assert_eq!(TRAILER_LEN, 32);
+        assert_eq!(MAX_MANIFEST_LEN, 8 * 1024 * 1024);
+    }
+
+    #[test]
+    fn bundle_header_encode_decode_roundtrip() {
+        let header = BundleHeader {
+            version: 1,
+            manifest_len: 1234,
+        };
+        let bytes = header.encode();
+        assert_eq!(bytes.len(), HEADER_LEN);
+        // Magic is first 8 bytes
+        assert_eq!(&bytes[0..8], &HEKABUND_MAGIC);
+        // Version BE
+        assert_eq!(&bytes[8..12], &[0, 0, 0, 1]);
+        // manifest_len BE
+        assert_eq!(&bytes[12..16], &[0, 0, 0x04, 0xD2]); // 1234 = 0x04D2
+
+        let back = BundleHeader::decode(&bytes).unwrap();
+        assert_eq!(back, header);
+    }
+
+    #[test]
+    fn bundle_header_too_short_errors() {
+        let bytes = [0u8; 10];
+        let r = BundleHeader::decode(&bytes);
+        assert!(matches!(
+            r,
+            Err(BundleError::HeaderTooShort { got: 10, need: 16 })
+        ));
+    }
+
+    #[test]
+    fn bundle_header_magic_mismatch_errors() {
+        let mut bytes = [0u8; HEADER_LEN];
+        bytes[0..8].copy_from_slice(b"NOTBUNDL");
+        bytes[8..12].copy_from_slice(&1u32.to_be_bytes());
+        bytes[12..16].copy_from_slice(&100u32.to_be_bytes());
+        let r = BundleHeader::decode(&bytes);
+        assert!(matches!(r, Err(BundleError::MagicMismatch(_))));
+    }
+
+    #[test]
+    fn bundle_header_version_unsupported_errors() {
+        let mut bytes = [0u8; HEADER_LEN];
+        bytes[0..8].copy_from_slice(&HEKABUND_MAGIC);
+        bytes[8..12].copy_from_slice(&2u32.to_be_bytes());
+        bytes[12..16].copy_from_slice(&100u32.to_be_bytes());
+        let r = BundleHeader::decode(&bytes);
+        assert!(matches!(r, Err(BundleError::UnsupportedVersion(2))));
+    }
+
+    #[test]
+    fn bundle_header_manifest_len_zero_errors() {
+        let mut bytes = [0u8; HEADER_LEN];
+        bytes[0..8].copy_from_slice(&HEKABUND_MAGIC);
+        bytes[8..12].copy_from_slice(&1u32.to_be_bytes());
+        bytes[12..16].copy_from_slice(&0u32.to_be_bytes());
+        let r = BundleHeader::decode(&bytes);
+        assert!(matches!(r, Err(BundleError::ManifestLenZero)));
+    }
+
+    #[test]
+    fn bundle_header_manifest_len_too_large_errors() {
+        let mut bytes = [0u8; HEADER_LEN];
+        bytes[0..8].copy_from_slice(&HEKABUND_MAGIC);
+        bytes[8..12].copy_from_slice(&1u32.to_be_bytes());
+        bytes[12..16].copy_from_slice(&(MAX_MANIFEST_LEN + 1).to_be_bytes());
+        let r = BundleHeader::decode(&bytes);
+        assert!(matches!(r, Err(BundleError::ManifestLenExceeded { .. })));
+    }
+
+    // ------------------------------------------------------------------
+    // BundleWriter tests
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn bundle_writer_rejects_empty_manifest() {
+        let r = BundleWriter::new(&[]);
+        assert!(matches!(r, Err(BundleError::ManifestLenZero)));
+    }
+
+    #[test]
+    fn bundle_writer_rejects_oversized_manifest() {
+        let big = vec![0u8; (MAX_MANIFEST_LEN as usize) + 1];
+        let r = BundleWriter::new(&big);
+        assert!(matches!(r, Err(BundleError::ManifestLenExceeded { .. })));
+    }
+
+    #[test]
+    fn bundle_writer_finalize_matches_independent_sha256() {
+        let manifest_json = br#"{"version":1,"root_name":"x","total_entries":0,"entries":[],"created_utc":"2026-01-01T00:00:00Z"}"#;
+        let body_a: &[u8] = b"hello";
+        let body_b: &[u8] = b"world";
+
+        // Streaming
+        let mut w = BundleWriter::new(manifest_json).unwrap();
+        w.update(body_a);
+        w.update(body_b);
+        let trailer_streaming = w.finalize();
+
+        // Independent
+        let mut h = Sha256::new();
+        let header = BundleHeader {
+            version: 1,
+            manifest_len: manifest_json.len() as u32,
+        }
+        .encode();
+        h.update(header);
+        h.update(manifest_json);
+        h.update(body_a);
+        h.update(body_b);
+        let trailer_baseline: [u8; 32] = h.finalize().into();
+
+        assert_eq!(trailer_streaming, trailer_baseline);
+    }
+
+    #[test]
+    fn bundle_writer_written_so_far_tracks_bytes() {
+        let manifest_json = br#"{"k":"v"}"#;
+        let mut w = BundleWriter::new(manifest_json).unwrap();
+        // header (16) + manifest (9)
+        assert_eq!(w.written_so_far(), 25);
+        w.update(&[0u8; 100]);
+        assert_eq!(w.written_so_far(), 125);
+        w.update(&[0u8; 50]);
+        assert_eq!(w.written_so_far(), 175);
+    }
+
+    // ------------------------------------------------------------------
+    // BundleReader tests
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn bundle_reader_open_roundtrip() {
+        let manifest_json = br#"{"version":1,"root_name":"x","total_entries":0,"entries":[],"created_utc":"2026-01-01T00:00:00Z"}"#;
+        let body_a: &[u8] = b"hello";
+        let body_b: &[u8] = b"world";
+
+        let tmp = write_bundle_to_temp(manifest_json, &[body_a, body_b]);
+        let reader = BundleReader::open(tmp.path()).unwrap();
+        assert_eq!(reader.header().version, 1);
+        assert_eq!(reader.header().manifest_len as usize, manifest_json.len());
+        assert_eq!(reader.manifest_json(), manifest_json);
+        assert_eq!(reader.concat_data_len(), 10); // hello + world
+    }
+
+    #[test]
+    fn bundle_reader_trailer_one_bit_flip_detected() {
+        let manifest_json = br#"{"version":1,"root_name":"x","total_entries":0,"entries":[],"created_utc":"2026-01-01T00:00:00Z"}"#;
+        let body: &[u8] = b"abcdefgh";
+
+        let tmp = write_bundle_to_temp(manifest_json, &[body]);
+
+        // Tamper: read all bytes, flip one body bit, write back to a new temp.
+        let bytes = std::fs::read(tmp.path()).unwrap();
+        let mut tampered = bytes.clone();
+        // body offset = HEADER_LEN + manifest_len
+        let body_offset = HEADER_LEN + manifest_json.len();
+        tampered[body_offset] ^= 0x01;
+
+        let tmp2 = NamedTempFile::new().unwrap();
+        std::fs::write(tmp2.path(), &tampered).unwrap();
+
+        let r = BundleReader::open(tmp2.path());
+        assert!(matches!(r, Err(BundleError::TrailerMismatch)), "got {r:?}");
+    }
+
+    #[test]
+    fn bundle_reader_truncated_file_rejected() {
+        let manifest_json = br#"{"k":"v"}"#;
+        let tmp = write_bundle_to_temp(manifest_json, &[b"x"]);
+
+        // Truncate to less than HEADER + TRAILER.
+        let truncated = std::fs::read(tmp.path()).unwrap();
+        let tmp2 = NamedTempFile::new().unwrap();
+        std::fs::write(tmp2.path(), &truncated[..10]).unwrap();
+
+        let r = BundleReader::open(tmp2.path());
+        assert!(matches!(r, Err(BundleError::BundleTooShort { .. })));
+    }
+
+    #[test]
+    fn bundle_reader_magic_mismatch_rejected() {
+        let manifest_json = br#"{"k":"v"}"#;
+        let tmp = write_bundle_to_temp(manifest_json, &[b"x"]);
+
+        let mut bytes = std::fs::read(tmp.path()).unwrap();
+        bytes[0] = b'X'; // tamper magic
+        let tmp2 = NamedTempFile::new().unwrap();
+        std::fs::write(tmp2.path(), &bytes).unwrap();
+
+        let r = BundleReader::open(tmp2.path());
+        assert!(matches!(r, Err(BundleError::MagicMismatch(_))));
+    }
+
+    #[test]
+    fn bundle_reader_concat_data_len_zero_for_no_files() {
+        let manifest_json = br#"{"version":1,"root_name":"x","total_entries":0,"entries":[],"created_utc":"2026-01-01T00:00:00Z"}"#;
+        let tmp = write_bundle_to_temp(manifest_json, &[]);
+        let reader = BundleReader::open(tmp.path()).unwrap();
+        assert_eq!(reader.concat_data_len(), 0);
+        assert_eq!(
+            reader.bundle_len(),
+            (HEADER_LEN + manifest_json.len() + TRAILER_LEN) as u64
+        );
+    }
+}

--- a/crates/hekadrop-core/src/folder/manifest.rs
+++ b/crates/hekadrop-core/src/folder/manifest.rs
@@ -1,0 +1,437 @@
+//! RFC-0005 §3 — `BundleManifest` JSON schema (in-bundle).
+//!
+//! Manifest, `HEKABUND` container'ın `manifest_json` slot'unda yaşar (UTF-8,
+//! ≤ 8 MiB). Wire'da protobuf değildir — `FolderManifest` proto mesajı v1'de
+//! kasıtlı olarak boştur (slot ABI mühürleme; bkz.
+//! `crates/hekadrop-proto/proto/hekadrop_extensions.proto`).
+//!
+//! Wire-byte-exact spec: `docs/protocol/folder-payload.md` §3.
+
+use crate::folder::sanitize::{sanitize_received_relative_path, sanitize_root_name, PathError};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::collections::BTreeSet;
+
+/// Manifest schema sürümü — v0.8.x boyunca yalnız `1`.
+///
+/// Bump `FOLDER_STREAM_V<n>` capability bit gerektirir
+/// (bkz. `docs/protocol/folder-payload.md` §3.3).
+pub const MANIFEST_VERSION: u32 = 1;
+
+/// `total_entries` üst sınırı (RFC-0005 §3.3 / `docs/protocol/folder-payload.md`
+/// §3.2 satırı).
+pub const MAX_ENTRIES: u32 = 10_000;
+
+/// `BundleManifest` — `HEKABUND` içindeki kanonik metadata.
+///
+/// Field sırası `docs/protocol/folder-payload.md` §3.1 ile **byte-exact** —
+/// JSON canonicalization sırası bu struct field sırasına göre derive
+/// edilir (serde default top-level ordering).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct BundleManifest {
+    /// Schema version. Şu anda yalnız `1` geçerli (`MANIFEST_VERSION`).
+    pub version: u32,
+
+    /// Receiver'ın `~/Downloads/<root_name>/` altına extract ettiği klasör
+    /// adı. Sender tarafında sanitize edilmiş tek segment.
+    pub root_name: String,
+
+    /// `entries.len()` ile **eşleşmeli** (validate guard).
+    pub total_entries: u32,
+
+    /// Concat-data sırası bu vektörün sırasıyla aynıdır (file body'leri
+    /// birleştirilirken).
+    pub entries: Vec<ManifestEntry>,
+
+    /// ISO-8601 UTC ("…Z" suffix). Sender üretim zamanı; receiver UI'da
+    /// göstermek için.
+    pub created_utc: DateTime<Utc>,
+}
+
+/// `ManifestEntry` — file ya da directory varyantı (tagged union, JSON `type`
+/// alanı ayırır).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type", rename_all = "lowercase")]
+pub enum ManifestEntry {
+    /// File entry: body `concat_data`'da entry sırasına göre yer alır.
+    File {
+        /// Root-relative POSIX path (forward-slash separator).
+        path: String,
+        /// Body uzunluğu (byte). 0 ≤ size ≤ `i64::MAX` — wire kontratı u64
+        /// tutar ama negatif/aşırı değerler validate fail.
+        size: u64,
+        /// 64-char lowercase hex SHA-256 digest of body (`docs/.../folder-
+        /// payload.md` §3.1).
+        sha256: String,
+        /// İsteğe bağlı POSIX mode (decimal). Best-effort uygula; platform
+        /// desteklemiyorsa silently drop.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        mode: Option<u32>,
+        /// İsteğe bağlı Unix epoch saniyesi (mtime). Best-effort.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        mtime: Option<u64>,
+    },
+    /// Directory entry: `concat_data`'ya 0 byte katkı.
+    Directory {
+        /// Root-relative POSIX path.
+        path: String,
+        /// İsteğe bağlı POSIX mode (decimal).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        mode: Option<u32>,
+        /// İsteğe bağlı Unix epoch saniyesi.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        mtime: Option<u64>,
+    },
+}
+
+impl ManifestEntry {
+    /// Entry path'ini döndür (file / directory variant agnostic).
+    #[must_use]
+    pub fn path(&self) -> &str {
+        match self {
+            Self::File { path, .. } | Self::Directory { path, .. } => path,
+        }
+    }
+}
+
+impl BundleManifest {
+    /// Manifest schema-level validate guard (RFC-0005 §3.2).
+    ///
+    /// Sıra:
+    /// 1. `version == MANIFEST_VERSION`
+    /// 2. `total_entries == entries.len()` (and ≤ `MAX_ENTRIES`)
+    /// 3. `root_name` sanitize OK
+    /// 4. her entry path sanitize OK + duplicate path yok
+    /// 5. file entry'lerin `sha256` field'ı 64-char hex
+    pub fn validate(&self) -> Result<(), ManifestError> {
+        if self.version != MANIFEST_VERSION {
+            return Err(ManifestError::UnsupportedVersion(self.version));
+        }
+
+        let actual = self.entries.len();
+        // INVARIANT (CLAUDE.md I-5): peer-controlled `total_entries` u32, ama
+        // `entries.len()` usize. u32 → u64 lossless via From; usize → u64
+        // 64-bit hedeflerde lossless (CI matrix tüm hedefler 64-bit), 32-bit
+        // hedefte de usize ≤ u32 ≤ u64 yine lossless.
+        let claimed_u64 = u64::from(self.total_entries);
+        let actual_u64 = u64::try_from(actual).unwrap_or(u64::MAX);
+        if claimed_u64 != actual_u64 {
+            return Err(ManifestError::EntryCountMismatch {
+                claimed: self.total_entries,
+                actual,
+            });
+        }
+        if self.total_entries > MAX_ENTRIES {
+            return Err(ManifestError::EntryCountExceeded {
+                claimed: self.total_entries,
+                limit: MAX_ENTRIES,
+            });
+        }
+
+        sanitize_root_name(&self.root_name)?;
+
+        let mut seen: BTreeSet<&str> = BTreeSet::new();
+        for entry in &self.entries {
+            let path = entry.path();
+            sanitize_received_relative_path(path)?;
+            if !seen.insert(path) {
+                return Err(ManifestError::DuplicatePath(path.to_owned()));
+            }
+            if let ManifestEntry::File { sha256, .. } = entry {
+                if !is_lowercase_hex_64(sha256) {
+                    return Err(ManifestError::Sha256HexFormat);
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Manifest JSON canonical byte stream'inin SHA-256 digest'i.
+    ///
+    /// Bu fonksiyon struct'tan deterministik canonical JSON üretip hash
+    /// hesaplar. Sender-side intro-frame `attachment_hash` hesabı için
+    /// kullanılır. `serde_json::to_vec` infallible değil teknik olarak
+    /// (custom serializer panic'i mümkün) ama `BundleManifest`'in alanları
+    /// salt primitive + Vec/String/Option olduğundan derive Serialize hata
+    /// üretmez — yine de Result imzası API güvenliği için tutuluyor.
+    ///
+    /// Canonical encoding: `serde_json::to_vec` — field sırası struct
+    /// declaration sırasına göre. JSON whitespace yok (compact form).
+    pub fn manifest_sha256(&self) -> Result<[u8; 32], serde_json::Error> {
+        let bytes = serde_json::to_vec(self)?;
+        Ok(Self::sha256_of_bytes(&bytes))
+    }
+
+    /// Convenience: pre-serialized `manifest_json` bytes üzerinden hash.
+    /// Sender bundle build pipeline'ında `BundleWriter::new`'e geçirdiği
+    /// bytes ile aynı hash'i bağımsız hesaplamak için kullanır.
+    #[must_use]
+    pub fn sha256_of_bytes(manifest_json: &[u8]) -> [u8; 32] {
+        let mut hasher = Sha256::new();
+        hasher.update(manifest_json);
+        hasher.finalize().into()
+    }
+
+    /// Intro-frame `FileMetadata.attachment_hash` (signed i64) hesabı.
+    ///
+    /// `i64::from_be_bytes(manifest_sha256[0..8])` —
+    /// `docs/protocol/folder-payload.md` §4.1.
+    pub fn attachment_hash_i64(&self) -> Result<i64, serde_json::Error> {
+        let digest = self.manifest_sha256()?;
+        // INVARIANT: digest sabit 32 byte; [0..8] slice her zaman 8 byte.
+        // try_into() infallible — array → array.
+        #[allow(clippy::expect_used)] // INVARIANT: 32-byte digest, [0..8] her zaman 8 byte
+        let prefix: [u8; 8] = digest[0..8].try_into().expect("sha256 prefix is 8 bytes");
+        Ok(i64::from_be_bytes(prefix))
+    }
+}
+
+/// Convenience: 64-char lowercase hex check.
+fn is_lowercase_hex_64(s: &str) -> bool {
+    s.len() == 64 && s.bytes().all(|b| matches!(b, b'0'..=b'9' | b'a'..=b'f'))
+}
+
+/// Manifest validate guard hata kategorileri.
+///
+/// Receiver UI'da i18n key'e map'lenir; mesajlar log için.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum ManifestError {
+    /// `version` field'ı `MANIFEST_VERSION` değil.
+    #[error("schema version {0} unsupported")]
+    UnsupportedVersion(u32),
+
+    /// `total_entries` field'ı `entries.len()` ile eşleşmiyor.
+    #[error("total_entries {claimed} != entries.len() {actual}")]
+    EntryCountMismatch { claimed: u32, actual: usize },
+
+    /// `total_entries > MAX_ENTRIES` (10 000 cap).
+    #[error("total_entries {claimed} exceeds limit {limit}")]
+    EntryCountExceeded { claimed: u32, limit: u32 },
+
+    /// File entry sha256 64-char lowercase hex değil.
+    #[error("file sha256 hex format invalid")]
+    Sha256HexFormat,
+
+    /// İki veya daha fazla entry aynı path'e sahip.
+    #[error("duplicate path: {0}")]
+    DuplicatePath(String),
+
+    /// Path sanitize başarısız (`root_name` ya da entry path).
+    #[error("path sanitize failed: {0}")]
+    Path(#[from] PathError),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_file(path: &str, body: &[u8]) -> ManifestEntry {
+        let mut h = Sha256::new();
+        h.update(body);
+        let digest: [u8; 32] = h.finalize().into();
+        ManifestEntry::File {
+            path: path.to_owned(),
+            size: body.len() as u64,
+            sha256: hex_lower(&digest),
+            mode: None,
+            mtime: None,
+        }
+    }
+
+    fn hex_lower(bytes: &[u8]) -> String {
+        const HEX: &[u8; 16] = b"0123456789abcdef";
+        let mut s = String::with_capacity(bytes.len() * 2);
+        for b in bytes {
+            s.push(HEX[(b >> 4) as usize] as char);
+            s.push(HEX[(b & 0x0F) as usize] as char);
+        }
+        s
+    }
+
+    fn sample_manifest() -> BundleManifest {
+        BundleManifest {
+            version: MANIFEST_VERSION,
+            root_name: "kat1".to_owned(),
+            total_entries: 3,
+            entries: vec![
+                ManifestEntry::Directory {
+                    path: "subdir".to_owned(),
+                    mode: Some(0o755),
+                    mtime: None,
+                },
+                sample_file("a.txt", b"hello"),
+                sample_file("subdir/b.txt", b"world"),
+            ],
+            created_utc: DateTime::parse_from_rfc3339("2026-01-01T00:00:00Z")
+                .unwrap()
+                .with_timezone(&Utc),
+        }
+    }
+
+    #[test]
+    fn manifest_serde_roundtrip() {
+        let m = sample_manifest();
+        let json = serde_json::to_vec(&m).unwrap();
+        let back: BundleManifest = serde_json::from_slice(&json).unwrap();
+        assert_eq!(m, back);
+    }
+
+    #[test]
+    fn manifest_validate_ok() {
+        sample_manifest().validate().unwrap();
+    }
+
+    #[test]
+    fn manifest_validate_version_unsupported() {
+        let mut m = sample_manifest();
+        m.version = 2;
+        assert_eq!(m.validate(), Err(ManifestError::UnsupportedVersion(2)));
+    }
+
+    #[test]
+    fn manifest_validate_entry_count_mismatch() {
+        let mut m = sample_manifest();
+        m.total_entries = 99;
+        assert_eq!(
+            m.validate(),
+            Err(ManifestError::EntryCountMismatch {
+                claimed: 99,
+                actual: 3,
+            })
+        );
+    }
+
+    #[test]
+    fn manifest_validate_entry_count_exceeded() {
+        // entries.len() == total_entries == MAX_ENTRIES + 1 → reject.
+        let mut entries = Vec::with_capacity((MAX_ENTRIES as usize) + 1);
+        for i in 0..=MAX_ENTRIES {
+            entries.push(ManifestEntry::Directory {
+                path: format!("d{i}"),
+                mode: None,
+                mtime: None,
+            });
+        }
+        let m = BundleManifest {
+            version: MANIFEST_VERSION,
+            root_name: "big".to_owned(),
+            total_entries: MAX_ENTRIES + 1,
+            entries,
+            created_utc: Utc::now(),
+        };
+        assert_eq!(
+            m.validate(),
+            Err(ManifestError::EntryCountExceeded {
+                claimed: MAX_ENTRIES + 1,
+                limit: MAX_ENTRIES,
+            })
+        );
+    }
+
+    #[test]
+    fn manifest_validate_sha256_hex_format() {
+        let mut m = sample_manifest();
+        // İlk file entry'sinin sha256'sını bozalım (uppercase hex YASAK).
+        if let Some(ManifestEntry::File { sha256, .. }) = m
+            .entries
+            .iter_mut()
+            .find(|e| matches!(e, ManifestEntry::File { .. }))
+        {
+            *sha256 = sha256.to_uppercase();
+        }
+        assert_eq!(m.validate(), Err(ManifestError::Sha256HexFormat));
+    }
+
+    #[test]
+    fn manifest_validate_sha256_hex_short() {
+        let mut m = sample_manifest();
+        if let Some(ManifestEntry::File { sha256, .. }) = m
+            .entries
+            .iter_mut()
+            .find(|e| matches!(e, ManifestEntry::File { .. }))
+        {
+            *sha256 = "abcd".to_owned();
+        }
+        assert_eq!(m.validate(), Err(ManifestError::Sha256HexFormat));
+    }
+
+    #[test]
+    fn manifest_validate_duplicate_paths() {
+        let mut m = sample_manifest();
+        m.entries.push(sample_file("a.txt", b"different body"));
+        m.total_entries = 4;
+        assert_eq!(
+            m.validate(),
+            Err(ManifestError::DuplicatePath("a.txt".to_owned()))
+        );
+    }
+
+    #[test]
+    fn manifest_validate_path_traversal() {
+        let mut m = sample_manifest();
+        m.entries.push(sample_file("../escape.txt", b"x"));
+        m.total_entries = 4;
+        let err = m.validate().unwrap_err();
+        assert!(matches!(err, ManifestError::Path(PathError::Traversal)));
+    }
+
+    #[test]
+    fn manifest_validate_root_name_with_slash() {
+        let mut m = sample_manifest();
+        m.root_name = "foo/bar".to_owned();
+        let err = m.validate().unwrap_err();
+        assert!(matches!(
+            err,
+            ManifestError::Path(PathError::BackslashSeparator)
+        ));
+    }
+
+    #[test]
+    fn manifest_attachment_hash_deterministic() {
+        let m = sample_manifest();
+        let h1 = m.attachment_hash_i64().unwrap();
+        let h2 = m.attachment_hash_i64().unwrap();
+        assert_eq!(h1, h2);
+    }
+
+    #[test]
+    fn manifest_sha256_matches_independent_hash() {
+        let m = sample_manifest();
+        let json = serde_json::to_vec(&m).unwrap();
+        let from_struct = m.manifest_sha256().unwrap();
+        let from_bytes = BundleManifest::sha256_of_bytes(&json);
+        assert_eq!(from_struct, from_bytes);
+    }
+
+    #[test]
+    fn manifest_attachment_hash_first_8_bytes() {
+        let m = sample_manifest();
+        let digest = m.manifest_sha256().unwrap();
+        let expected = i64::from_be_bytes(digest[0..8].try_into().unwrap());
+        assert_eq!(m.attachment_hash_i64().unwrap(), expected);
+    }
+
+    #[test]
+    fn entry_path_accessor() {
+        let f = sample_file("a/b.txt", b"x");
+        assert_eq!(f.path(), "a/b.txt");
+        let d = ManifestEntry::Directory {
+            path: "x".to_owned(),
+            mode: None,
+            mtime: None,
+        };
+        assert_eq!(d.path(), "x");
+    }
+
+    #[test]
+    fn is_lowercase_hex_64_helper() {
+        assert!(is_lowercase_hex_64(&"a".repeat(64)));
+        assert!(is_lowercase_hex_64(&"0".repeat(64)));
+        assert!(!is_lowercase_hex_64(&"A".repeat(64)));
+        assert!(!is_lowercase_hex_64(&"a".repeat(63)));
+        assert!(!is_lowercase_hex_64(&"a".repeat(65)));
+        assert!(!is_lowercase_hex_64(&"g".repeat(64)));
+    }
+}

--- a/crates/hekadrop-core/src/folder/mod.rs
+++ b/crates/hekadrop-core/src/folder/mod.rs
@@ -1,0 +1,26 @@
+//! RFC-0005 — `folder_stream_v1` payload primitives.
+//!
+//! Bu modül stateless `HEKABUND` v1 wire-byte container ile in-bundle JSON
+//! manifest helper'larını barındırır. Sender (PR-C) ve receiver (PR-D) bunu
+//! ortak primitive seti olarak tüketir; modül kendisi UI/global state taşımaz.
+//!
+//! - [`bundle`] — `HEKABUND` header + streaming writer / reader, trailer SHA-256
+//! - [`manifest`] — `BundleManifest` JSON schema serde + validate guards
+//! - [`sanitize`] — per-segment path traversal + depth/null-byte/separator
+//!   guard; `..` reject (`docs/protocol/folder-payload.md` §5)
+//!
+//! Wire-byte-exact spec: `docs/protocol/folder-payload.md`
+//! Normative RFC: `docs/rfcs/0005-folder-payload.md`
+//! Capabilities gate: `crate::capabilities::features::FOLDER_STREAM_V1`
+//! (PR-D'de proto sırası kilitlenecek).
+
+pub mod bundle;
+pub mod manifest;
+pub mod sanitize;
+
+pub use bundle::{
+    BundleError, BundleHeader, BundleReader, BundleWriter, HEADER_LEN, HEKABUND_MAGIC,
+    HEKABUND_VERSION, MAX_MANIFEST_LEN, TRAILER_LEN,
+};
+pub use manifest::{BundleManifest, ManifestEntry, ManifestError, MANIFEST_VERSION, MAX_ENTRIES};
+pub use sanitize::{sanitize_received_relative_path, sanitize_root_name, PathError, MAX_DEPTH};

--- a/crates/hekadrop-core/src/folder/sanitize.rs
+++ b/crates/hekadrop-core/src/folder/sanitize.rs
@@ -1,0 +1,299 @@
+//! RFC-0005 §5 — `HEKABUND` per-segment path sanitization.
+//!
+//! Folder bundle her bir manifest entry'sinin `path` alanı için **per-segment**
+//! sanitize kuralları uygular. Bu bestaande `sanitize_received_name`
+//! (basename-only) helper'ından farklıdır:
+//!
+//! - basename-only helper `..` segmentini sessizce `"dosya"` olarak yeniden
+//!   yazar — single-file akışında zararsız ama multi-segment context'te
+//!   silent path mutation entries arası collision yaratabilir.
+//! - bu modül `..` görür görmez **tüm bundle'ı reject** eder; defensive
+//!   anti-traversal posture.
+//!
+//! Wire-byte-exact spec: `docs/protocol/folder-payload.md` §5.
+
+/// Per-segment path sanitize sonucu döner ya da hata fırlatır.
+///
+/// Kurallar (`docs/protocol/folder-payload.md` §5):
+/// - `\` (Windows separator) → reject (sender POSIX-normalize etmeliydi)
+/// - `\0` (NUL byte) → reject
+/// - `..` segment → reject (path traversal)
+/// - `.` segment → skip
+/// - boş segment (consecutive `/`, leading `/`) → skip
+/// - depth (sanitize sonrası segment sayısı) > 32 → reject
+/// - sanitize sonrası boş → reject
+///
+/// Bu helper **basename-only** karakter sanitize'i (control char, Windows
+/// reserved name, length cap) burada UYGULAMAZ — yalnız structural traversal
+/// guard. PR-D'de extract pipeline her segment'i ayrıca
+/// `sanitize_received_name` zinciriyle filtre eder; o katman karakter
+/// kontrolünü yapar.
+pub fn sanitize_received_relative_path(raw: &str) -> Result<Vec<String>, PathError> {
+    if raw.contains('\\') {
+        return Err(PathError::BackslashSeparator);
+    }
+    if raw.contains('\0') {
+        return Err(PathError::NullByte);
+    }
+
+    let mut out: Vec<String> = Vec::new();
+    for seg in raw.split('/') {
+        match seg {
+            "" | "." => continue,
+            ".." => return Err(PathError::Traversal),
+            other => out.push(other.to_owned()),
+        }
+    }
+
+    if out.len() > MAX_DEPTH {
+        return Err(PathError::DepthExceeded(out.len()));
+    }
+    if out.is_empty() {
+        return Err(PathError::Empty);
+    }
+
+    Ok(out)
+}
+
+/// `root_name` için sanitize: tek segment, `/` ve `\` yasak.
+///
+/// `BundleManifest.root_name` receiver'ın UI'da göreceği klasör ismi
+/// (`~/Downloads/<root_name>/`). Slash ya da backslash içermesi sender bug'ı
+/// veya hostile input'tur — reject.
+pub fn sanitize_root_name(raw: &str) -> Result<String, PathError> {
+    if raw.is_empty() {
+        return Err(PathError::Empty);
+    }
+    if raw.contains('/') || raw.contains('\\') {
+        return Err(PathError::BackslashSeparator);
+    }
+    if raw.contains('\0') {
+        return Err(PathError::NullByte);
+    }
+    if raw == "." || raw == ".." {
+        return Err(PathError::Traversal);
+    }
+    Ok(raw.to_owned())
+}
+
+/// Maksimum nested directory derinliği (RFC-0005 §3.3 / §5).
+pub const MAX_DEPTH: usize = 32;
+
+/// Path sanitize hata kategorileri.
+///
+/// `PartialEq + Eq` test ergonomi için; receiver UI katmanında i18n key'e
+/// map'lenir.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum PathError {
+    /// `..` segment — path traversal saldırısı varsayımı.
+    #[error("path traversal `..` segment")]
+    Traversal,
+
+    /// `\` karakter — Windows separator wire'da yasak (POSIX-only).
+    #[error("Windows separator `\\` in path")]
+    BackslashSeparator,
+
+    /// `\0` NUL byte — UNIX path API'leri için truncation riski.
+    #[error("null byte in path")]
+    NullByte,
+
+    /// Segment sayısı `MAX_DEPTH` üstünde.
+    #[error("depth {0} exceeds limit 32")]
+    DepthExceeded(usize),
+
+    /// Sanitize sonrası segment kalmamış (`""`, `"./"`, `"/"` vs).
+    #[error("path empty after sanitize")]
+    Empty,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sanitize_simple_path_ok() {
+        let segs = sanitize_received_relative_path("a/b/c.txt").unwrap();
+        assert_eq!(segs, vec!["a", "b", "c.txt"]);
+    }
+
+    #[test]
+    fn sanitize_single_segment_ok() {
+        let segs = sanitize_received_relative_path("file.txt").unwrap();
+        assert_eq!(segs, vec!["file.txt"]);
+    }
+
+    #[test]
+    fn sanitize_traversal_rejected_simple() {
+        assert_eq!(
+            sanitize_received_relative_path(".."),
+            Err(PathError::Traversal)
+        );
+    }
+
+    #[test]
+    fn sanitize_traversal_rejected_leading() {
+        assert_eq!(
+            sanitize_received_relative_path("../escape"),
+            Err(PathError::Traversal)
+        );
+    }
+
+    #[test]
+    fn sanitize_traversal_rejected_middle() {
+        assert_eq!(
+            sanitize_received_relative_path("a/../b"),
+            Err(PathError::Traversal)
+        );
+    }
+
+    #[test]
+    fn sanitize_traversal_rejected_trailing() {
+        assert_eq!(
+            sanitize_received_relative_path("a/.."),
+            Err(PathError::Traversal)
+        );
+    }
+
+    #[test]
+    fn sanitize_traversal_corpus_extended() {
+        // RFC-0005 §5 + `docs/protocol/folder-payload.md` §10 traversal
+        // corpus — fuzz seed'i olarak da PR-D harness'inde kullanılacak.
+        let cases = [
+            "..",
+            "../",
+            "a/..",
+            "a/../b",
+            "../../etc/passwd",
+            "x/y/../../z",
+        ];
+        for raw in cases {
+            assert_eq!(
+                sanitize_received_relative_path(raw),
+                Err(PathError::Traversal),
+                "expected Traversal for {raw:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn sanitize_dot_segments_skipped() {
+        let segs = sanitize_received_relative_path("a/./b").unwrap();
+        assert_eq!(segs, vec!["a", "b"]);
+    }
+
+    #[test]
+    fn sanitize_consecutive_slashes_collapsed() {
+        let segs = sanitize_received_relative_path("a//b").unwrap();
+        assert_eq!(segs, vec!["a", "b"]);
+    }
+
+    #[test]
+    fn sanitize_leading_slash_skipped() {
+        let segs = sanitize_received_relative_path("/a/b").unwrap();
+        assert_eq!(segs, vec!["a", "b"]);
+    }
+
+    #[test]
+    fn sanitize_backslash_rejected() {
+        assert_eq!(
+            sanitize_received_relative_path("a\\b"),
+            Err(PathError::BackslashSeparator)
+        );
+    }
+
+    #[test]
+    fn sanitize_backslash_traversal_rejected() {
+        // `..\\` saldırısı (Windows-shell-style traversal) — backslash check
+        // önce vurur, ama her iki şekilde de reject; kategori önemli değil
+        // burada sadece reject kesin.
+        let r = sanitize_received_relative_path("..\\escape");
+        assert!(matches!(
+            r,
+            Err(PathError::BackslashSeparator) | Err(PathError::Traversal)
+        ));
+    }
+
+    #[test]
+    fn sanitize_null_byte_rejected() {
+        assert_eq!(
+            sanitize_received_relative_path("a\0b"),
+            Err(PathError::NullByte)
+        );
+    }
+
+    #[test]
+    fn sanitize_depth_limit_enforced() {
+        // 33 segment derinliği — limit 32 üstü reject.
+        let raw = (0..33)
+            .map(|i| format!("d{i}"))
+            .collect::<Vec<_>>()
+            .join("/");
+        assert_eq!(
+            sanitize_received_relative_path(&raw),
+            Err(PathError::DepthExceeded(33))
+        );
+    }
+
+    #[test]
+    fn sanitize_depth_limit_boundary_ok() {
+        // Tam 32 segment — sınırda kabul.
+        let raw = (0..32)
+            .map(|i| format!("d{i}"))
+            .collect::<Vec<_>>()
+            .join("/");
+        let segs = sanitize_received_relative_path(&raw).unwrap();
+        assert_eq!(segs.len(), 32);
+    }
+
+    #[test]
+    fn sanitize_empty_input_rejected() {
+        assert_eq!(sanitize_received_relative_path(""), Err(PathError::Empty));
+    }
+
+    #[test]
+    fn sanitize_only_dot_rejected() {
+        assert_eq!(sanitize_received_relative_path("./"), Err(PathError::Empty));
+        assert_eq!(sanitize_received_relative_path("."), Err(PathError::Empty));
+    }
+
+    #[test]
+    fn sanitize_only_slashes_rejected() {
+        assert_eq!(
+            sanitize_received_relative_path("///"),
+            Err(PathError::Empty)
+        );
+    }
+
+    #[test]
+    fn sanitize_root_name_simple() {
+        assert_eq!(sanitize_root_name("docs").unwrap(), "docs");
+    }
+
+    #[test]
+    fn sanitize_root_name_separator_rejected() {
+        assert_eq!(
+            sanitize_root_name("a/b"),
+            Err(PathError::BackslashSeparator)
+        );
+        assert_eq!(
+            sanitize_root_name("a\\b"),
+            Err(PathError::BackslashSeparator)
+        );
+    }
+
+    #[test]
+    fn sanitize_root_name_empty_rejected() {
+        assert_eq!(sanitize_root_name(""), Err(PathError::Empty));
+    }
+
+    #[test]
+    fn sanitize_root_name_dot_rejected() {
+        assert_eq!(sanitize_root_name("."), Err(PathError::Traversal));
+        assert_eq!(sanitize_root_name(".."), Err(PathError::Traversal));
+    }
+
+    #[test]
+    fn sanitize_root_name_null_rejected() {
+        assert_eq!(sanitize_root_name("a\0b"), Err(PathError::NullByte));
+    }
+}

--- a/crates/hekadrop-core/src/lib.rs
+++ b/crates/hekadrop-core/src/lib.rs
@@ -46,6 +46,10 @@ pub mod config;
 pub mod crypto;
 pub mod error;
 pub mod file_size_guard;
+// RFC-0005 — folder_stream_v1 payload primitives. PR-B: stateless
+// HEKABUND encoder/decoder + manifest serde + sanitize. PR-C/D
+// sender/receiver consumers.
+pub mod folder;
 pub mod frame;
 pub mod identity;
 pub mod log_redact;


### PR DESCRIPTION
## Summary

RFC-0005 §2/§3/§5 wire-byte spec'ini stateless primitive olarak çekirdeğe taşır. Sender (PR-C) ve receiver (PR-D) için ortak encoder/decoder + path sanitize zinciri; tek wire-truth kaynağı.

- **`crates/hekadrop-core/src/folder/bundle.rs`** — `HEKABUND` v1 container (`docs/protocol/folder-payload.md` §2)
  - `BundleHeader` — 16-byte fixed (magic `HEKABUND` + version BE u32 + `manifest_len` BE u32)
  - `BundleWriter` — streaming hash chain: `new(manifest_json)` header + manifest commit; `update(body_chunk)` per-chunk; `finalize()` → 32-byte trailer SHA-256. Caller disk I/O policy'sini seçer (socket veya `FileSink`).
  - `BundleReader` — `open(path)` magic gate + `manifest_len` cap (≤ 8 MiB) + trailer constant-time verify (`subtle::ConstantTimeEq`); başarılı verify sonrası `manifest_json()` + `into_file()` PR-D extractor için.
- **`crates/hekadrop-core/src/folder/manifest.rs`** — `BundleManifest` JSON schema (§3)
  - `serde` tagged enum (`type: "file" | "directory"`) + `chrono::DateTime<Utc>` `created_utc`
  - `validate()` — version/total_entries/MAX_ENTRIES (10 000)/per-entry sanitize/duplicate path/file SHA-256 64-char lowercase hex
  - `manifest_sha256()` + `attachment_hash_i64()` (§4.1 — first 8 bytes BE i64; intro-frame commit)
- **`crates/hekadrop-core/src/folder/sanitize.rs`** — per-segment traversal guard (§5)
  - `..` reject (atomic-reject saldırı varsayımı; basename-only `sanitize_received_name`'in silent rewrite davranışından farklı)
  - `\` reject, `\0` reject, `.` skip, boş segment skip, derinlik > 32 reject
  - `sanitize_root_name` tek-segment guard (`/`, `\`, `\0`, `.`, `..` reject)

## Spec referansları

- `docs/protocol/folder-payload.md` §2 — wire layout (magic + version BE + manifest_len BE + manifest_json + concat_data + trailer SHA-256)
- §3 — manifest JSON schema (file/directory entry, version, root_name, total_entries cap)
- §4.1 — `attachment_hash` derivation (first 8 bytes of `SHA-256(manifest_json)` as BE i64)
- §5 — per-segment sanitize policy (forbid `..`, `\`, `\0`; skip `.` and empty; depth ≤ 32)
- §10 — security guards (path traversal, oversized manifest, bundle tampering)

## Test coverage (54 unit test)

- `bundle.rs` (16 test) — header roundtrip, magic/version/manifest_len reject, writer streaming hash = independent baseline (`compute_tag` PR #104 ile aynı pattern), reader 1-bit-flip trailer detect, truncated/magic-corrupt reject, `concat_data_len()` accessor.
- `manifest.rs` (13 test) — serde roundtrip (file + directory karışık), validate corpus (version unsupported, entry count mismatch / exceeded, sha256 hex format/length, duplicate path, traversal path, root_name with slash), `attachment_hash_i64` deterministic + first-8-bytes byte-exact.
- `sanitize.rs` (25 test) — path traversal corpus 6 vector + Windows backslash `..\\` variant + depth boundary 32/33 + root_name dot/empty/null/separator.

**Path traversal corpus boyutu:** 6 distinct vector (`..`, `../`, `a/..`, `a/../b`, `../../etc/passwd`, `x/y/../../z`) + extended Windows-style guard. PR-D fuzz harness'ında bu corpus seed olarak kullanılacak.

## Validate guards (CLAUDE.md I-5 — peer-controlled input)

- `manifest_len` ≤ 8 MiB (DoS guard, `BundleHeader::decode` zorunlu)
- `manifest_len > 0` (schema'nın minimum field set'ini garanti)
- `manifest_len` overflow check (`HEADER_LEN + manifest_len > bundle_len - TRAILER_LEN` reject)
- `total_entries == entries.len()` (u32 ↔ usize karşılaştırması u64 lossless via `From`)
- `total_entries ≤ MAX_ENTRIES` (10 000 üst sınır)
- `body.len()` u32 cast checked (32-bit hedefte infallible; 64-bit hedefte `u32::MAX` üstü reject)

## CLAUDE.md uyumu

- **I-1** — yeni modül leaf core; `crate::platform/paths/ui/i18n` referansı yok (grep doğruladı)
- **I-2** — yeni `#[allow]` minimum: 3 item-level `expect_used` (8/4/4-byte slice → array infallible try_into) yorumlu
- **I-3** — `map_err(|_e: T| ...)` bypass yok; `match` pattern + canonical `_` discard kullandık (`BundleWriter::new` `u32::try_from`)
- **I-5** — peer-controlled tüm length/u32 alanlar checked
- **I-6** — yeni global state yok

## "No behavior change — primitive only"

PR-A `FolderManifest` slot 14 seal + spec dokümanı; bu PR sadece encoder/decoder primitive surface ekler. PR-C (sender folder enumerate + bundle stream) ve PR-D (receiver extract + atomic-reject state machine) consumer'ları sıradaki PR'larda gelecek; mevcut wire akışı dokunulmadı.

## Test plan

- [x] `cargo build -p hekadrop-core` clean
- [x] `cargo test --workspace` 307 (core lib) + 54 (folder) yeşil
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` temiz
- [x] `cargo fmt --all -- --check` temiz
- [x] `cargo machete --with-metadata` unused dep yok
- [x] `typos` temiz
- [x] CLAUDE.md I-1/I-2/I-3 grep'leri 0 hit

🤖 Generated with [Claude Code](https://claude.com/claude-code)