### PR TITLE
feat(rfc-0005): PR-C — sender folder enumerate + HEKABUND bundle stream emit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1518,6 +1518,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tao",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",

--- a/crates/hekadrop-app/Cargo.toml
+++ b/crates/hekadrop-app/Cargo.toml
@@ -111,6 +111,10 @@ criterion = { version = "0.8", features = ["html_reports"] }
 # invariant testi `Duration::days` kullanıyor. core'da zaten dep, aynı
 # feature set'i ile test build grafine alınır (Cargo unification).
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
+# RFC-0005 PR-C — `tests/folder_sender_send.rs` enumerate + manifest build
+# fixture'ları için tempdir. core'da zaten dev-dep; Cargo unification ile
+# tekrar resolve maliyeti yok.
+tempfile = "3"
 
 [[bench]]
 name = "crypto"

--- a/crates/hekadrop-app/src/lib.rs
+++ b/crates/hekadrop-app/src/lib.rs
@@ -52,8 +52,9 @@
 // (binary `src/main.rs` direkt `hekadrop_core::xxx` kullanır; lib bağımsız
 // derlenir). Yeni core sembolü eklendiğinde tek mecburi update buradadır.
 pub use hekadrop_core::{
-    capabilities, config, connection, crypto, discovery_types, error, file_size_guard, frame,
-    identity, log_redact, payload, resume, secure, sender, server, settings, stats, ui_port, ukey2,
+    capabilities, config, connection, crypto, discovery_types, error, file_size_guard, folder,
+    frame, identity, log_redact, payload, resume, secure, sender, server, settings, stats, ui_port,
+    ukey2,
 };
 
 // RFC-0001 §5 Adım 2: protobuf bindings `hekadrop-proto` crate'inden

--- a/crates/hekadrop-app/tests/folder_sender_send.rs
+++ b/crates/hekadrop-app/tests/folder_sender_send.rs
@@ -1,0 +1,333 @@
+// Test/bench dosyası — production lint'leri test idiomatik kullanımı bozmasın.
+// Cast/clone family de gevşek: test verisi hardcoded, numerik safety burada
+// odak değil; behavior validation odaklıyız.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::expect_fun_call,
+    clippy::panic,
+    clippy::print_stdout,
+    clippy::print_stderr,
+    clippy::missing_panics_doc,
+    clippy::redundant_clone,
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap,
+    clippy::cast_sign_loss,
+    clippy::cast_lossless,
+    clippy::cast_precision_loss,
+    clippy::ignored_unit_patterns,
+    clippy::use_self,
+    clippy::trivially_copy_pass_by_ref,
+    clippy::single_match_else,
+    clippy::map_err_ignore,
+    clippy::doc_markdown
+)]
+
+//! RFC-0005 PR-C — sender folder enumerate + `HEKABUND` bundle stream
+//! invariant'ları.
+//!
+//! Bu test dosyası `hekadrop::folder` (re-export) public API'si üzerinden
+//! sender-side folder primitive'lerinin spec uyumunu sabitler:
+//!
+//! - **Enumerate kontratı:** symlink + special file skip, depth ≤ 32, entry
+//!   count ≤ 10 000, root_must_be_directory.
+//! - **Manifest build:** per-file streaming SHA-256 doğru, manifest validate
+//!   geçer, `attachment_hash_i64` `manifest_sha256[0..8]` BE i64'e eşit
+//!   (Introduction frame contract `docs/protocol/folder-payload.md` §4.1).
+//! - **Bundle stream:** `BundleWriter` + manifest + per-file body birleşimi
+//!   `BundleReader::open` ile parse + trailer verify + `manifest_json`
+//!   round-trip. Bu test sender'ın gerçek pipeline'ında ne emit edeceğinin
+//!   byte-exact simülasyonudur (in-memory; network yerine `Vec<u8>`).
+//! - **Flatten fallback semantiği:** directory entries `concat_data`'ya
+//!   katkı vermez, file count fallback'te beklenen file-kind entry sayısı
+//!   ile eşleşir.
+//!
+//! `send_folder_bundle` private async fn — network mock tokio TcpListener
+//! E2E PR-D (receiver) merge'inden sonra `crates/hekadrop-app/tests/
+//! folder_e2e.rs` harness'ine eklenecek (loopback sender↔receiver).
+
+use hekadrop::folder::{
+    build_manifest, bundle_total_size, enumerate_folder, BundleManifest, BundleReader,
+    BundleWriter, EntryKind, EnumerateError, ManifestEntry, HEADER_LEN, MAX_FOLDER_ENTRIES,
+    TRAILER_LEN,
+};
+use sha2::{Digest, Sha256};
+use std::fs;
+use std::io::Write;
+use std::path::Path;
+use tempfile::{tempdir, NamedTempFile};
+
+fn write_file(dir: &Path, rel: &str, body: &[u8]) {
+    let full = dir.join(rel);
+    if let Some(parent) = full.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    let mut f = fs::File::create(&full).unwrap();
+    f.write_all(body).unwrap();
+}
+
+/// PR-C invariant 1 — enumerate, symlink + (Unix) special file skip eder
+/// ve görünür file/directory entries döner. Symlink deneyimi sadece Unix
+/// hedeflerinde anlamlı; Windows'ta `std::os::windows::fs::symlink_*`
+/// admin yetkisi ister, CI'da pratik değil.
+#[cfg(unix)]
+#[test]
+fn enumerate_folder_3_files_skips_symlinks() {
+    let tmp = tempdir().unwrap();
+    write_file(tmp.path(), "a.txt", b"alpha");
+    write_file(tmp.path(), "b.txt", b"beta");
+    write_file(tmp.path(), "c.txt", b"gamma");
+    // Symlink → alpha (file). Walk skip etmeli + warn log.
+    let target = tmp.path().join("a.txt");
+    let link = tmp.path().join("link_to_a");
+    std::os::unix::fs::symlink(&target, &link).unwrap();
+
+    let entries = enumerate_folder(tmp.path()).unwrap();
+    let files: Vec<_> = entries
+        .iter()
+        .filter(|e| e.kind == EntryKind::File)
+        .collect();
+    assert_eq!(files.len(), 3, "symlink skip edilmeli; got {entries:#?}");
+    let names: Vec<&str> = files.iter().map(|e| e.relative_path.as_str()).collect();
+    assert!(names.contains(&"a.txt"));
+    assert!(names.contains(&"b.txt"));
+    assert!(names.contains(&"c.txt"));
+    assert!(
+        !names.contains(&"link_to_a"),
+        "symlink manifest'e SIZMAMALI"
+    );
+}
+
+/// PR-C invariant 2 — depth > MAX_FOLDER_DEPTH (32) reject.
+///
+/// 33-deep nested directory walk başarısız olmalı; receiver tarafında DoS /
+/// path-traversal guard.
+#[test]
+fn enumerate_folder_depth_exceeded_errors() {
+    let tmp = tempdir().unwrap();
+    let mut path = tmp.path().to_path_buf();
+    for i in 0..33 {
+        path = path.join(format!("d{i}"));
+    }
+    fs::create_dir_all(&path).unwrap();
+    let r = enumerate_folder(tmp.path());
+    assert!(
+        matches!(r, Err(EnumerateError::DepthExceeded { .. })),
+        "depth 33 reject beklenirken: {r:?}"
+    );
+}
+
+/// PR-C invariant 3 — entry count > MAX_FOLDER_ENTRIES (10 000) reject.
+///
+/// Receiver memory + manifest size guard.
+#[test]
+fn enumerate_folder_entry_count_exceeded_errors() {
+    let tmp = tempdir().unwrap();
+    // 10 001 file flat tek dizinde.
+    for i in 0..=MAX_FOLDER_ENTRIES {
+        let p = tmp.path().join(format!("f{i:05}.bin"));
+        fs::write(&p, b"x").unwrap();
+    }
+    let r = enumerate_folder(tmp.path());
+    assert!(
+        matches!(r, Err(EnumerateError::EntryCountExceeded { .. })),
+        "entry count > {MAX_FOLDER_ENTRIES} reject beklenirken: {r:?}"
+    );
+}
+
+/// PR-C invariant 4 — manifest entries içindeki SHA-256, file body'sinin
+/// streaming SHA-256'sıyla **byte-exact** eşleşmeli.
+///
+/// Receiver per-entry verify aşamasında bu hash'leri kullanır
+/// (`docs/protocol/folder-payload.md` §6 step 5).
+#[test]
+fn build_manifest_per_file_sha256_correct() {
+    let tmp = tempdir().unwrap();
+    write_file(tmp.path(), "alpha.txt", b"hello world");
+    write_file(tmp.path(), "beta.txt", b"second body");
+    let entries = enumerate_folder(tmp.path()).unwrap();
+    let manifest = build_manifest(tmp.path(), &entries).unwrap();
+    manifest.validate().unwrap();
+
+    for entry in &manifest.entries {
+        if let ManifestEntry::File { path, sha256, .. } = entry {
+            let mut h = Sha256::new();
+            let body = match path.as_str() {
+                "alpha.txt" => b"hello world".as_slice(),
+                "beta.txt" => b"second body".as_slice(),
+                other => panic!("beklenmeyen path: {other}"),
+            };
+            h.update(body);
+            let expected = hex_lower(&h.finalize());
+            assert_eq!(sha256, &expected, "{path} hash uymuyor");
+        }
+    }
+}
+
+/// PR-C invariant 5 — bundle_total_size = 16 + manifest_len +
+/// sum(file_sizes) + 32 (`docs/protocol/folder-payload.md` §2 layout).
+///
+/// `Introduction.FileMetadata.size` bunu kullanır; receiver tarafında
+/// `concat_data_len` checked-arithmetic ile bu değerden türetilir.
+#[test]
+fn bundle_total_size_calculation() {
+    let tmp = tempdir().unwrap();
+    write_file(tmp.path(), "x.bin", b"1234567890"); // 10 byte
+    write_file(tmp.path(), "y.bin", b"abcdef"); // 6 byte
+    let entries = enumerate_folder(tmp.path()).unwrap();
+    let manifest = build_manifest(tmp.path(), &entries).unwrap();
+    let manifest_json = serde_json::to_vec(&manifest).unwrap();
+    let total = bundle_total_size(manifest_json.len(), &entries).unwrap();
+    let expected = HEADER_LEN as u64 + manifest_json.len() as u64 + 10 + 6 + TRAILER_LEN as u64;
+    assert_eq!(
+        total, expected,
+        "bundle_total_size hesabı yanlış (header={HEADER_LEN}, manifest_len={}, files=16, trailer={TRAILER_LEN})",
+        manifest_json.len()
+    );
+}
+
+/// PR-C invariant 6 — sender'ın emit edeceği tam bundle byte stream'i,
+/// `BundleReader::open` ile parse edilebilmeli + trailer verify geçmeli.
+///
+/// Bu test `send_folder_bundle` private async fn'ün byte-exact in-memory
+/// simülasyonudur (`BundleWriter::new` then header then manifest then per-file
+/// body then finalize trailer). Sonrasında bytes diske yazılır,
+/// `BundleReader::open` parse + manifest_json round-trip karşılaştırılır.
+#[test]
+fn send_folder_bundle_full_loopback_decode_matches_manifest() {
+    let tmp = tempdir().unwrap();
+    write_file(tmp.path(), "alpha.txt", b"alpha-body-content");
+    write_file(tmp.path(), "subdir/beta.txt", b"beta-content-2");
+    let entries = enumerate_folder(tmp.path()).unwrap();
+    let manifest = build_manifest(tmp.path(), &entries).unwrap();
+    manifest.validate().unwrap();
+    let manifest_json = serde_json::to_vec(&manifest).unwrap();
+
+    // BundleWriter — sender pipeline'ının byte-exact aynısı.
+    let mut writer = BundleWriter::new(&manifest_json).unwrap();
+    let mut bundle: Vec<u8> = Vec::new();
+    bundle.extend_from_slice(&writer.header_bytes());
+    bundle.extend_from_slice(&manifest_json);
+
+    // Per-entry body — dizin atlanır, file order manifest sırasıyla aynı
+    // (enumerate deterministic).
+    for entry in &entries {
+        if entry.kind != EntryKind::File {
+            continue;
+        }
+        let body = fs::read(&entry.absolute_path).unwrap();
+        writer.update(&body);
+        bundle.extend_from_slice(&body);
+    }
+    let trailer = writer.finalize();
+    bundle.extend_from_slice(&trailer);
+
+    // Disk'e yaz + BundleReader ile parse.
+    let tmp_bundle = NamedTempFile::new().unwrap();
+    fs::write(tmp_bundle.path(), &bundle).unwrap();
+    let reader = BundleReader::open(tmp_bundle.path()).expect("BundleReader::open success");
+    assert_eq!(reader.manifest_json(), manifest_json.as_slice());
+    assert_eq!(reader.bundle_len(), bundle.len() as u64);
+    // concat_data_len = sum of file sizes (alpha 18 + beta 14 = 32).
+    assert_eq!(reader.concat_data_len(), 18 + 14);
+
+    // Manifest'i bytes'tan tekrar parse + spec uygunluk.
+    let parsed: BundleManifest = serde_json::from_slice(reader.manifest_json()).unwrap();
+    assert_eq!(parsed, manifest);
+}
+
+/// PR-C invariant 7 — `Introduction.attachment_hash` = `manifest_sha256[0..8]`
+/// BE i64 (`docs/protocol/folder-payload.md` §4.1). Receiver bu değeri
+/// post-bundle `manifest_json` re-hash sonucu ile karşılaştırır; mismatch
+/// `Atomic-reject`.
+#[test]
+fn attachment_hash_matches_manifest_sha256_prefix() {
+    let tmp = tempdir().unwrap();
+    write_file(tmp.path(), "f.bin", b"deterministic-body");
+    let entries = enumerate_folder(tmp.path()).unwrap();
+    let manifest = build_manifest(tmp.path(), &entries).unwrap();
+    let manifest_json = serde_json::to_vec(&manifest).unwrap();
+
+    let attachment_hash = manifest.attachment_hash_i64().unwrap();
+
+    // Bağımsız hesap: SHA-256(manifest_json)[0..8] BE i64.
+    let mut h = Sha256::new();
+    h.update(&manifest_json);
+    let digest: [u8; 32] = h.finalize().into();
+    let prefix: [u8; 8] = digest[0..8].try_into().unwrap();
+    let expected = i64::from_be_bytes(prefix);
+    assert_eq!(
+        attachment_hash, expected,
+        "Introduction.attachment_hash != SHA-256(manifest_json)[0..8] BE i64"
+    );
+}
+
+/// PR-C invariant 8 — capability inactive yolda flatten fallback semantiği:
+/// directory entries `concat_data`'ya katkı vermez (size = 0), file
+/// basename'leri tekildir, sender bunları individual file plan'larına
+/// dönüştürebilir.
+///
+/// `flatten_folder_to_files` sender.rs içinde private; testte enumerate
+/// çıktısı, `bundle_total_size`'in directory'leri sıfır byte saydığı,
+/// ve file count'un beklenen değer olduğu doğrulanarak fallback
+/// invariant'ı sabitlenir.
+#[test]
+fn send_folder_bundle_capability_inactive_falls_back_to_flatten() {
+    let tmp = tempdir().unwrap();
+    // 2 file + 2 directory (boş alt klasör + nested sub).
+    write_file(tmp.path(), "top.txt", b"top-body");
+    write_file(tmp.path(), "subdir1/inner.txt", b"inner-body");
+    fs::create_dir_all(tmp.path().join("subdir2_empty")).unwrap();
+
+    let entries = enumerate_folder(tmp.path()).unwrap();
+    let files: Vec<_> = entries
+        .iter()
+        .filter(|e| e.kind == EntryKind::File)
+        .collect();
+    let dirs: Vec<_> = entries
+        .iter()
+        .filter(|e| e.kind == EntryKind::Directory)
+        .collect();
+
+    // 2 file (top.txt + subdir1/inner.txt), 2 directory (subdir1, subdir2_empty).
+    assert_eq!(files.len(), 2, "file count flatten için sayılır");
+    assert_eq!(dirs.len(), 2, "directory entries manifest'te kalır");
+
+    // bundle_total_size dir entries için 0 byte sayar — sadece file size'ları
+    // toplanır.
+    let manifest = build_manifest(tmp.path(), &entries).unwrap();
+    let manifest_json = serde_json::to_vec(&manifest).unwrap();
+    let total = bundle_total_size(manifest_json.len(), &entries).unwrap();
+    let file_size_sum: u64 = files.iter().map(|e| e.size).sum();
+    let expected =
+        HEADER_LEN as u64 + manifest_json.len() as u64 + file_size_sum + TRAILER_LEN as u64;
+    assert_eq!(
+        total, expected,
+        "directory entries body byte katkısı SIFIR olmalı"
+    );
+
+    // Capability inactive path'te sender flat akışa düşer; flat plan'da
+    // yalnızca file basename'leri kullanılır (sub-directory yapısı kayıp).
+    // Bu invariant'ı assert etmek için file basename'lerinin map'ini kur:
+    let basenames: Vec<&str> = files
+        .iter()
+        .map(|e| {
+            std::path::Path::new(&e.relative_path)
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or("dosya")
+        })
+        .collect();
+    assert!(basenames.contains(&"top.txt"));
+    assert!(basenames.contains(&"inner.txt"));
+}
+
+fn hex_lower(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        s.push(HEX[(b >> 4) as usize] as char);
+        s.push(HEX[(b & 0x0F) as usize] as char);
+    }
+    s
+}

--- a/crates/hekadrop-core/src/folder/enumerate.rs
+++ b/crates/hekadrop-core/src/folder/enumerate.rs
@@ -1,0 +1,540 @@
+//! RFC-0005 §3.4 + §5 — sender-side folder walk + per-file SHA-256
+//! pre-compute + `BundleManifest` build helpers.
+//!
+//! Bu modül **stateless** (no global state, no UI). Sender (`sender.rs::send`)
+//! bir directory path için:
+//! 1. [`enumerate_folder`] ile recursive walk yapıp `EnumeratedEntry`
+//!    listesi alır.
+//! 2. [`build_manifest`] ile per-file SHA-256 streaming hash hesaplar +
+//!    `BundleManifest` üretir.
+//! 3. [`bundle_total_size`] ile `Introduction.size` field'ı için
+//!    `52 + manifest_len + sum(file_sizes)` hesabı yapar.
+//!
+//! Disk I/O policy:
+//! - `enumerate_folder` `std::fs` blocking call'ları kullanır; caller
+//!   `tokio::task::spawn_blocking` ile sarmalı (yüksek depth/large directory
+//!   senaryosunda async runtime'ı bloklar).
+//! - `build_manifest` per-file open + `BufReader::read_exact` streaming;
+//!   yine blocking, caller `spawn_blocking` ile sarmalı.
+//!
+//! Limit'ler (RFC-0005 §3.3 + `docs/protocol/folder-payload.md` §3.2 / §5):
+//! - [`MAX_FOLDER_DEPTH`] = 32 (path-traversal + filesystem `PATH_MAX` guard)
+//! - [`MAX_FOLDER_ENTRIES`] = 10 000 (manifest size + receiver memory cap)
+
+use crate::folder::manifest::{BundleManifest, ManifestEntry, MANIFEST_VERSION};
+use crate::folder::sanitize::{sanitize_root_name, PathError};
+use chrono::Utc;
+use sha2::{Digest, Sha256};
+use std::fs;
+use std::io::{BufReader, Read};
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Maksimum nested directory derinliği — RFC-0005 §3.3.
+///
+/// Sender walk bu değeri aşan branch'i sessizce skip etmek yerine **fail**
+/// eder; aksi halde manifest'te eksik entry'ler oluşur ve receiver'da
+/// veri kaybına yol açar.
+pub const MAX_FOLDER_DEPTH: usize = 32;
+
+/// Maksimum entry sayısı (file + directory) — RFC-0005 §3.3.
+///
+/// `BundleManifest.total_entries` u32 cap'i ile aynı. 8 MiB manifest cap
+/// pratik olarak ~13 000 entry'e dek izin verir; 10 000 receiver memory
+/// hijyeni için defansif.
+pub const MAX_FOLDER_ENTRIES: usize = 10_000;
+
+/// Sender-side enumerate sonucu — bir manifest entry'sinin disk + manifest
+/// metadata kombinasyonu.
+///
+/// Bu struct manifest'e direkt encode edilmez; [`build_manifest`] bu listeyi
+/// `ManifestEntry::{File, Directory}` varyantlarına dönüştürür ve
+/// SHA-256'yı per-file hesaplar.
+#[derive(Debug, Clone)]
+pub struct EnumeratedEntry {
+    /// Sender disk üzerindeki absolute path.
+    pub absolute_path: PathBuf,
+    /// Root-relative POSIX-normalized path (forward-slash). Manifest'te
+    /// `entries[*].path` field'ı.
+    pub relative_path: String,
+    /// Entry tipi (file vs directory).
+    pub kind: EntryKind,
+    /// Sadece file için anlamlı; directory için 0.
+    pub size: u64,
+    /// İsteğe bağlı POSIX mode (Unix only). Best-effort.
+    pub mode: Option<u32>,
+    /// İsteğe bağlı mtime (Unix epoch saniyesi). Best-effort.
+    pub mtime: Option<u64>,
+}
+
+/// Entry tipi — manifest tagged union'ı (`"file"` / `"directory"`) ile
+/// 1:1 eşleşir.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EntryKind {
+    File,
+    Directory,
+}
+
+/// Folder walk hata kategorileri.
+#[derive(Debug, thiserror::Error)]
+pub enum EnumerateError {
+    /// `root` mevcut değil veya stat fail.
+    #[error("root path okunamadı: {0}")]
+    RootStat(#[source] std::io::Error),
+
+    /// `root` directory değil (file/symlink/special).
+    #[error("root path bir directory değil")]
+    RootNotDirectory,
+
+    /// Walk sırasında directory entry stat fail.
+    #[error("directory entry okunamadı: {0}")]
+    EntryStat(#[source] std::io::Error),
+
+    /// Walk sırasında `read_dir` fail.
+    #[error("read_dir başarısız: {0}")]
+    ReadDir(#[source] std::io::Error),
+
+    /// `MAX_FOLDER_DEPTH` aşıldı.
+    #[error("derinlik {depth} > {limit}")]
+    DepthExceeded { depth: usize, limit: usize },
+
+    /// `MAX_FOLDER_ENTRIES` aşıldı.
+    #[error("entry sayısı {count} > {limit}")]
+    EntryCountExceeded { count: usize, limit: usize },
+
+    /// `root.file_name()` None (örn. `/` veya `..`) veya sanitize fail.
+    #[error("root_name belirlenemedi veya sanitize fail: {0}")]
+    RootName(#[source] PathError),
+
+    /// Root içindeki bir entry path'i UTF-8 değil veya path encoding
+    /// bozulmuş.
+    #[error("path UTF-8 değil veya encoding hatalı")]
+    PathEncoding,
+}
+
+/// Manifest build hata kategorileri.
+#[derive(Debug, thiserror::Error)]
+pub enum BuildError {
+    /// File body open / read fail.
+    #[error("file body okunamadı ({path}): {source}")]
+    FileRead {
+        path: String,
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// Root name sanitize fail.
+    #[error("root_name sanitize fail: {0}")]
+    RootName(#[source] PathError),
+
+    /// Entry sayısı u32'ye sığmıyor (>> `MAX_FOLDER_ENTRIES` de zaten reject).
+    #[error("entry sayısı u32 sınırını aşıyor: {0}")]
+    EntryCountOverflow(usize),
+}
+
+/// Recursive folder walk — file + directory entries döner.
+///
+/// Davranış (RFC-0005 §3.4 + `docs/protocol/folder-payload.md` §5):
+/// - **Symlink:** `symlink_metadata` ile detect; skip + warn log.
+/// - **Special file** (block/char/socket/fifo): skip + warn log (Unix-only;
+///   Windows'ta `is_file()` / `is_dir()` zaten filtre eder).
+/// - **Depth check:** her recursion seviyesinde `MAX_FOLDER_DEPTH` aşılırsa
+///   `DepthExceeded` döner.
+/// - **Entry count check:** çıktı listesi `MAX_FOLDER_ENTRIES` aşamaz.
+/// - **Path encoding:** `OsStr::to_str()` None ise `PathEncoding` döner —
+///   manifest UTF-8 zorunlu.
+///
+/// **Order:** entries deterministic sıralı. Per-directory `read_dir` çıktısı
+/// dosya adına göre `sort()` ile sıralanır → cross-platform reproducible
+/// manifest (fuzz corpus + receiver byte-exact diff).
+pub fn enumerate_folder(root: &Path) -> Result<Vec<EnumeratedEntry>, EnumerateError> {
+    let root_meta = fs::symlink_metadata(root).map_err(EnumerateError::RootStat)?;
+    if root_meta.file_type().is_symlink() {
+        return Err(EnumerateError::RootNotDirectory);
+    }
+    if !root_meta.is_dir() {
+        return Err(EnumerateError::RootNotDirectory);
+    }
+
+    let mut out: Vec<EnumeratedEntry> = Vec::new();
+    walk_directory(root, root, 0, &mut out)?;
+    Ok(out)
+}
+
+fn walk_directory(
+    root: &Path,
+    current: &Path,
+    depth: usize,
+    out: &mut Vec<EnumeratedEntry>,
+) -> Result<(), EnumerateError> {
+    if depth > MAX_FOLDER_DEPTH {
+        return Err(EnumerateError::DepthExceeded {
+            depth,
+            limit: MAX_FOLDER_DEPTH,
+        });
+    }
+
+    let read = fs::read_dir(current).map_err(EnumerateError::ReadDir)?;
+    let mut child_paths: Vec<PathBuf> = Vec::new();
+    for entry in read {
+        let entry = entry.map_err(EnumerateError::ReadDir)?;
+        child_paths.push(entry.path());
+    }
+    // Deterministic order — cross-platform manifest reproducibility.
+    child_paths.sort();
+
+    for child in child_paths {
+        // INVARIANT (CLAUDE.md I-5): entry count peer-controlled değil ama
+        // directory'de milyonlarca file olabilir → defansif cap.
+        if out.len() >= MAX_FOLDER_ENTRIES {
+            return Err(EnumerateError::EntryCountExceeded {
+                count: out.len() + 1,
+                limit: MAX_FOLDER_ENTRIES,
+            });
+        }
+
+        let meta = fs::symlink_metadata(&child).map_err(EnumerateError::EntryStat)?;
+        let ft = meta.file_type();
+
+        if ft.is_symlink() {
+            tracing::warn!("[sender] folder walk: symlink skip: {}", child.display());
+            continue;
+        }
+
+        // Special files (Unix): block/char/socket/fifo — `is_file()` ve
+        // `is_dir()` ikisi de false döner.
+        if !ft.is_file() && !ft.is_dir() {
+            tracing::warn!(
+                "[sender] folder walk: special file skip: {}",
+                child.display()
+            );
+            continue;
+        }
+
+        let relative_path = relative_to_root(root, &child)?;
+        let mode = extract_mode(&meta);
+        let mtime = extract_mtime(&meta);
+
+        if ft.is_dir() {
+            out.push(EnumeratedEntry {
+                absolute_path: child.clone(),
+                relative_path,
+                kind: EntryKind::Directory,
+                size: 0,
+                mode,
+                mtime,
+            });
+            walk_directory(root, &child, depth + 1, out)?;
+        } else {
+            // is_file() == true
+            out.push(EnumeratedEntry {
+                absolute_path: child,
+                relative_path,
+                kind: EntryKind::File,
+                size: meta.len(),
+                mode,
+                mtime,
+            });
+        }
+    }
+
+    Ok(())
+}
+
+/// `child` path'ini `root` altına göre relative POSIX-normalize string'e
+/// çevir.
+fn relative_to_root(root: &Path, child: &Path) -> Result<String, EnumerateError> {
+    // INVARIANT (CLAUDE.md I-3): `StripPrefixError` zero-sized marker — taşıyacak
+    // ek context yok; `EnumerateError::PathEncoding` canonical reporting yeri.
+    let Ok(rel) = child.strip_prefix(root) else {
+        return Err(EnumerateError::PathEncoding);
+    };
+    let mut parts: Vec<String> = Vec::new();
+    for comp in rel.components() {
+        match comp {
+            std::path::Component::Normal(s) => {
+                let s_str = s.to_str().ok_or(EnumerateError::PathEncoding)?;
+                // RFC-0005 §5.1: Windows backslash → forward slash. Component
+                // bazında walk ettiğimiz için zaten OS separator'ı atlanmış
+                // oluyor; component value'su raw segment string.
+                parts.push(s_str.to_owned());
+            }
+            // Root/parent/curdir component beklenmiyor (strip_prefix sonrası);
+            // defansif olarak fail.
+            _ => return Err(EnumerateError::PathEncoding),
+        }
+    }
+    Ok(parts.join("/"))
+}
+
+#[cfg(unix)]
+fn extract_mode(meta: &fs::Metadata) -> Option<u32> {
+    use std::os::unix::fs::PermissionsExt;
+    Some(meta.permissions().mode())
+}
+
+#[cfg(not(unix))]
+fn extract_mode(_meta: &fs::Metadata) -> Option<u32> {
+    None
+}
+
+fn extract_mtime(meta: &fs::Metadata) -> Option<u64> {
+    let mt = meta.modified().ok()?;
+    let dur = mt.duration_since(UNIX_EPOCH).ok()?;
+    Some(dur.as_secs())
+}
+
+/// Per-file SHA-256 streaming hash + `BundleManifest` build.
+///
+/// Çağıran (sender) `enumerate_folder` çıktısını ve aynı root path'i geçer.
+/// `root.file_name()` `BundleManifest.root_name` olarak kullanılır;
+/// sanitize edildikten sonra atanır.
+///
+/// **Performans notu:** her file için `BufReader` + 64 KiB chunk. 1 GB
+/// folder ~10–15 sn (host disk hızına bağlı). Async runtime'ı bloklamamak
+/// için caller `spawn_blocking` ile sarmalı.
+pub fn build_manifest(
+    root: &Path,
+    entries: &[EnumeratedEntry],
+) -> Result<BundleManifest, BuildError> {
+    let root_name_raw = root
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("klasor");
+    let root_name = sanitize_root_name(root_name_raw).map_err(BuildError::RootName)?;
+
+    // INVARIANT (CLAUDE.md I-3): `TryFromIntError` zero-sized marker; canonical
+    // reporting `BuildError::EntryCountOverflow.0` field.
+    let Ok(total_entries) = u32::try_from(entries.len()) else {
+        return Err(BuildError::EntryCountOverflow(entries.len()));
+    };
+
+    let mut manifest_entries: Vec<ManifestEntry> = Vec::with_capacity(entries.len());
+    for entry in entries {
+        match entry.kind {
+            EntryKind::Directory => {
+                manifest_entries.push(ManifestEntry::Directory {
+                    path: entry.relative_path.clone(),
+                    mode: entry.mode,
+                    mtime: entry.mtime,
+                });
+            }
+            EntryKind::File => {
+                let sha256_hex =
+                    file_sha256_hex(&entry.absolute_path).map_err(|e| BuildError::FileRead {
+                        path: entry.relative_path.clone(),
+                        source: e,
+                    })?;
+                manifest_entries.push(ManifestEntry::File {
+                    path: entry.relative_path.clone(),
+                    size: entry.size,
+                    sha256: sha256_hex,
+                    mode: entry.mode,
+                    mtime: entry.mtime,
+                });
+            }
+        }
+    }
+
+    Ok(BundleManifest {
+        version: MANIFEST_VERSION,
+        root_name,
+        total_entries,
+        entries: manifest_entries,
+        // RFC3339 UTC; manifest schema doc §3.1.
+        created_utc: <chrono::DateTime<Utc>>::from(SystemTime::now()),
+    })
+}
+
+/// Streaming SHA-256 hash → 64-char lowercase hex.
+fn file_sha256_hex(path: &Path) -> std::io::Result<String> {
+    let f = fs::File::open(path)?;
+    let mut reader = BufReader::with_capacity(64 * 1024, f);
+    let mut hasher = Sha256::new();
+    let mut buf = [0u8; 64 * 1024];
+    loop {
+        let n = reader.read(&mut buf)?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+    }
+    let digest: [u8; 32] = hasher.finalize().into();
+    Ok(hex_lower(&digest))
+}
+
+fn hex_lower(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        s.push(HEX[(b >> 4) as usize] as char);
+        s.push(HEX[(b & 0x0F) as usize] as char);
+    }
+    s
+}
+
+/// `HEKABUND` toplam bundle byte boyutu (header + manifest + `concat_data` +
+/// trailer). `Introduction.FileMetadata.size` field'ı bunu kullanır.
+///
+/// Hesap: `16 (header) + manifest_json.len() + sum(file_sizes) + 32 (trailer)`.
+///
+/// Overflow defansif: `file_sizes` toplamı u64'a sığmazsa `None` döner —
+/// caller bundle'ı reddedip flatten fallback'e düşmeli (pratikte erişilemez,
+/// 16 EiB folder).
+#[must_use]
+pub fn bundle_total_size(manifest_json_len: usize, entries: &[EnumeratedEntry]) -> Option<u64> {
+    use crate::folder::bundle::{HEADER_LEN, TRAILER_LEN};
+
+    let mut total: u64 = HEADER_LEN as u64;
+    total = total.checked_add(u64::try_from(manifest_json_len).ok()?)?;
+    for entry in entries {
+        if entry.kind == EntryKind::File {
+            total = total.checked_add(entry.size)?;
+        }
+    }
+    total = total.checked_add(TRAILER_LEN as u64)?;
+    Some(total)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::tempdir;
+
+    fn write_file(dir: &Path, rel: &str, body: &[u8]) {
+        let full = dir.join(rel);
+        if let Some(parent) = full.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        let mut f = fs::File::create(&full).unwrap();
+        f.write_all(body).unwrap();
+    }
+
+    #[test]
+    fn enumerate_root_must_be_directory() {
+        let tmp = tempdir().unwrap();
+        let file = tmp.path().join("not_a_dir.txt");
+        fs::write(&file, b"x").unwrap();
+        let r = enumerate_folder(&file);
+        assert!(matches!(r, Err(EnumerateError::RootNotDirectory)));
+    }
+
+    #[test]
+    fn enumerate_simple_two_files() {
+        let tmp = tempdir().unwrap();
+        write_file(tmp.path(), "a.txt", b"alpha");
+        write_file(tmp.path(), "b.txt", b"beta_payload");
+
+        let entries = enumerate_folder(tmp.path()).unwrap();
+        let files: Vec<_> = entries
+            .iter()
+            .filter(|e| e.kind == EntryKind::File)
+            .collect();
+        assert_eq!(files.len(), 2);
+        // Deterministic order: a.txt before b.txt.
+        assert_eq!(files[0].relative_path, "a.txt");
+        assert_eq!(files[0].size, 5);
+        assert_eq!(files[1].relative_path, "b.txt");
+        assert_eq!(files[1].size, 12);
+    }
+
+    #[test]
+    fn enumerate_nested_directory_creates_directory_entry() {
+        let tmp = tempdir().unwrap();
+        write_file(tmp.path(), "sub/inner.txt", b"abc");
+        let entries = enumerate_folder(tmp.path()).unwrap();
+        // Beklenen: directory "sub" + file "sub/inner.txt"
+        let dirs: Vec<_> = entries
+            .iter()
+            .filter(|e| e.kind == EntryKind::Directory)
+            .collect();
+        let files: Vec<_> = entries
+            .iter()
+            .filter(|e| e.kind == EntryKind::File)
+            .collect();
+        assert_eq!(dirs.len(), 1);
+        assert_eq!(dirs[0].relative_path, "sub");
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].relative_path, "sub/inner.txt");
+    }
+
+    #[test]
+    fn enumerate_depth_limit_enforced() {
+        let tmp = tempdir().unwrap();
+        // 33-deep nested dir → MAX_FOLDER_DEPTH (32) aşılır.
+        let mut path = tmp.path().to_path_buf();
+        for i in 0..33 {
+            path = path.join(format!("d{i}"));
+        }
+        fs::create_dir_all(&path).unwrap();
+        let r = enumerate_folder(tmp.path());
+        assert!(
+            matches!(r, Err(EnumerateError::DepthExceeded { .. })),
+            "got {r:?}"
+        );
+    }
+
+    #[test]
+    fn build_manifest_per_file_sha256_correct() {
+        let tmp = tempdir().unwrap();
+        write_file(tmp.path(), "a.txt", b"hello");
+        write_file(tmp.path(), "b.txt", b"world");
+        let entries = enumerate_folder(tmp.path()).unwrap();
+        let manifest = build_manifest(tmp.path(), &entries).unwrap();
+
+        // root_name = tempdir leaf name (random-ish).
+        assert!(!manifest.root_name.is_empty());
+        assert_eq!(manifest.version, MANIFEST_VERSION);
+        assert_eq!(manifest.total_entries as usize, entries.len());
+
+        // Per-file SHA-256 — bağımsız hesapla, manifest ile karşılaştır.
+        for entry in &manifest.entries {
+            if let ManifestEntry::File { path, sha256, .. } = entry {
+                let expected = if path == "a.txt" {
+                    let mut h = Sha256::new();
+                    h.update(b"hello");
+                    hex_lower(&h.finalize())
+                } else if path == "b.txt" {
+                    let mut h = Sha256::new();
+                    h.update(b"world");
+                    hex_lower(&h.finalize())
+                } else {
+                    panic!("beklenmeyen path: {path}");
+                };
+                assert_eq!(sha256, &expected);
+            }
+        }
+        manifest.validate().unwrap();
+    }
+
+    #[test]
+    fn bundle_total_size_calculation_basic() {
+        // 16 header + manifest_len + (5 + 12) + 32 trailer
+        let tmp = tempdir().unwrap();
+        write_file(tmp.path(), "a.txt", b"hello");
+        write_file(tmp.path(), "b.txt", b"twelve_bytes");
+        let entries = enumerate_folder(tmp.path()).unwrap();
+        let manifest_json = b"{\"placeholder\":\"100bytes\"}";
+        let total = bundle_total_size(manifest_json.len(), &entries).unwrap();
+        // Sadece file size'ları toplanır (5 + 12 = 17), directory 0 katkı.
+        let expected = 16u64 + manifest_json.len() as u64 + 5 + 12 + 32;
+        assert_eq!(total, expected);
+    }
+
+    #[test]
+    fn enumerate_entry_count_limit_enforced() {
+        // MAX_FOLDER_ENTRIES + 1 (10001) file create — uzun ama walk hızlı.
+        let tmp = tempdir().unwrap();
+        for i in 0..=MAX_FOLDER_ENTRIES {
+            // Per-loop file create — flat dir; depth=1.
+            let p = tmp.path().join(format!("f{i:05}.txt"));
+            fs::write(&p, b"x").unwrap();
+        }
+        let r = enumerate_folder(tmp.path());
+        assert!(
+            matches!(r, Err(EnumerateError::EntryCountExceeded { .. })),
+            "got {r:?}"
+        );
+    }
+}

--- a/crates/hekadrop-core/src/folder/mod.rs
+++ b/crates/hekadrop-core/src/folder/mod.rs
@@ -15,12 +15,17 @@
 //! (PR-D'de proto sırası kilitlenecek).
 
 pub mod bundle;
+pub mod enumerate;
 pub mod manifest;
 pub mod sanitize;
 
 pub use bundle::{
     BundleError, BundleHeader, BundleReader, BundleWriter, HEADER_LEN, HEKABUND_MAGIC,
     HEKABUND_VERSION, MAX_MANIFEST_LEN, TRAILER_LEN,
+};
+pub use enumerate::{
+    build_manifest, bundle_total_size, enumerate_folder, BuildError, EntryKind, EnumerateError,
+    EnumeratedEntry, MAX_FOLDER_DEPTH, MAX_FOLDER_ENTRIES,
 };
 pub use manifest::{BundleManifest, ManifestEntry, ManifestError, MANIFEST_VERSION, MAX_ENTRIES};
 pub use sanitize::{sanitize_received_relative_path, sanitize_root_name, PathError, MAX_DEPTH};

--- a/crates/hekadrop-core/src/sender.rs
+++ b/crates/hekadrop-core/src/sender.rs
@@ -89,6 +89,39 @@ struct PlannedFile {
     payload_id: i64,
 }
 
+/// RFC-0005 PR-C — sender için pre-computed folder bundle planı.
+///
+/// `send()` plan aşamasında bir directory path için:
+/// 1. `enumerate_folder` ile entries listesi alır
+/// 2. `build_manifest` ile per-file SHA-256 hesaplar + manifest üretir
+/// 3. `serde_json::to_vec(&manifest)` ile JSON bytes
+/// 4. `bundle_total_size(&manifest_json, &entries)` ile total byte
+///
+/// Bu yapı capability gate aşamasında ya:
+/// - `FOLDER_STREAM_V1` aktifse `send_folder_bundle` ile tek FILE payload
+///   olarak gönderilir (`HEKABUND` header + manifest + `concat_data` + trailer)
+/// - capability inactive ise `flatten_folder_to_files` ile individual file
+///   plan'larına çevrilir (mevcut multi-file akış)
+struct PlannedFolder {
+    /// Sender disk root path (folder kökü). Şu anda sadece debug log'da
+    /// kullanılıyor; ileride retry/resume yolunda walk-yenileme için
+    /// gerekecek (PR-D sonrası).
+    #[allow(dead_code)] // PR-C scope: log + future use; field zaten plan-level.
+    root_path: std::path::PathBuf,
+    /// Manifest validate edilmiş + JSON-serialize için hazır.
+    manifest: crate::folder::BundleManifest,
+    /// Pre-serialized canonical JSON bytes (`BundleWriter::new`'e ve
+    /// `Introduction.attachment_hash` hesabına aynı bytes gider —
+    /// re-serialize ile mismatch riski yok).
+    manifest_json: Vec<u8>,
+    /// Enumerate çıktısı (file body'leri için `absolute_path` lookup).
+    entries: Vec<crate::folder::EnumeratedEntry>,
+    /// `Introduction.FileMetadata.size` — `52 + manifest_len + sum_files`.
+    total_size: i64,
+    /// `Introduction.FileMetadata.payload_id`.
+    payload_id: i64,
+}
+
 pub async fn send(req: SendRequest, state: Arc<AppState>) -> Result<()> {
     if req.files.is_empty() {
         // Not: "hiç dosya yok" ile "toplam 0 bayt dosya var" semantik olarak
@@ -98,11 +131,78 @@ pub async fn send(req: SendRequest, state: Arc<AppState>) -> Result<()> {
     }
 
     let mut plans: Vec<PlannedFile> = Vec::with_capacity(req.files.len());
+    // RFC-0005 PR-C — folder dispatch. İlk directory path bir
+    // `PlannedFolder`'a dönüşür (capability gate aşamasında bundle vs flatten
+    // kararı verilir). Bu PR scope'unda tek folder destekleniyor; mixed
+    // file+folder veya çoklu folder gelecek PR'lara erteleniyor (UI dağıtım
+    // semantiği RFC-0005 §3.7 + §6 kapanış aşamasında).
+    let mut planned_folder: Option<PlannedFolder> = None;
     for path in &req.files {
         if !path.exists() {
             return Err(HekaError::FileNotFound(path.display().to_string()).into());
         }
         let meta = std::fs::metadata(path)?;
+        if meta.is_dir() {
+            // Folder branch — yalnız ilk directory işlenir; sonrasındaki
+            // path'ler sessiz skip + warn.
+            if planned_folder.is_some() {
+                warn!(
+                    "[sender] folder send: ek directory path atlandı (PR-C: tek folder destekleniyor): {}",
+                    path.display()
+                );
+                continue;
+            }
+            // INVARIANT (CLAUDE.md I-1): enumerate_folder + build_manifest
+            // pure folder primitive'leri; UI/global state yok. spawn_blocking
+            // ile sarmalı çünkü recursive walk + per-file SHA-256 disk-bound.
+            let walk_root = path.clone();
+            let entries =
+                tokio::task::spawn_blocking(move || crate::folder::enumerate_folder(&walk_root))
+                    .await
+                    .map_err(|e| anyhow!("folder enumerate task join: {e}"))?
+                    .with_context(|| format!("folder enumerate: {}", path.display()))?;
+            let manifest_root = path.clone();
+            let entries_for_build = entries.clone();
+            let manifest = tokio::task::spawn_blocking(move || {
+                crate::folder::build_manifest(&manifest_root, &entries_for_build)
+            })
+            .await
+            .map_err(|e| anyhow!("folder build_manifest task join: {e}"))?
+            .with_context(|| format!("folder build_manifest: {}", path.display()))?;
+            // Schema-level validate — root_name + entry path sanitize +
+            // duplicate check. Hata receiver'da reject ile kalmasındansa
+            // sender-side erken yakalanır.
+            manifest
+                .validate()
+                .with_context(|| "folder manifest validate")?;
+            let manifest_json =
+                serde_json::to_vec(&manifest).with_context(|| "folder manifest JSON serialize")?;
+            // INVARIANT (CLAUDE.md I-5): bundle_total_size checked aritmetik;
+            // overflow → reject (16 EiB folder pratik dışı ama defansif).
+            let total_u64 = crate::folder::bundle_total_size(manifest_json.len(), &entries)
+                .ok_or_else(|| anyhow!("folder bundle total size overflow"))?;
+            if total_u64 > i64::MAX as u64 {
+                return Err(HekaError::FileTooLarge {
+                    max: i64::MAX,
+                    path: path.display().to_string(),
+                }
+                .into());
+            }
+            // SAFETY-CAST: total_u64 > i64::MAX kontrolü yukarıda; cast wrap yapamaz.
+            #[allow(clippy::cast_possible_wrap)] // INVARIANT: total_u64 ≤ i64::MAX checked
+            let total_i64 = total_u64 as i64;
+            #[allow(clippy::cast_possible_wrap)] // INVARIANT: u64 >> 1 high bit sıfır
+            let payload_id_i64 = (rand::thread_rng().next_u64() >> 1) as i64;
+            planned_folder = Some(PlannedFolder {
+                root_path: path.clone(),
+                manifest,
+                manifest_json,
+                entries,
+                total_size: total_i64,
+                payload_id: payload_id_i64,
+            });
+            continue;
+        }
         let name = path
             .file_name()
             .and_then(|n| n.to_str())
@@ -135,10 +235,19 @@ pub async fn send(req: SendRequest, state: Arc<AppState>) -> Result<()> {
     }
     // Multi-file toplamda i64 overflow olmaması için checked_add kullan.
     // 60 GB üstü senaryoda bile i64 hâlâ rahat, ama yine de savunmacı yaklaşım.
-    let total_bytes: i64 = plans
+    let mut total_bytes: i64 = plans
         .iter()
         .try_fold(0i64, |acc, p| acc.checked_add(p.size))
         .ok_or(HekaError::ByteCountOverflow)?;
+    // RFC-0005 PR-C: folder bundle bayt'ları total_bytes hesabına dahil
+    // edilir → progress yüzde hesabı bundle stream sırasında doğru olsun
+    // (capability inactive flatten yolunda total_bytes flat file'lardan
+    // tekrar hesaplanır; PlannedFolder'ın `total_size` kayıp olur).
+    if let Some(folder) = &planned_folder {
+        total_bytes = total_bytes
+            .checked_add(folder.total_size)
+            .ok_or(HekaError::ByteCountOverflow)?;
+    }
     // Bug #30: Boş dosya(lar) → total_bytes == 0 → aşağıda yüzde hesabı 0/0 olur.
     // Boş dosya göndermeyi reddetmek en açık davranış; UI kullanıcıya anlamlı hata gösterir.
     if total_bytes == 0 {
@@ -339,10 +448,51 @@ pub async fn send(req: SendRequest, state: Arc<AppState>) -> Result<()> {
                         }
 
                         if !introduction_sent {
-                            let intro = build_introduction_multi(&plans);
-                            connection::send_sharing_frame(&mut socket, &mut ctx, &intro).await?;
+                            // RFC-0005 §7 — capability gate: FOLDER_STREAM_V1 inactive ise
+                            // folder bundle akışı yerine flatten fallback (mevcut multi-file
+                            // Introduction). Aktif ise folder Introduction'a tek
+                            // `application/x-hekadrop-folder` FILE entry eklenir.
+                            if let Some(folder) = &planned_folder {
+                                if active_capabilities
+                                    .has(crate::capabilities::features::FOLDER_STREAM_V1)
+                                {
+                                    let intro = build_introduction_folder(folder, &plans);
+                                    connection::send_sharing_frame(&mut socket, &mut ctx, &intro)
+                                        .await?;
+                                    info!(
+                                        "[sender] Folder Introduction gönderildi — bundle {} bayt + {} ek dosya",
+                                        folder.total_size,
+                                        plans.len()
+                                    );
+                                } else {
+                                    // Flatten fallback — folder içeriğini individual file
+                                    // plan'larına dönüştürüp mevcut akışa enjekte et.
+                                    let flattened = flatten_folder_to_files(folder);
+                                    let flat_count = flattened.len();
+                                    plans.extend(flattened);
+                                    // Bundle bayt'ları total_bytes'a eklenmişti; flatten yolunda
+                                    // gerçek dosya bayt'ları farklı (header + manifest + trailer
+                                    // çıkarılır). total_bytes'i flat dosyalardan tekrar hesapla.
+                                    total_bytes = plans
+                                        .iter()
+                                        .try_fold(0i64, |acc, p| acc.checked_add(p.size))
+                                        .ok_or(HekaError::ByteCountOverflow)?;
+                                    planned_folder = None;
+                                    let intro = build_introduction_multi(&plans);
+                                    connection::send_sharing_frame(&mut socket, &mut ctx, &intro)
+                                        .await?;
+                                    info!(
+                                        "[sender] Folder flatten fallback — {} dosya (capability inactive)",
+                                        flat_count
+                                    );
+                                }
+                            } else {
+                                let intro = build_introduction_multi(&plans);
+                                connection::send_sharing_frame(&mut socket, &mut ctx, &intro)
+                                    .await?;
+                                info!("[sender] Introduction gönderildi — {} dosya", plans.len());
+                            }
                             introduction_sent = true;
-                            info!("[sender] Introduction gönderildi — {} dosya", plans.len());
                         }
                     }
                     Some(sh_v1::FrameType::Response) => {
@@ -385,6 +535,31 @@ pub async fn send(req: SendRequest, state: Arc<AppState>) -> Result<()> {
                         let known_payload_ids: Vec<i64> =
                             plans.iter().map(|p| p.payload_id).collect();
                         let mut bytes_sent: i64 = 0;
+                        // RFC-0005 §6 — folder bundle önce gönderilir (intro
+                        // sırasında file_metadata listesinin başında yer
+                        // aldığı için tutarlı).
+                        if let Some(folder) = planned_folder.take() {
+                            let folder_size = folder.total_size;
+                            info!(
+                                "[sender] folder bundle gönderiliyor: payload_id={} ({} bayt)",
+                                folder.payload_id, folder.total_size
+                            );
+                            send_folder_bundle(
+                                &mut socket,
+                                &mut ctx,
+                                folder,
+                                &peer_label,
+                                bytes_sent,
+                                total_bytes,
+                                &cancel_token,
+                                state.as_ref(),
+                                chunk_hmac_key.as_ref(),
+                            )
+                            .await?;
+                            bytes_sent = bytes_sent
+                                .checked_add(folder_size)
+                                .ok_or(HekaError::ByteCountOverflow)?;
+                        }
                         for plan in &plans {
                             info!(
                                 "[sender] gönderiliyor: {} ({} bayt) payload_id={}",
@@ -1381,6 +1556,275 @@ fn wrap_payload_transfer(
             ..Default::default()
         }),
     }
+}
+
+/// RFC-0005 §4 — Folder Introduction frame (`mime_type =
+/// "application/x-hekadrop-folder"`, `attachment_hash = manifest_sha256[0..8]`
+/// BE i64). Intro içine ek individual file plan'ları varsa onlar da eklenir
+/// (PR-C scope: pratikte bu PR'da `plans` boş, ama yapı hazır).
+fn build_introduction_folder(folder: &PlannedFolder, plans: &[PlannedFile]) -> SharingFrame {
+    // INVARIANT (CLAUDE.md I-2): manifest validate `send` aşamasında çağrıldı;
+    // attachment_hash hesabı `serde_json::to_vec` round-trip ile sender-side
+    // başarısız olmaz (manifest `BundleManifest`'in field tipleri primitive +
+    // Vec/String/Option). Hata durumunda 0 fallback — receiver mismatch ile
+    // reject eder, sender-side panic üretmez.
+    let attachment_hash = folder.manifest.attachment_hash_i64().unwrap_or(0);
+    let bundle_name = format!("{}.hekabundle", folder.manifest.root_name);
+    let mut files: Vec<FileMetadata> = Vec::with_capacity(1 + plans.len());
+    files.push(FileMetadata {
+        name: Some(bundle_name),
+        r#type: Some(FileKind::Unknown as i32),
+        payload_id: Some(folder.payload_id),
+        size: Some(folder.total_size),
+        mime_type: Some("application/x-hekadrop-folder".to_string()),
+        attachment_hash: Some(attachment_hash),
+        ..Default::default()
+    });
+    for p in plans {
+        files.push(FileMetadata {
+            name: Some(p.name.clone()),
+            r#type: Some(FileKind::Unknown as i32),
+            payload_id: Some(p.payload_id),
+            size: Some(p.size),
+            mime_type: Some(guess_mime(&p.name).to_string()),
+            ..Default::default()
+        });
+    }
+    SharingFrame {
+        version: Some(ShVersion::V1 as i32),
+        v1: Some(ShV1Frame {
+            r#type: Some(sh_v1::FrameType::Introduction as i32),
+            introduction: Some(IntroductionFrame {
+                file_metadata: files,
+                ..Default::default()
+            }),
+            ..Default::default()
+        }),
+    }
+}
+
+/// RFC-0005 §7 — capability inactive yolda folder içeriği individual file
+/// plan'larına flatten edilir. Sub-directory'ler atlanır (Quick Share legacy
+/// flat akışı zaten dizin yapısını korumaz). Per-file `payload_id` random.
+fn flatten_folder_to_files(folder: &PlannedFolder) -> Vec<PlannedFile> {
+    let mut out: Vec<PlannedFile> = Vec::new();
+    for entry in &folder.entries {
+        if entry.kind != crate::folder::EntryKind::File {
+            continue;
+        }
+        // Flat akış için sadece basename — receiver mevcut Quick Share
+        // yolunda subdir yapısı kuramaz.
+        let name = std::path::Path::new(&entry.relative_path)
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("dosya")
+            .to_owned();
+        // INVARIANT (CLAUDE.md I-5): u64 size sender-controlled (kendi
+        // diskimiz); enumerate sırasında `meta.len()` dönüyor, i64::MAX
+        // kontrolü `enumerate_folder` içinde yapılmıyor — burada checked.
+        let Ok(size_i64) = i64::try_from(entry.size) else {
+            warn!(
+                "[sender] folder flatten: dosya boyutu i64'a sığmıyor, skip: {}",
+                entry.relative_path
+            );
+            continue;
+        };
+        // SAFETY-CAST (CLAUDE.md I-2): u64 >> 1 high-bit sıfır.
+        #[allow(clippy::cast_possible_wrap)] // INVARIANT: u64 >> 1
+        let payload_id_i64 = (rand::thread_rng().next_u64() >> 1) as i64;
+        out.push(PlannedFile {
+            path: entry.absolute_path.clone(),
+            name,
+            size: size_i64,
+            payload_id: payload_id_i64,
+        });
+    }
+    out
+}
+
+/// RFC-0005 §6 — `HEKABUND` bundle stream emit.
+///
+/// Akış (`docs/protocol/folder-payload.md` §2):
+/// 1. `BundleWriter::new(&manifest_json)` → header (16 byte) + manifest hash
+///    chain'e commit.
+/// 2. Header bytes + `manifest_json` bytes accumulator'a yazılır.
+/// 3. Per-file body: absolute path'ten chunk'lar okunur, `BundleWriter` hash
+///    chain'e feed edilir, accumulator `CHUNK_SIZE`'a doldukça
+///    `PayloadTransferFrame{File}` chunk olarak gönderilir.
+/// 4. `BundleWriter::finalize()` → 32 byte trailer accumulator'a, kalan
+///    bytes son chunk olarak `last=1` flag ile gönderilir.
+///
+/// **Chunk ordering invariant:** Tüm chunk'lar tek `payload_id` altında, monoton
+/// artan `offset`. Last chunk `flags=1`. RFC-0003 chunk-HMAC enabled ise her
+/// data chunk'ından sonra `ChunkIntegrity` envelope'u emit edilir (mevcut
+/// `send_file_chunks` pattern'ı).
+#[allow(clippy::too_many_arguments)]
+async fn send_folder_bundle(
+    socket: &mut TcpStream,
+    ctx: &mut SecureCtx,
+    folder: PlannedFolder,
+    peer_label: &str,
+    bytes_sent_before: i64,
+    total_bytes: i64,
+    cancel: &CancellationToken,
+    state: &AppState,
+    chunk_hmac_key: Option<&[u8; 32]>,
+) -> Result<()> {
+    use crate::folder::bundle::BundleWriter;
+
+    let payload_id = folder.payload_id;
+    let total_size = folder.total_size;
+    let bundle_label = format!("{}.hekabundle", folder.manifest.root_name);
+
+    let mut writer = BundleWriter::new(&folder.manifest_json)
+        .with_context(|| "BundleWriter init (manifest_json)")?;
+    let header_bytes = writer.header_bytes();
+
+    // Accumulator — CHUNK_SIZE'a varan flush'lar.
+    let mut accum: Vec<u8> = Vec::with_capacity(CHUNK_SIZE * 2);
+    accum.extend_from_slice(&header_bytes);
+    accum.extend_from_slice(&folder.manifest_json);
+
+    let mut offset: i64 = 0;
+    let mut chunk_index: i64 = 0;
+
+    // Helper: accum'dan tam CHUNK_SIZE drain edip data chunk gönder.
+    // Her drain'de `chunk_index += 1`, `offset += chunk_len`.
+    // (Closure değil — `await` ile mut borrow zinciri).
+    for entry in &folder.entries {
+        if entry.kind != crate::folder::EntryKind::File {
+            continue;
+        }
+        let mut file = tokio::fs::File::open(&entry.absolute_path)
+            .await
+            .with_context(|| format!("folder bundle file open: {}", entry.relative_path))?;
+        let mut buf = vec![0u8; CHUNK_SIZE];
+        loop {
+            // Cancel'i parallel bekle — büyük chunk'larda anında bail.
+            let n = tokio::select! {
+                biased;
+                () = cancel.cancelled() => return Err(HekaError::CancelledDuringChunk.into()),
+                res = file.read(&mut buf) => res?,
+            };
+            if n == 0 {
+                break;
+            }
+            accum.extend_from_slice(&buf[..n]);
+            // BundleWriter hash chain'e feed et.
+            writer.update(&buf[..n]);
+
+            while accum.len() >= CHUNK_SIZE {
+                let chunk: Vec<u8> = accum.drain(..CHUNK_SIZE).collect();
+                send_bundle_chunk(
+                    socket,
+                    ctx,
+                    payload_id,
+                    total_size,
+                    offset,
+                    &chunk,
+                    false,
+                    chunk_hmac_key,
+                    chunk_index,
+                )
+                .await?;
+                // SAFETY-CAST: chunk.len() == CHUNK_SIZE (512 KiB) usize → i64
+                // wrap imkansız (CHUNK_SIZE << i64::MAX).
+                #[allow(clippy::cast_possible_wrap)] // INVARIANT: CHUNK_SIZE = 512 KiB
+                let chunk_len_i64 = chunk.len() as i64;
+                offset = offset
+                    .checked_add(chunk_len_i64)
+                    .ok_or_else(|| anyhow!("folder bundle offset overflow"))?;
+                chunk_index = chunk_index
+                    .checked_add(1)
+                    .ok_or_else(|| anyhow!("folder bundle chunk_index overflow"))?;
+                if let Some(percent) = compute_percent(bytes_sent_before, offset, total_bytes) {
+                    state.set_progress(ProgressState::Receiving {
+                        device: peer_label.to_string(),
+                        file: bundle_label.clone(),
+                        percent,
+                    });
+                }
+            }
+        }
+    }
+
+    // Trailer (32 byte) accumulator'a; kalan bytes (manifest+last partial+trailer)
+    // son chunk olarak `last=1` flag ile yollanır.
+    let trailer = writer.finalize();
+    accum.extend_from_slice(&trailer);
+
+    // Trailing chunk: last_flag=1, body = remaining accum bytes (en az 32 byte
+    // trailer; mümkünse manifest tail + son partial chunk).
+    send_bundle_chunk(
+        socket,
+        ctx,
+        payload_id,
+        total_size,
+        offset,
+        &accum,
+        true,
+        chunk_hmac_key,
+        chunk_index,
+    )
+    .await?;
+
+    info!("[sender] folder bundle gönderildi — {}", bundle_label);
+    Ok(())
+}
+
+/// Tek bundle chunk'ını wrap + encrypt + write yap; chunk-HMAC enabled ise
+/// `ChunkIntegrity` envelope'u peşinden ekle. PR-C: hot-path artık
+/// `send_file_chunks` ile aynı emit pattern'ı.
+#[allow(clippy::too_many_arguments)]
+async fn send_bundle_chunk(
+    socket: &mut TcpStream,
+    ctx: &mut SecureCtx,
+    payload_id: i64,
+    total_size: i64,
+    offset: i64,
+    body: &[u8],
+    last: bool,
+    chunk_hmac_key: Option<&[u8; 32]>,
+    chunk_index: i64,
+) -> Result<()> {
+    let body_bytes = Bytes::copy_from_slice(body);
+    let flags = if last { 1 } else { 0 };
+    let wrapped = wrap_payload_transfer(payload_id, total_size, offset, flags, body_bytes);
+    let enc = ctx.encrypt(&wrapped.encode_to_vec())?;
+    frame::write_frame(socket, &enc).await?;
+
+    // RFC-0003 §2: data chunk hemen ardından ChunkIntegrity envelope'u
+    // (capability gate açık). Last chunk için de tag emit edilir (receiver
+    // her chunk'ı verify eder; final body dahil).
+    if let Some(key) = chunk_hmac_key {
+        let tag = crate::chunk_hmac::compute_tag(key, payload_id, chunk_index, offset, body)
+            .with_context(|| {
+                format!(
+                    "folder bundle chunk-HMAC tag compute (payload_id={payload_id}, chunk_index={chunk_index})"
+                )
+            })?;
+        let ci = crate::chunk_hmac::build_chunk_integrity(
+            payload_id,
+            chunk_index,
+            offset,
+            body.len(),
+            tag,
+        )
+        .with_context(|| {
+            format!(
+                "folder bundle ChunkIntegrity build (payload_id={payload_id}, chunk_index={chunk_index})"
+            )
+        })?;
+        let heka_frame = hekadrop_proto::hekadrop_ext::HekaDropFrame {
+            version: crate::capabilities::ENVELOPE_VERSION,
+            payload: Some(hekadrop_proto::hekadrop_ext::heka_drop_frame::Payload::ChunkTag(ci)),
+        };
+        let pb = heka_frame.encode_to_vec();
+        let wrapped_bytes = frame::wrap_hekadrop_frame(&pb);
+        let enc_tag = ctx.encrypt(&wrapped_bytes)?;
+        frame::write_frame(socket, &enc_tag).await?;
+    }
+    Ok(())
 }
 
 fn build_introduction_multi(plans: &[PlannedFile]) -> SharingFrame {


### PR DESCRIPTION
## Summary

RFC-0005 PR-C — sender pipeline'ı bir directory path verildiğinde recursive
enumerate yapıp per-file SHA-256 pre-compute eder, `BundleManifest` build
edip `HEKABUND` v1 bundle byte stream'ini tek `FILE` payload (MIME marker
`application/x-hekadrop-folder`) olarak emit eder.

Kapsanan spec bölümleri:
- `docs/protocol/folder-payload.md` §3.4 (folder walk symlink/special skip)
- `docs/protocol/folder-payload.md` §3 (BundleManifest schema build)
- `docs/protocol/folder-payload.md` §4 (Introduction frame contract — MIME
  marker + `attachment_hash = manifest_sha256[0..8]` BE i64)
- `docs/protocol/folder-payload.md` §6 (sender bundle stream emit pipeline)
- `docs/protocol/folder-payload.md` §7 (capability gate fallback)

## Yeni public API (`hekadrop-core::folder`)

```rust
pub fn enumerate_folder(root: &Path) -> Result<Vec<EnumeratedEntry>, EnumerateError>;
pub fn build_manifest(root: &Path, entries: &[EnumeratedEntry]) -> Result<BundleManifest, BuildError>;
pub fn bundle_total_size(manifest_json_len: usize, entries: &[EnumeratedEntry]) -> Option<u64>;

pub const MAX_FOLDER_DEPTH: usize = 32;
pub const MAX_FOLDER_ENTRIES: usize = 10_000;

pub struct EnumeratedEntry { absolute_path, relative_path, kind, size, mode, mtime }
pub enum EntryKind { File, Directory }
```

## Sender akış (sender.rs)

1. **Plan aşaması:** `req.files` içindeki ilk directory path için
   `tokio::task::spawn_blocking` ile `enumerate_folder` + `build_manifest`
   (disk-bound; async runtime'ı bloklamaz). Manifest validate + JSON
   serialize + `bundle_total_size` checked aritmetik.
2. **Capability gate** (PairedKeyResult sonrası):
   - `FOLDER_STREAM_V1` aktif → `build_introduction_folder` ile tek FILE
     entry (MIME marker + `attachment_hash`) Introduction.
   - inactive → `flatten_folder_to_files` ile individual file plan'larına
     dönüştür, mevcut multi-file Introduction akışı.
3. **Bundle emit** (Response Accept sonrası): `send_folder_bundle`
   → `BundleWriter` ile header + manifest_json + per-entry body (CHUNK_SIZE
   = 512 KiB chunk'lara split, hash chain feed) + finalize trailer.
   Chunk-HMAC enabled ise her data chunk'tan sonra `ChunkIntegrity`
   envelope (RFC-0003 §2 ordering invariant).

## Test plan (8 test, `tests/folder_sender_send.rs`)

- [x] `enumerate_folder_3_files_skips_symlinks` (Unix; symlink wire'a
      sızmıyor)
- [x] `enumerate_folder_depth_exceeded_errors` (33 nested dir → reject)
- [x] `enumerate_folder_entry_count_exceeded_errors` (10 001 file → reject)
- [x] `build_manifest_per_file_sha256_correct` (manifest hash = bağımsız
      streaming SHA-256)
- [x] `bundle_total_size_calculation` (HEADER_LEN + manifest_len +
      sum(file_sizes) + TRAILER_LEN)
- [x] `send_folder_bundle_full_loopback_decode_matches_manifest`
      (BundleWriter byte stream → BundleReader::open trailer verify +
      manifest_json round-trip)
- [x] `attachment_hash_matches_manifest_sha256_prefix` (Introduction frame
      contract §4.1)
- [x] `send_folder_bundle_capability_inactive_falls_back_to_flatten`
      (directory entries 0 byte concat_data katkısı, file basename'leri
      flatten plan'a aktarılır)

`send_folder_bundle` private async fn — gerçek network mock E2E
(receiver-side bundle parse + extract) PR-D merge'inden sonra
`crates/hekadrop-app/tests/folder_e2e.rs` harness'ine eklenecek.

## Capability state

`FOLDER_STREAM_V1` hâlâ `ALL_SUPPORTED`'da DEĞİL (PR-F sender+receiver
karşılıklı bağlandıktan sonra açılacak). Bu PR sender-side primitive'leri
hazır eder ama capability advertise edilmediği için pratikte capability
inactive yolu (flatten fallback) çalışacak.

## CLAUDE.md uyumu

- **I-1** (core app-only ref yok): enumerate.rs sadece `std` + `chrono` +
  `sha2` + `tracing` import eder; sender.rs `crate::folder::*` çağırır.
- **I-2** (`#[allow]` scoped + yorumlu): tüm yeni allow'lar item-scoped
  + INVARIANT/SAFETY-CAST açıklamalı.
- **I-3** (`_e` bypass yok): let-else + match destructuring; zero-sized
  marker error'lar canonical reporting field'ına kanalize.
- **I-5** (untrusted aritmetik checked): `bundle_total_size` + `entry.size`
  → `checked_add`, `i64::try_from`, `u32::try_from` zinciri.
- **I-6** (hidden global state yok): tüm folder helper'ları pure.

## Test plan (manuel doğrulama)

- [ ] `cargo fmt --all -- --check` yeşil
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
      yeşil
- [ ] `cargo test --workspace` yeşil (314 core + 8 yeni integration test)
- [ ] `cargo machete --with-metadata` yeşil
- [ ] `typos` yeşil

🤖 Generated with [Claude Code](https://claude.com/claude-code)