### PR TITLE
feat(rfc-0005): PR-F — FOLDER_STREAM_V1 capability advertise + UI integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — v0.8.0 protocol features (RFC-0003 + RFC-0004 + RFC-0005)
+- **feat(rfc-0005): folder bundle support** — `FOLDER_STREAM_V1` capability
+  (`0x0000_0004`) `ALL_SUPPORTED`'a eklendi (PR-F). Sender tarafı `enumerate_folder`
+  + `build_manifest` + `BundleWriter` ile folder'ı `HEKABUND` v1 container'da tek
+  payload olarak gönderir; receiver bundle'ı staging dir'e extract eder + per-file
+  SHA-256 verify + atomic-reject (herhangi bir hata → tüm extract iptal, diskte
+  yarım veri kalmaz). Manifest sanitize: path traversal (`..`), null byte,
+  separator collapse, depth ≤ 32, entry ≤ 10 000. Chunk-HMAC + RESUME_V1 ile
+  birlikte çalışır — yarıda kesilen folder transfer kaldığı yerden devam eder.
+  UI: accept dialog "📁 {root_name} klasörü — {N} dosya, {size}" satırı; tamam
+  notification'ı `Klasörü Aç` aksiyonu ile (Finder/Explorer/xdg-open).
+- **feat(rfc-0004): transfer resume** — `RESUME_V1` capability (`0x0000_0002`)
+  PR-G ile aktive edildi (PR #138). Receiver `.meta` partial state persist +
+  `ResumeHint`/`ResumeReject` proto frame'leri + sender offset seek; cleanup
+  sweep TTL/budget LRU.
+- **feat(rfc-0003): chunk-HMAC** — `CHUNK_HMAC_V1` capability (`0x0000_0001`)
+  per-data-chunk HMAC-SHA256 integrity tag.
+
 ### Added — Workspace Refactor (RFC-0001 §5, Adım 1-8 tamamlandı)
 - **5 üyeli Cargo workspace**: `hekadrop-proto` (leaf, prost wire types) →
   `hekadrop-core` (protocol engine: crypto, frame, UKEY2, secure, payload,

--- a/README.md
+++ b/README.md
@@ -45,6 +45,14 @@ doğrudan — bulut yok, hesap yok, tracker yok.
   açılır, güvensizleri panoya düşer. Preview `text_title` sadece `scheme://host` —
   token'lı URL'ler payload geçmişinde kalıcı bırakmaz.
 - **Klasör drag-drop** — pencereye sürüklenen dizinler özyinelemeli olarak dosyalara açılır.
+- **Folder transfer (HEKABUND, atomic-reject + per-file SHA-256)** — RFC-0005 v0.8.0
+  ile klasörler tek paket halinde gönderilir: `HEKABUND` v1 container header + JSON
+  manifest (path traversal sanitize, derinlik ≤ 32, entry ≤ 10 000) + per-file body
+  + trailer SHA-256. Receiver tarafında bundle bir staging dizinine extract edilir;
+  herhangi bir hata (manifest mismatch, sanitize fail, partial write) tüm extract'i
+  atomik olarak iptal eder ve diskte yarım veri kalmaz. Chunk-HMAC + RESUME_V1 ile
+  birlikte çalışır — yarıda kesilen klasör transferi tekrar bağlanıldığında kaldığı
+  yerden devam eder.
 - **Trusted devices (whitelist)** — güvendiğiniz cihazlar her seferinde PIN sormadan otomatik kabul edilir
   ve **rate limit kurallarının dışında tutulur**. v0.6.0'dan itibaren **kriptografik hash-first**
   trust kararı (spoofing'e karşı sertleştirilmiş, bkz. [design 017](docs/design/017-trusted-id-hardening.md)).

--- a/crates/hekadrop-app/src/i18n.rs
+++ b/crates/hekadrop-app/src/i18n.rs
@@ -201,6 +201,14 @@ fn lookup_tr(key: &str) -> Option<&'static str> {
         "accept.trust_yes" => "Evet, güven",
         "accept.trust_later" => "Sadece bu sefer",
 
+        // RFC-0005 PR-F — folder accept dialog body satırı: peer'dan klasör
+        // bundle geldiğinde dosya listesi yerine "klasör — N dosya, X" özeti.
+        "prompt.folder_accept.body" => "📁 {0} klasörü — {1} dosya, {2}",
+
+        // RFC-0005 PR-F — folder completion notification
+        "notification.folder_received.title" => "{0} klasörü tamam",
+        "notification.folder_received.body" => "{1} dosya, {2} alındı",
+
         // Sender dialog
         "send.choose_title" => "Gönderilecek dosyaları seçin",
         "send.device_prompt" => "Hedef cihaz",
@@ -407,6 +415,13 @@ fn lookup_en(key: &str) -> Option<&'static str> {
         "accept.trust_prompt" => "Add {0} to the trusted devices list for this and future transfers?",
         "accept.trust_yes" => "Yes, trust",
         "accept.trust_later" => "Just this once",
+
+        // RFC-0005 PR-F — folder accept dialog body line.
+        "prompt.folder_accept.body" => "📁 {0} folder — {1} files, {2}",
+
+        // RFC-0005 PR-F — folder completion notification.
+        "notification.folder_received.title" => "Folder {0} received",
+        "notification.folder_received.body" => "{1} files, {2} received",
 
         // Sender dialog
         "send.choose_title" => "Select files to send",
@@ -774,6 +789,10 @@ mod tests {
             "onboarding.body",
             "onboarding.cta_settings",
             "onboarding.cta_dismiss",
+            // RFC-0005 PR-F — folder UI keys
+            "prompt.folder_accept.body",
+            "notification.folder_received.title",
+            "notification.folder_received.body",
         ];
         for k in &sample_keys {
             assert!(lookup_tr(k).is_some(), "Türkçe çeviri eksik: {k}");

--- a/crates/hekadrop-app/src/ui.rs
+++ b/crates/hekadrop-app/src/ui.rs
@@ -23,6 +23,18 @@ pub(crate) struct FileSummary {
     pub size: i64,
 }
 
+/// RFC-0005 PR-F — accept dialog folder enrichment payload.
+///
+/// Sender peer Introduction'ında `application/x-hekadrop-folder` MIME marker
+/// ile bundle gönderdiğinde [`prompt_accept`] çağrısı buna sahip olur ve
+/// dialog body'sinde dosya listesi yerine "klasör — N dosya, X" özeti
+/// gösterilir.
+pub(crate) struct FolderSummary {
+    pub root_name: String,
+    pub entry_count: u32,
+    pub total_size: i64,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum AcceptResult {
     Reject,
@@ -34,11 +46,16 @@ pub(crate) enum AcceptResult {
 ///   - Reddet
 ///   - Kabul et
 ///   - Kabul + güven (`device_name` ileride otomatik kabul edilir)
+///
+/// `folder` `Some` iken peer bundle gönderiyor (RFC-0005 PR-F); dosya listesi
+/// yerine `prompt.folder_accept.body` çevrim'i ile zenginleştirilmiş satır
+/// gösterilir.
 pub(crate) async fn prompt_accept(
     device_name: &str,
     pin_code: &str,
     files: &[FileSummary],
     text_count: usize,
+    folder: Option<&FolderSummary>,
 ) -> Result<AcceptResult> {
     // Peer-kontrollü alanları dialog gövdesine yerleştirmeden önce
     // control karakterleri (özellikle `\n`, `\r`) strip et — kötü niyetli
@@ -50,10 +67,20 @@ pub(crate) async fn prompt_accept(
         .iter()
         .map(|f| (sanitize_field(&f.name), f.size))
         .collect();
+    // RFC-0005 PR-F: root_name peer-controlled — sender'da
+    // sanitize_root_name'den geçti ama UI display öncesi defansif bir kez
+    // daha control char strip.
+    let folder_owned = folder.map(|f| FolderSummary {
+        root_name: sanitize_field(&f.root_name),
+        entry_count: f.entry_count,
+        total_size: f.total_size,
+    });
 
-    task::spawn_blocking(move || prompt_accept_blocking(&device, &pin, &files, text_count))
-        .await
-        .map_err(|e| anyhow::anyhow!("UI task join: {e}"))
+    task::spawn_blocking(move || {
+        prompt_accept_blocking(&device, &pin, &files, text_count, folder_owned.as_ref())
+    })
+    .await
+    .map_err(|e| anyhow::anyhow!("UI task join: {e}"))
 }
 
 /// Tek bir peer-kontrollü alan (cihaz adı, dosya adı, PIN) için sıkı
@@ -76,7 +103,26 @@ fn sanitize_display_text(s: &str) -> String {
         .collect()
 }
 
-fn format_payload_lines(files: &[(String, i64)], text_count: usize) -> String {
+fn format_payload_lines(
+    files: &[(String, i64)],
+    text_count: usize,
+    folder: Option<&FolderSummary>,
+) -> String {
+    // RFC-0005 PR-F: bundle MIME marker → "klasör — N dosya, X" satırı
+    // dosya listesinin önüne. Folder summary mevcutken peer'ın gerçek payload
+    // semantiği "tek bundle" (bundle_name `<root>.hekabundle` summaries'in
+    // içinde dosya gibi görünüyor — kullanıcıya "klasör" olarak sunuyoruz ki
+    // dağılım/extract şeffaf kalsın).
+    if let Some(f) = folder {
+        return crate::i18n::tf(
+            "prompt.folder_accept.body",
+            &[
+                &f.root_name,
+                &f.entry_count.to_string(),
+                &human_size(f.total_size),
+            ],
+        );
+    }
     if files.is_empty() {
         if text_count > 0 {
             crate::i18n::tf("accept.text_count", &[&text_count.to_string()])
@@ -98,8 +144,9 @@ fn prompt_accept_blocking(
     pin: &str,
     files: &[(String, i64)],
     text_count: usize,
+    folder: Option<&FolderSummary>,
 ) -> AcceptResult {
-    let files_str = format_payload_lines(files, text_count);
+    let files_str = format_payload_lines(files, text_count, folder);
     let message = crate::i18n::tf("accept.body", &[device, pin, &files_str]);
     let btn_reject = crate::i18n::t("accept.reject");
     let btn_accept = crate::i18n::t("accept.accept");
@@ -153,6 +200,7 @@ fn prompt_accept_blocking(
     pin: &str,
     files: &[(String, i64)],
     text_count: usize,
+    folder: Option<&FolderSummary>,
 ) -> AcceptResult {
     // Windows MessageBoxW ile 3 seçenekli dialog:
     //   Evet  = Kabul + güven   (MB_YESNOCANCEL → IDYES)
@@ -169,7 +217,7 @@ fn prompt_accept_blocking(
         MessageBoxW, IDCANCEL, IDNO, IDYES, MB_ICONINFORMATION, MB_SYSTEMMODAL, MB_YESNOCANCEL,
     };
 
-    let files_str = format_payload_lines(files, text_count);
+    let files_str = format_payload_lines(files, text_count, folder);
     // MessageBoxW'un Yes/No/Cancel butonları Windows sistem diline göre
     // zaten lokalize geliyor; biz mesajın gövdesinde buton anlamlarını
     // i18n üzerinden yazdırıyoruz.
@@ -219,8 +267,9 @@ fn prompt_accept_blocking(
     pin: &str,
     files: &[(String, i64)],
     text_count: usize,
+    folder: Option<&FolderSummary>,
 ) -> AcceptResult {
-    let files_str = format_payload_lines(files, text_count);
+    let files_str = format_payload_lines(files, text_count, folder);
     let message =
         sanitize_display_text(&crate::i18n::tf("accept.body", &[device, pin, &files_str]));
     let title = crate::i18n::t("accept.title");

--- a/crates/hekadrop-app/src/ui_adapter.rs
+++ b/crates/hekadrop-app/src/ui_adapter.rs
@@ -14,7 +14,9 @@
 //! ve timing değişmez. Refactor pure mechanical decoupling.
 
 use async_trait::async_trait;
-use hekadrop_core::ui_port::{AcceptDecision, FileSummary, UiNotification, UiPort};
+use hekadrop_core::ui_port::{
+    AcceptDecision, FileSummary, FolderPromptSummary, UiNotification, UiPort,
+};
 
 /// `connection::PlatformOps` trait'inin app-side concrete impl'i —
 /// `crate::platform::open_url` / `crate::platform::copy_to_clipboard`'ı
@@ -89,6 +91,24 @@ impl UiPort for UiAdapter {
                 let body = crate::i18n::tf(body_key, &args_refs);
                 crate::ui::notify_file_received(title, &body, path);
             }
+            UiNotification::FolderReceived {
+                title_key,
+                body_key,
+                body_args,
+                path,
+            } => {
+                // RFC-0005 PR-F: folder completion toast. Notification altyapısı
+                // file ile aynı (`notify-rust` action: open) — ancak file tıklanınca
+                // `open_path` dosyayı açar; klasörde aynı çağrı klasörü açar
+                // (Finder/Explorer/xdg-open). Reveal action mantıksal olarak
+                // duplicate olur (klasör zaten parent'ı olur), o yüzden
+                // file path'iyle aynı helper'a delege; OS-bazlı reveal davranışı
+                // file için optimal ama klasör için de bozulmaz (parent dir açar).
+                let title = crate::i18n::t(title_key);
+                let args_refs: Vec<&str> = body_args.iter().map(String::as_str).collect();
+                let body = crate::i18n::tf(body_key, &args_refs);
+                crate::ui::notify_file_received(title, &body, path);
+            }
             UiNotification::ToastRaw { title, body } => {
                 crate::ui::notify(&title, &body);
             }
@@ -106,6 +126,7 @@ impl UiPort for UiAdapter {
         pin: &str,
         files: &[FileSummary],
         text_count: usize,
+        folder: Option<&FolderPromptSummary>,
     ) -> AcceptDecision {
         // Core FileSummary → app ui::FileSummary type conversion. İki struct
         // alan bazında izomorfik; convert burada zorunlu çünkü `crate::ui`
@@ -117,7 +138,15 @@ impl UiPort for UiAdapter {
                 size: f.size,
             })
             .collect();
-        let result = crate::ui::prompt_accept(device, pin, &ui_files, text_count).await;
+        // RFC-0005 PR-F: folder summary'i app-side ui::FolderSummary'e map et.
+        // Core type'ı `crate::ui` modülüne sızdırmamak için manual convert.
+        let ui_folder = folder.map(|f| crate::ui::FolderSummary {
+            root_name: f.root_name.clone(),
+            entry_count: f.entry_count,
+            total_size: f.total_size,
+        });
+        let result =
+            crate::ui::prompt_accept(device, pin, &ui_files, text_count, ui_folder.as_ref()).await;
         match result {
             Ok(crate::ui::AcceptResult::Accept) => AcceptDecision::Accept,
             Ok(crate::ui::AcceptResult::AcceptAndTrust) => AcceptDecision::AcceptAndTrust,

--- a/crates/hekadrop-app/tests/folder_ui_integration.rs
+++ b/crates/hekadrop-app/tests/folder_ui_integration.rs
@@ -1,0 +1,105 @@
+// Test/bench dosyası — production lint'leri test idiomatik kullanımı bozmasın.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::missing_panics_doc,
+    clippy::doc_markdown
+)]
+
+//! RFC-0005 PR-F — UI integration smoke tests.
+//!
+//! Bu testler folder transfer pipeline'ının UI dispatch katmanını ve capability
+//! gate'ini sabitler. Tüm tests platform-agnostik; gerçek dialog/notification
+//! gösterimi platform-specific (CI'da headless ortamlar için skip) ve manuel
+//! smoke ile doğrulanır.
+//!
+//! - `folder_received_notification_payload` — `UiNotification::FolderReceived`
+//!   variant'ının i18n key + body args formatı doğru taşınıyor mu.
+//! - `folder_accept_prompt_message_format` — `FolderPromptSummary` field'ları
+//!   beklenen değerleri taşıyor; downstream rendering pipeline (i18n çevrimi)
+//!   için sabit kontrat.
+//! - `all_supported_includes_folder_stream_v1` — capabilities.rs assertion
+//!   defensive duplicate (bit aktif, peer'a advertise ediliyor).
+
+use hekadrop::capabilities::features;
+use hekadrop::ui_port::{FolderPromptSummary, UiNotification};
+use std::path::PathBuf;
+
+#[test]
+fn folder_received_notification_payload() {
+    // RFC-0005 PR-F: connection.rs::finalize_received_payload bundle extract
+    // başarısı sonrası `UiNotification::FolderReceived` emit eder. Bu test
+    // variant'ın i18n key + body args + path triple'ını sabitler — UI adapter
+    // (app-side) bu kontrat üzerine `notification.folder_received.*` keys'i
+    // çevirip toast gösterir.
+    let final_path = PathBuf::from("/tmp/hekadrop-test/Belgeler");
+    let n = UiNotification::FolderReceived {
+        title_key: "notification.folder_received.title",
+        body_key: "notification.folder_received.body",
+        body_args: vec![
+            "Belgeler".to_string(),
+            "12".to_string(),
+            "3.4 MB".to_string(),
+        ],
+        path: final_path.clone(),
+    };
+    if let UiNotification::FolderReceived {
+        title_key,
+        body_key,
+        body_args,
+        path,
+    } = n
+    {
+        assert_eq!(title_key, "notification.folder_received.title");
+        assert_eq!(body_key, "notification.folder_received.body");
+        // Body args sırası: [root_name, file_count, human_size].
+        // tf("notification.folder_received.title", &args) → "{0}" =
+        // root_name; body → "{1} dosya, {2}" pattern. {0} body'de
+        // unused — title rendering için reserve.
+        assert_eq!(body_args.len(), 3);
+        assert_eq!(body_args[0], "Belgeler");
+        assert_eq!(body_args[1], "12");
+        assert_eq!(body_args[2], "3.4 MB");
+        assert_eq!(path, final_path);
+    } else {
+        panic!("FolderReceived variant beklendi");
+    }
+}
+
+#[test]
+fn folder_accept_prompt_message_format() {
+    // RFC-0005 PR-F: `FolderPromptSummary` core'dan UI'a geçen kontrat.
+    // `connection.rs::build_folder_prompt_summary` Introduction'daki bundle
+    // marker'dan üretir; UI adapter `prompt.folder_accept.body` template'ini
+    // `[root_name, count, human_size]` ile interpolate eder.
+    //
+    // Bu test sadece struct field'larının taşıdığı değerleri sabitler;
+    // rendering (`format_payload_lines`) i18n module-private olduğu için
+    // tests'ten çağrılamaz, manuel smoke ile doğrulanır.
+    let summary = FolderPromptSummary {
+        root_name: "Tatil 2025".to_string(),
+        entry_count: 42,
+        total_size: 12_345_678,
+    };
+    assert_eq!(summary.root_name, "Tatil 2025");
+    assert_eq!(summary.entry_count, 42);
+    assert_eq!(summary.total_size, 12_345_678);
+    // root_name boş peer-attack'a karşı sender-side
+    // `folder::sanitize::sanitize_root_name` validates; bu kontrat yine de
+    // empty olmaması beklenen sender semantiği.
+    assert!(!summary.root_name.is_empty());
+}
+
+#[test]
+fn all_supported_includes_folder_stream_v1() {
+    // RFC-0005 PR-F: capability gate. Bu assertion `capabilities.rs`'teki
+    // `all_supported_only_has_implemented_features` testinin defensive
+    // duplicate'i — integration test seviyesinde de bit'in aktif olduğunu
+    // sabitler. PR-F öncesi bu test panic ederdi.
+    assert_ne!(features::ALL_SUPPORTED & features::FOLDER_STREAM_V1, 0);
+    assert_eq!(
+        features::ALL_SUPPORTED,
+        features::CHUNK_HMAC_V1 | features::RESUME_V1 | features::FOLDER_STREAM_V1
+    );
+}

--- a/crates/hekadrop-core/src/capabilities.rs
+++ b/crates/hekadrop-core/src/capabilities.rs
@@ -36,31 +36,36 @@ pub mod features {
     /// AND sonucundan düşer (forward-compat).
     ///
     /// **Yalnızca implementasyonu hazır feature'lar advertise edilir** (PR #103
-    /// Copilot review): hâlihazırda peer'a bir feature'ı reklam etmek "biz bu
+    /// Copilot review): peer'a bir feature'ı reklam etmek "biz bu
     /// extension frame'lerini doğru handle edebiliriz" sözleşmesidir.
-    /// `FOLDER_STREAM_V1` (RFC-0005) implementasyonu henüz yok → advertise
-    /// EDİLMEZ. Implementasyon merge olunca buraya geri eklenir.
     ///
-    /// `RESUME_V1` (RFC-0004) PR-A→PR-F zinciriyle merge oldu (proto schema +
-    /// `resume.rs` primitives + receiver `.meta` persist + `ResumeHint` emit
-    /// + sender `wait_for_resume_hint_or_zero` verify + cleanup sweep).
+    /// Tarihçe (RFC-0004 `RESUME_V1`):
+    /// - PR-F'de açıldı, **PR #136 Gemini high yorumu sonrası geri kapatıldı**
+    ///   (receiver `truncate(true)` → veri kaybı).
+    /// - **PR-G ile geri açıldı:** `payload.rs::ingest_file` artık resume
+    ///   aktifken `truncate(false)` + `seek(received_bytes)` ile mevcut
+    ///   `.part`'a devam eder; hasher önceki byte'larla feed edilir (final
+    ///   SHA-256 chain tutarlı kalır); `connection.rs::resolve_resume_path`
+    ///   Introduction handler'ında fresh placeholder yerine `meta.dest_path`'i
+    ///   register eder.
     ///
-    /// **PR #136 Gemini high yorumu sonrası geri kapatıldı** (receiver
-    /// `truncate(true)` → veri kaybı). **PR-G ile geri açıldı:**
-    /// `payload.rs::ingest_file` artık resume aktifken `truncate(false)` +
-    /// `seek(received_bytes)` ile mevcut `.part`'a devam eder; hasher önceki
-    /// byte'larla feed edilir (final SHA-256 chain tutarlı kalır);
-    /// `connection.rs::resolve_resume_path` Introduction handler'ında fresh
-    /// placeholder yerine `meta.dest_path`'i register eder.
-    pub const ALL_SUPPORTED: u64 = CHUNK_HMAC_V1 | RESUME_V1;
+    /// Tarihçe (RFC-0005 `FOLDER_STREAM_V1`):
+    /// - PR-A → PR-E ile primitives + sender enumerate + receiver extract +
+    ///   chunk-HMAC/resume entegrasyonu tamamlandı.
+    /// - **PR-F'de aktive edildi**: `ALL_SUPPORTED` bayrağa eklendi; UI
+    ///   accept dialog folder summary + completion notification "Klasörü Aç"
+    ///   aksiyonu wire'landı; `FOLDER_BUNDLE_MIME` Introduction'da
+    ///   bulunduğunda extract pipeline (`crate::folder::extract`) atomic-reject
+    ///   garantisiyle devreye girer.
+    pub const ALL_SUPPORTED: u64 = CHUNK_HMAC_V1 | RESUME_V1 | FOLDER_STREAM_V1;
 
     /// Bu build için reserved (henüz hiçbir RFC'nin sahip olmadığı) bit'ler.
     /// Test'lerde forward-compat akışını doğrulamak için kullanılır.
     ///
-    /// `ALL_SUPPORTED`'a dahil olmayan ama bit konumu kayıtlı feature'lar
-    /// (`RESUME_V1`, `FOLDER_STREAM_V1`) burada otomatik içerilir — peer'ın
-    /// "ben bu future bit'i destekliyorum" demesinin AND ile düşmesi forward-
-    /// compat semantiğini gösterir.
+    /// PR-F (RFC-0005) sonrası `ALL_SUPPORTED = CHUNK_HMAC_V1 | RESUME_V1 |
+    /// FOLDER_STREAM_V1`; geri kalan tüm üst bit'ler henüz herhangi bir RFC'ye
+    /// atanmamış reserved alandır. Peer'ın "ben bu future bit'i destekliyorum"
+    /// demesinin AND ile düşmesi forward-compat semantiğini gösterir.
     #[cfg(test)]
     pub const RESERVED_FUTURE: u64 = !ALL_SUPPORTED;
 }
@@ -375,17 +380,18 @@ mod tests {
     #[test]
     fn all_supported_only_has_implemented_features() {
         // PR #103 review (Copilot): ALL_SUPPORTED yalnızca implementasyonu
-        // hazır feature'ları içerir. RFC-0004 (RESUME_V1) PR-F'de açıldı,
-        // PR #136 high yorumu sonrası geri kapatıldı (receiver truncate(true)
-        // → resume body sıfırlama riski). **PR-G ile geri açıldı**: receiver
-        // append/seek + hasher feed entegre. RFC-0005 (FOLDER_STREAM_V1)
-        // hâlâ unimplemented → advertise edilmez.
+        // hazır feature'ları içerir. RFC-0004 (RESUME_V1) PR-G ile geri
+        // açıldı (receiver append/seek + hasher feed entegre). **RFC-0005
+        // (FOLDER_STREAM_V1) PR-F ile aktive edildi**: PR-A → PR-E ile
+        // primitives + sender + receiver + chunk-HMAC/resume entegrasyonu
+        // tamamlandı, PR-F UI dialog + completion notification + capability
+        // gate açtı.
         assert_eq!(
             features::ALL_SUPPORTED,
-            features::CHUNK_HMAC_V1 | features::RESUME_V1
+            features::CHUNK_HMAC_V1 | features::RESUME_V1 | features::FOLDER_STREAM_V1
         );
         assert_ne!(features::ALL_SUPPORTED & features::CHUNK_HMAC_V1, 0);
         assert_ne!(features::ALL_SUPPORTED & features::RESUME_V1, 0);
-        assert_eq!(features::ALL_SUPPORTED & features::FOLDER_STREAM_V1, 0);
+        assert_ne!(features::ALL_SUPPORTED & features::FOLDER_STREAM_V1, 0);
     }
 }

--- a/crates/hekadrop-core/src/connection.rs
+++ b/crates/hekadrop-core/src/connection.rs
@@ -28,7 +28,7 @@ use crate::sharing::nearby::{
     PairedKeyEncryptionFrame, PairedKeyResultFrame, V1Frame as ShV1Frame,
 };
 use crate::state::{self, AppState, HistoryItem, ProgressState};
-use crate::ui_port::{AcceptDecision, FileSummary, UiNotification, UiPort};
+use crate::ui_port::{AcceptDecision, FileSummary, FolderPromptSummary, UiNotification, UiPort};
 use crate::ukey2;
 use anyhow::{anyhow, Context, Result};
 use prost::Message;
@@ -563,10 +563,18 @@ fn finalize_received_payload(
                     when: std::time::SystemTime::now(),
                     sha256_short: hex::encode(sha256).chars().take(16).collect(),
                 });
-                ui.notify(UiNotification::FileReceived {
-                    title_key: "notify.app_name",
-                    body_key: "notify.received",
-                    body_args: vec![folder_label, format!("{}", extracted.file_count)],
+                // RFC-0005 PR-F: folder-specific notification — `FolderReceived`
+                // varyantı `notification.folder_received.*` i18n key'leri ile
+                // "klasör tamam" başlığı + "N dosya, X" body, "Klasörü Aç"
+                // aksiyon path'i (`platform::open_path` Finder/Explorer/xdg).
+                ui.notify(UiNotification::FolderReceived {
+                    title_key: "notification.folder_received.title",
+                    body_key: "notification.folder_received.body",
+                    body_args: vec![
+                        folder_label,
+                        extracted.file_count.to_string(),
+                        human_size(total_size),
+                    ],
                     path: extracted.final_path,
                 });
             }
@@ -586,6 +594,42 @@ fn finalize_received_payload(
     }
     // Mevcut individual file akışı — bundle marker yok.
     finalize_received_file(peer, path, total_size, sha256, remote_name, state, ui);
+}
+
+/// RFC-0005 PR-F — Introduction'daki bundle marker'larından accept dialog
+/// için folder summary üret. Aynı Introduction içinde tek bundle olur (sender
+/// `build_introduction_folder` tek `<root>.hekabundle` `FileMetadata` + her
+/// inner file için ek metadata gönderir); birden fazla bundle gelirse ilkini
+/// kullanırız (defansif — spec dışı).
+///
+/// `entry_count` = `planned_files` − `planned_bundles`: bundle marker kendisi
+/// dosya değil, manifest'teki gerçek file entry sayısı kalır.
+///
+/// `root_name` bundle filename'inden `.hekabundle` suffix strip ile
+/// türetilir; sender invariantı `<sanitized_root>.hekabundle`. Strip
+/// başarısızsa filename olduğu gibi gösterilir (defansif).
+fn build_folder_prompt_summary(
+    planned_bundles: &[(i64, i64, std::path::PathBuf)],
+    planned_files: &[(i64, std::path::PathBuf, String, i64)],
+) -> Option<FolderPromptSummary> {
+    let (bundle_pid, _, _) = planned_bundles.first()?;
+    let (_, _, bundle_name, bundle_size) =
+        planned_files.iter().find(|(pid, ..)| pid == bundle_pid)?;
+    let root_name = bundle_name
+        .strip_suffix(".hekabundle")
+        .unwrap_or(bundle_name)
+        .to_string();
+    // INVARIANT (CLAUDE.md I-5): planned_files.len() ≤ 1000 (Introduction
+    // flood guard L817), planned_bundles.len() ≤ planned_files.len().
+    // Saturating sub + u32 cast (max 1000 ≪ u32::MAX) güvenli.
+    let total_entries = planned_files.len().saturating_sub(planned_bundles.len());
+    #[allow(clippy::cast_possible_truncation)] // INVARIANT: ≤ 1000 < u32::MAX
+    let entry_count = total_entries as u32;
+    Some(FolderPromptSummary {
+        root_name,
+        entry_count,
+        total_size: *bundle_size,
+    })
 }
 
 /// `CompletedPayload::File` finalize ortak işleri (stats record, history push,
@@ -1072,8 +1116,22 @@ async fn handle_sharing_frame(
                         pin: pin_code.to_string(),
                     });
                 }
-                ui.prompt_accept(remote_name, pin_code, &summaries, text_count)
-                    .await
+                // RFC-0005 PR-F: peer Introduction'da bundle MIME marker
+                // gönderdiyse `planned_bundles` non-empty. UI'a klasör
+                // summary'i geç → dialog body "klasör — N dosya, X MB"
+                // satırı ile zenginleşir. Sender `build_introduction_folder`
+                // bundle marker + her bir inner file için ek FileMetadata
+                // gönderir; entry_count = (toplam planned_files) − (bundle
+                // marker count) = manifest'teki file entry sayısı.
+                let folder_summary = build_folder_prompt_summary(&planned_bundles, &planned_files);
+                ui.prompt_accept(
+                    remote_name,
+                    pin_code,
+                    &summaries,
+                    text_count,
+                    folder_summary.as_ref(),
+                )
+                .await
             };
 
             let ok = !matches!(decision, AcceptDecision::Reject);

--- a/crates/hekadrop-core/src/frame.rs
+++ b/crates/hekadrop-core/src/frame.rs
@@ -245,13 +245,13 @@ mod dispatcher_tests {
                 if let Some(Payload::Capabilities(c)) = frame.payload {
                     assert_eq!(c.features, 0x07);
                     let active = ActiveCapabilities::negotiate(features::ALL_SUPPORTED, c.features);
-                    // PR-G: RESUME_V1 ALL_SUPPORTED'a geri eklendi (receiver
-                    // append/seek tamamlandı). Peer 0x07 advertise edince
-                    // intersection CHUNK_HMAC + RESUME_V1; FOLDER_STREAM_V1
-                    // bizim build'imizde yok → düşer.
+                    // PR-F (RFC-0005): FOLDER_STREAM_V1 da ALL_SUPPORTED'a
+                    // eklendi. Peer 0x07 advertise edince intersection
+                    // CHUNK_HMAC + RESUME_V1 + FOLDER_STREAM_V1 — üçü de
+                    // aktif.
                     assert!(active.has(features::CHUNK_HMAC_V1));
                     assert!(active.has(features::RESUME_V1));
-                    assert!(!active.has(features::FOLDER_STREAM_V1));
+                    assert!(active.has(features::FOLDER_STREAM_V1));
                 } else {
                     panic!("capabilities oneof beklendi");
                 }

--- a/crates/hekadrop-core/src/negotiation.rs
+++ b/crates/hekadrop-core/src/negotiation.rs
@@ -211,10 +211,10 @@ mod tests {
         assert_eq!(client_active.raw(), features::ALL_SUPPORTED);
         assert_eq!(server_active.raw(), features::ALL_SUPPORTED);
         assert!(client_active.has(features::CHUNK_HMAC_V1));
-        // PR-G: RESUME_V1 ALL_SUPPORTED'a geri eklendi. FOLDER_STREAM_V1
-        // (RFC-0005) hâlâ implementasyonsuz → advertise edilmez.
+        // PR-F (RFC-0005): hem RESUME_V1 hem FOLDER_STREAM_V1 ALL_SUPPORTED'a
+        // dahil; loopback'te üç feature da aktif olur.
         assert!(client_active.has(features::RESUME_V1));
-        assert!(!client_active.has(features::FOLDER_STREAM_V1));
+        assert!(client_active.has(features::FOLDER_STREAM_V1));
         assert!(!client_active.is_legacy());
         // Genuine HekaDrop path'inde leftover olmamalı.
         assert!(client_outcome.leftover_plain.is_none());

--- a/crates/hekadrop-core/src/ui_port.rs
+++ b/crates/hekadrop-core/src/ui_port.rs
@@ -32,6 +32,24 @@ pub struct FileSummary {
     pub size: i64,
 }
 
+/// RFC-0005 PR-F — accept dialog enrichment. Peer'dan gelen Introduction'da
+/// `application/x-hekadrop-folder` MIME marker bulunduğunda connection
+/// handler bu summary'i doldurur; UI dialog body'sinde "klasör — N dosya, X
+/// MB" satırı ile dosya yerine klasör bağlamı gösterir.
+///
+/// `root_name`: peer-controlled string. **Sender tarafında** zaten
+/// `folder::sanitize::sanitize_root_name` ile path-traversal/null-byte/depth
+/// kontrolünden geçer; receiver UI rendering öncesi ek kontrol gerekmez
+/// (CLAUDE.md I-5). `entry_count`: manifest entry sayısı (file + dir);
+/// peer-controlled fakat sender tarafında `MAX_FOLDER_ENTRIES` cap altında.
+/// `total_size`: bundle içi toplam byte (announced); receiver legacy
+/// `MAX_FILE_BYTES` guard'ı zaten Introduction parse aşamasında uyguluyor.
+pub struct FolderPromptSummary {
+    pub root_name: String,
+    pub entry_count: u32,
+    pub total_size: i64,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AcceptDecision {
     Reject,
@@ -53,6 +71,17 @@ pub enum UiNotification {
         body_args: Vec<String>,
         path: PathBuf,
     },
+    /// RFC-0005 PR-F — klasör alımı tamamlandı toast'u. `path` extract sonrası
+    /// final klasör konumu; UI bu yola "Klasörü Aç" aksiyonu bağlar
+    /// (`platform::open_path`: Finder/Explorer/xdg-open). `body_args` =
+    /// `[root_name, entry_count, human_size]`; çevrim app tarafında
+    /// `notification.folder_received.body` key'i ile yapılır.
+    FolderReceived {
+        title_key: &'static str,
+        body_key: &'static str,
+        body_args: Vec<String>,
+        path: PathBuf,
+    },
     /// Hardcoded body (legacy — i18n key'e taşınması bekleyen 2 site).
     /// TODO: i18n key haline getir, bu varyantı kaldır.
     ToastRaw { title: String, body: String },
@@ -67,11 +96,16 @@ pub trait UiPort: Send + Sync {
 
     /// User'dan kabul kararı al — modal blocking. `text_count` 0 ise dosya
     /// transferi, ≥1 ise text + dosya kombinasyonu (UI farklı render eder).
+    ///
+    /// `folder` `Some` iken peer bundle MIME marker ile bir klasör gönderiyor;
+    /// UI dialog body'sini "klasör — N dosya, X MB" satırı ile zenginleştirir.
+    /// `None` iken mevcut bireysel dosya/metin akışı (RFC-0005 öncesi davranış).
     async fn prompt_accept(
         &self,
         device: &str,
         pin: &str,
         files: &[FileSummary],
         text_count: usize,
+        folder: Option<&FolderPromptSummary>,
     ) -> AcceptDecision;
 }

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -118,11 +118,9 @@ README'nin vaat ettiklerini kodun gerçekten yaptığı noktaya çek. Monolitik 
 - Screenshots eklenir (placeholder'lar yerine gerçek macOS + Linux + Windows ekran görüntüleri; `docs/screenshots/`).
 
 **v0.8.0 — Protokol Sağlamlaştırma (2026-07-31)**
-- **Chunk-level HMAC**: Her 512 KiB chunk için ayrı HMAC-SHA256 tag; `secure.rs` refactor. Mid-stream corruption anında tespit, tüm dosyayı beklemek yerine chunk başında kesim.
-- **Transfer resume**: Protokol mesaj eklentisi `ResumeHint { session_id, file_id, offset, partial_hash }`. Receiver yarım dosyaları `~/.hekadrop/partial/` altında tutar (7 gün TTL, temizlik job'u). Sender `ResumeHint`'i görünce seeker'dan başlar.
-  - Protokol spec: `docs/protocol/resume.md` (RFC formatında, alan uzunlukları byte-level).
-  - Geri uyumluluk: sender capabilities negotiation (Quick Share `extra_capabilities` field).
-- **Folder streaming**: `FolderPayload` için tar-like stream format (dahili, disk'te tar oluşturmaz); her dosya yine ayrı SHA-256 + chunk-HMAC ile korunur.
+- ✅ **Chunk-level HMAC** (RFC-0003, `CHUNK_HMAC_V1`): her 512 KiB chunk için ayrı HMAC-SHA256 tag; `secure.rs` refactor. Mid-stream corruption anında tespit, tüm dosyayı beklemek yerine chunk başında kesim.
+- ✅ **Transfer resume** (RFC-0004, `RESUME_V1`): protokol mesaj eklentisi `ResumeHint { session_id, file_id, offset, partial_hash }`. Receiver yarım dosyaları `~/.hekadrop/partial/` altında tutar (7 gün TTL, cleanup sweep job'u). Sender `ResumeHint`'i görünce seeker'dan başlar. Geri uyumluluk: capability negotiation. Spec: `docs/protocol/resume.md`. PR-G ile re-enabled (PR #138).
+- ✅ **Folder streaming** (RFC-0005, `FOLDER_STREAM_V1`): `HEKABUND` v1 container — header + JSON manifest + per-file body + trailer SHA-256. Disk'te tar oluşturmaz; in-memory streaming. Her dosya yine ayrı SHA-256 + chunk-HMAC + RESUME_V1 ile korunur. Receiver atomic-reject pipeline (staging dir + Drop guard). UI: accept dialog folder summary + completion notification "Klasörü Aç" aksiyonu (Finder/Explorer/xdg-open). Spec: `docs/protocol/folder-payload.md`. PR-A → PR-F.
 - **Issue #17 fix**: Trusted device verification UKEY2 sonrasına taşınır. Pre-handshake rate-limit bypass kaldırılır. Test: `tests/trust_race.rs` — name/id spoof senaryosu.
 - **Protobuf şema versioning**: `proto/v2/` dizini; geriye uyumluluk için v1 shim.
 

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -135,7 +135,7 @@ Bu dizin otomatik güncellenmez. Yeni RFC eklendiğinde aşağıya ekleyin.
 | 0002 | URL payload decision | Accepted (implemented in bb2cedf + 393c74c) | v0.7.0 |
 | 0003 | Chunk-level HMAC-SHA256 | Draft | v0.8.0 |
 | 0004 | Transfer resume | Draft | v0.8.0 |
-| 0005 | Folder payload (HEKABUND) | Draft | v0.8.0 |
+| 0005 | Folder payload (HEKABUND) | Implemented (PR-A → PR-F merged) | v0.8.0 |
 
 ---
 

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -297,6 +297,25 @@ Tam denetim yukarıda (§5.3 E-row). Doğrulama listesi:
 
 Test coverage: `src/connection.rs:1455+` (`sanitize_*` test bloğu). Fuzz-coverage fuzz/ altında mevcut (ayrı inceleme).
 
+**RFC-0005 folder bundle (HEKABUND, v0.8.0):** klasör transfer'inde her manifest
+entry path'i ek bir sanitize katmanından geçer
+(`crates/hekadrop-core/src/folder/sanitize.rs`):
+
+* Per-segment `..`/`.` reject — split segments üzerinde tek tek kontrol (joined
+  path'te whole-string compare yetersiz olurdu, bkz. `a/../b` saldırısı).
+* Null byte (`\0`) ve control char reject — POSIX/NTFS path engine'lerinde
+  truncation/early termination saldırılarına karşı.
+* Forward + backward separator collapse: receiver `\` ve `/` ikisini de
+  segment ayırıcı sayar, mixed-separator escape engellenir.
+* Manifest depth ≤ 32, entry count ≤ 10 000 — DoS guard (cf. §7.4).
+* Root name sanitize (`sanitize_root_name`): aynı kurallar + tek-segment.
+
+Mitigation kontrol noktası **çift**: sender `build_manifest` aşamasında ve
+receiver `extract_bundle` aşamasında aynı sanitize çalışır (defense in depth).
+Receiver-side **atomic-reject pipeline**: herhangi bir entry sanitize fail
+ederse staging dizini Drop guard ile silinir, hiçbir extracted dosya
+kullanıcının `~/Downloads`'una geçmez.
+
 ### 7.2 Rate Limiting Bypass (Issue #17 / PR #81)
 
 Önceki davranış: gate öncesi `is_trusted_legacy(peer_name, peer_id)` muafiyet; peer-controlled string spoof → 10/60s bypass → 32-permit `Semaphore` doldur → meşru peer DoS. Fix (commit `52e4ff1`, PR #81):
@@ -312,6 +331,22 @@ Test coverage: `src/connection.rs:1455+` (`sanitize_*` test bloğu). Fuzz-covera
 `ingest_file` — `symlink_metadata` (`src/payload.rs:349-360`) link resolve etmeden tip kontrol; symlink tespit → iptal. Test: `src/payload.rs:690-713`.
 
 **Kalan risk:** hardlink saldırısı (same-inode alt-dizinde placeholder olarak yaratıldıktan sonra A5 hardlink ekler) — `create_new` hardlink'e karşı koruma vermez; ama Downloads dir tipik olarak user-only ve hardlink için kaynak inode'a yazma izni zaten gerekir.
+
+**RFC-0005 folder bundle (v0.8.0):** Bundle extract pipeline TOCTOU + symlink
+race'lere karşı **staging-dir + atomic-rename** stratejisi kullanır
+(`crates/hekadrop-core/src/folder/extract.rs`):
+
+* Tüm extract işlemi `~/Downloads/.hekadrop-staging-<session_hex>/` altına
+  yapılır (`OpenOptions::create_new`); session-deterministik isim race
+  pencerelerini sıfırlar.
+* Per-entry sanitize fail, manifest mismatch, partial write veya cancel →
+  `ExtractGuard` Drop'ta tüm staging dizini silinir (atomic-reject); hiçbir
+  yarım dosya kullanıcı görünür alana geçmez.
+* Başarılı extract sonrası staging → final path `std::fs::rename` ile atomik
+  taşınır; collision varsa `unique_downloads_path` ile suffix.
+* Bundle dosyası (`.hekadrop-temp-<session>.bundle`) extract bittikten sonra
+  silinir; crash artığı kaldıysa sonraki Introduction'da `RESUME_V1` aktifse
+  partial olarak korunur, değilse silinir.
 
 ### 7.4 Resource Exhaustion
 


### PR DESCRIPTION
## Özet

**RFC-0005 implementasyon TAMAMLANDI** — PR-A → PR-F zinciri merge sonrası HekaDrop end-to-end folder transfer (HEKABUND atomic-reject pipeline + chunk-HMAC + RESUME_V1 entegrasyon) production'da aktif.

Bu PR (PR-F) zincirin son halkası: capability bit'ini açar, accept dialog + completion notification UI'ını folder-aware yapar, dokümantasyonu günceller.

## Değişiklikler

### Capability gate
- `crates/hekadrop-core/src/capabilities.rs`: `ALL_SUPPORTED |= FOLDER_STREAM_V1` (`0x0000_0004`). Bu commit sonrası HekaDrop peer'a folder stream support reklam eder ve bundle MIME marker'lı Introduction'ı extract pipeline'a yönlendirir.
- Etkilenen test assertion'ları update edildi:
  - `capabilities.rs::all_supported_only_has_implemented_features` — `CHUNK_HMAC_V1 | RESUME_V1 | FOLDER_STREAM_V1` triple.
  - `frame.rs::capabilities_kat_all_features_dispatch` — peer `0x07` ile intersection FOLDER_STREAM_V1 dahil.
  - `negotiation.rs::loopback_negotiate_all_features_active` — loopback üç feature aktif.

### UI integration (`crates/hekadrop-app/`)
- **Accept dialog**: `UiPort::prompt_accept` `Option<&FolderPromptSummary>` parametresi alır. `connection.rs::build_folder_prompt_summary` Introduction'daki bundle marker'dan summary üretir; bundle MIME varsa dialog body'sinde dosya listesi yerine **`📁 {root_name} klasörü — {N} dosya, {size}`** satırı gösterilir.
- **Completion notification**: Yeni `UiNotification::FolderReceived` variant'ı. Bundle extract başarısı sonrası "Klasörü Aç" aksiyonlu toast — `crate::platform::open_path` Finder/Explorer/xdg-open ile açar (klasör için `open_path` zaten doğru davranır).
- **i18n**: Yeni TR + EN keys:
  - `prompt.folder_accept.body` — accept dialog body satırı
  - `notification.folder_received.title` — completion title
  - `notification.folder_received.body` — completion body

### Test (3 smoke)
`crates/hekadrop-app/tests/folder_ui_integration.rs`:
1. `folder_received_notification_payload` — `FolderReceived` variant'ının i18n key + body args + path triple kontratı.
2. `folder_accept_prompt_message_format` — `FolderPromptSummary` field değerleri sabit kontrat (rendering pipeline manuel smoke).
3. `all_supported_includes_folder_stream_v1` — capability gate defensive duplicate.

**Reveal action test'leri** (Finder/Explorer/xdg-open spawn) platform-spesifik olduğu için CI'da skip; manuel smoke ile doğrulanır.

### Dokümantasyon
- `README.md` — özellik listesinde "Folder transfer (HEKABUND, atomic-reject + per-file SHA-256)" maddesi.
- `CHANGELOG.md` — v0.8.0 protocol features bloğu (RFC-0003 + RFC-0004 + RFC-0005).
- `docs/security/threat-model.md` — §7.1 (path traversal) + §7.3 (TOCTOU/symlink) HEKABUND atomic-reject pipeline mitigation eklendi.
- `docs/ROADMAP.md` v0.8.0 satırında ✅ folder feature checkmark.
- `docs/rfcs/README.md` — RFC-0005 status `Implemented (PR-A → PR-F merged)`.

## CLAUDE.md compliance

- **I-1**: app-side UI değişikliği; core'da `crate::platform/paths/ui/i18n` referansı yok (grep clean).
- **I-2**: yeni `#[allow]` minimum, hepsi item-level + yorumlu (`// INVARIANT: ≤ 1000 < u32::MAX` cast guard).
- **I-3**: yeni `map_err.*|_e:` pattern yok.
- **I-5**: peer-controlled `root_name` UI render öncesi `sanitize_field` (control char strip); sender-side `folder::sanitize::sanitize_root_name` zaten path-traversal/null-byte engelliyor (defense in depth).

## Test plan

- [x] `cargo fmt --all -- --check` temiz.
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` temiz.
- [x] `cargo test --workspace` — 33 test binary, hepsi green; 3 yeni test geçer.
- [x] `typos` temiz.
- [ ] **Manuel smoke** (CI dışı, reviewer'a kalır): macOS dialog → klasör accept → toast → "Klasörü Aç" Finder'da klasörü açar.

## Sıradaki adım (opsiyonel)

**PR-G** (E2E + fuzz + interop testing, ~400 satır + 25 test) opsiyonel ama önerilir. Bu PR sonrası karar verilebilir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)