### PR TITLE
fix(rfc-0005): post-merge high yorumlar — EXDEV cleanup + i18n tf

### DIFF
--- a/crates/hekadrop-app/src/ui_adapter.rs
+++ b/crates/hekadrop-app/src/ui_adapter.rs
@@ -104,10 +104,15 @@ impl UiPort for UiAdapter {
                 // duplicate olur (klasör zaten parent'ı olur), o yüzden
                 // file path'iyle aynı helper'a delege; OS-bazlı reveal davranışı
                 // file için optimal ama klasör için de bozulmaz (parent dir açar).
-                let title = crate::i18n::t(title_key);
+                //
+                // PR #147 high yorumu (Gemini): title key
+                // `notification.folder_received.title` `{0}` placeholder içeriyor.
+                // `i18n::t` (format'sız) raw string sızdırıyordu. Hem title hem
+                // body için `tf` kullan, aynı args setini ver.
                 let args_refs: Vec<&str> = body_args.iter().map(String::as_str).collect();
+                let title = crate::i18n::tf(title_key, &args_refs);
                 let body = crate::i18n::tf(body_key, &args_refs);
-                crate::ui::notify_file_received(title, &body, path);
+                crate::ui::notify_file_received(&title, &body, path);
             }
             UiNotification::ToastRaw { title, body } => {
                 crate::ui::notify(&title, &body);

--- a/crates/hekadrop-core/src/folder/extract.rs
+++ b/crates/hekadrop-core/src/folder/extract.rs
@@ -332,8 +332,13 @@ fn extract_bundle_inner(
     match fs::rename(staging_dir, &final_path) {
         Ok(()) => {}
         Err(e) if is_cross_device(&e) => {
-            // Recursive copy + delete fallback.
-            recursive_copy_dir(staging_dir, &final_path)?;
+            // PR #145 high yorumu (Gemini): Recursive copy partial-failure'da
+            // (ör. disk dolu) `final_path` altında kısmi dosya bırakırsa
+            // atomic-reject vaadi bozulur. Hata olursa final_path'i de temizle.
+            if let Err(copy_err) = recursive_copy_dir(staging_dir, &final_path) {
+                let _ = fs::remove_dir_all(&final_path);
+                return Err(copy_err);
+            }
             // Source'u sil (best-effort; başarısız olursa Drop yine deneyecek).
             let _ = fs::remove_dir_all(staging_dir);
         }


### PR DESCRIPTION
RFC-0005 zinciri (PR #142-147) sonrası AI review'da 2 high finding:

| PR | Bug |
|---|---|
| #145 extract.rs:336 | EXDEV recursive_copy partial-failure → final_path kısmi dosya kalır (atomic-reject bozulur) |
| #147 ui_adapter.rs:107 | FolderReceived title `{0}` placeholder format'sız → UI'da raw string sızar |

**Fix:**
1. EXDEV copy fail → `fs::remove_dir_all(&final_path)` cleanup
2. `i18n::tf(title_key, &args_refs)` ile format

Diğer 15 medium yorum follow-up cleanup PR'ında.

🤖 Generated with [Claude Code](https://claude.com/claude-code)