### PR TITLE
chore(rfc-0005): tier-2 medium cleanup — doc + cast + mode/mtime apply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `ResumeHint`/`ResumeReject` proto frame'leri + sender offset seek; cleanup
   sweep TTL/budget LRU.
 - **feat(rfc-0003): chunk-HMAC** — `CHUNK_HMAC_V1` capability (`0x0000_0001`)
-  per-data-chunk HMAC-SHA256 integrity tag.
+  per-data-chunk HMAC-SHA256 integrity tag (PR #146); legacy peer'lar capability
+  inactive olduğunda hash-only modda calışmaya devam eder.
 
 ### Added — Workspace Refactor (RFC-0001 §5, Adım 1-8 tamamlandı)
 - **5 üyeli Cargo workspace**: `hekadrop-proto` (leaf, prost wire types) →

--- a/crates/hekadrop-core/src/folder/bundle.rs
+++ b/crates/hekadrop-core/src/folder/bundle.rs
@@ -293,7 +293,10 @@ impl BundleReader {
         let mut remaining = trailer_start;
         let mut buf = vec![0u8; 64 * 1024];
         while remaining > 0 {
-            let want = u64::min(remaining, buf.len() as u64);
+            // remaining: u64, buf.len(): usize. usize → u64 lossless (CI matrix
+            // 64-bit). `.min()` method form `u64::min(...)` standalone yerine
+            // idiomatik (Gemini PR #143 yorumu).
+            let want = remaining.min(buf.len() as u64);
             // INVARIANT: want ≤ buf.len() ≤ usize::MAX; downcast güvenli.
             let want_us = usize::try_from(want).unwrap_or(buf.len());
             let n = file.read(&mut buf[..want_us])?;

--- a/crates/hekadrop-core/src/folder/extract.rs
+++ b/crates/hekadrop-core/src/folder/extract.rs
@@ -53,6 +53,9 @@ use std::fs::{self, File, OpenOptions};
 use std::io::{self, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+
 /// Streaming read tamponu — per-file body okuma için. 64 KiB ile syscall
 /// sayısı düşük, RAM maliyeti ihmal edilebilir.
 const EXTRACT_READ_BUF: usize = 64 * 1024;
@@ -119,10 +122,6 @@ pub enum ExtractError {
         claimed: u64,
         remainder: u64,
     },
-
-    /// Manifest entry boyutu i64'a sığmıyor (peer-controlled u64).
-    #[error("file size i64'a sığmıyor: {0}")]
-    FileSizeTooLarge(u64),
 
     /// I/O hatası (mkdir, open, read, write, rename).
     #[error("I/O error: {0}")]
@@ -276,10 +275,17 @@ fn extract_bundle_inner(
         }
 
         match entry {
-            ManifestEntry::Directory { .. } => {
+            ManifestEntry::Directory { mode, .. } => {
                 fs::create_dir_all(&joined)?;
+                // RFC-0005 §3.2 — `mode` opsiyonel, best-effort uygula.
+                // Unix-only; Windows'ta mode anlamsız → silently skip.
+                // Hata yutulur (best-effort) — chmod fail'i dosyanın varlığını
+                // bozmaz, sadece izin metadata tam değil.
+                apply_mode_best_effort(&joined, *mode);
             }
-            ManifestEntry::File { size, sha256, .. } => {
+            ManifestEntry::File {
+                size, sha256, mode, ..
+            } => {
                 file_count = file_count.saturating_add(1);
 
                 // Parent dizinini oluştur (mkdir -p).
@@ -321,6 +327,11 @@ fn extract_bundle_inner(
                 // Best-effort fsync — durability güvencesi (kullanıcı tarafından
                 // beklenen "alındı" anlamı diskte var).
                 let _ = out.sync_all();
+
+                // RFC-0005 §3.2 — `mode` opsiyonel, best-effort uygula.
+                // sync_all sonrası — yazma kompleti garanti, sonra metadata.
+                drop(out);
+                apply_mode_best_effort(&joined, *mode);
             }
         }
     }
@@ -388,6 +399,26 @@ fn stream_copy_with_sha256(
     }
     let digest: [u8; 32] = hasher.finalize().into();
     Ok(hex_lower(&digest))
+}
+
+/// RFC-0005 §3.2 — best-effort POSIX mode apply. Unix-only; Windows'ta
+/// no-op (mode anlamsız NTFS ACL modeli ile). Hata yutulur — chmod fail'i
+/// içeriği bozmaz, sadece izin metadata tam değil. `mtime` benzer bir
+/// best-effort apply ileri PR'a (yeni `filetime` dep ekleme overhead'ini
+/// taşımak istemiyoruz; v0.8.1 follow-up).
+#[cfg(unix)]
+fn apply_mode_best_effort(path: &Path, mode: Option<u32>) {
+    if let Some(m) = mode {
+        // Tehlikeli bit'leri (setuid/setgid/sticky) maskele — peer-controlled
+        // mode'a güvenmiyoruz; sadece rwx bit'lerini al (lower 9 bit).
+        let safe = m & 0o777;
+        let _ = fs::set_permissions(path, std::fs::Permissions::from_mode(safe));
+    }
+}
+
+#[cfg(not(unix))]
+fn apply_mode_best_effort(_path: &Path, _mode: Option<u32>) {
+    // No-op: NTFS ACL modeli POSIX mode bit'lerini temsil etmez.
 }
 
 fn hex_lower(bytes: &[u8]) -> String {
@@ -882,6 +913,69 @@ mod tests {
         // Cleanup
         assert!(!bundle.exists());
         assert!(!downloads.path().join("rt").exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn extract_applies_posix_mode_best_effort() {
+        use std::os::unix::fs::PermissionsExt;
+        let downloads = tempdir().unwrap();
+        let bundle = downloads.path().join("test.bundle");
+        let mut m = BundleManifest {
+            version: MANIFEST_VERSION,
+            root_name: "perm".to_owned(),
+            total_entries: 0,
+            entries: vec![ManifestEntry::File {
+                path: "exec.sh".to_owned(),
+                size: 4,
+                sha256: sha_hex(b"abcd"),
+                mode: Some(0o755),
+                mtime: None,
+            }],
+            created_utc: Utc::now(),
+        };
+        m.total_entries = u32::try_from(m.entries.len()).unwrap();
+        let json = serde_json::to_vec(&m).unwrap();
+        write_bundle(&bundle, &json, &[b"abcd"]);
+        let prefix = m.attachment_hash_i64().unwrap();
+
+        let result = extract_bundle(&bundle, prefix, downloads.path(), "modebit").unwrap();
+        let target = result.final_path.join("exec.sh");
+        let perms = fs::metadata(&target).unwrap().permissions();
+        assert_eq!(perms.mode() & 0o777, 0o755);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn extract_masks_setuid_setgid_sticky_bits() {
+        use std::os::unix::fs::PermissionsExt;
+        // Hostile peer setuid bit ile mode gönderirse mask edilir — sadece
+        // alt 9 bit (rwx) uygulanır.
+        let downloads = tempdir().unwrap();
+        let bundle = downloads.path().join("test.bundle");
+        let mut m = BundleManifest {
+            version: MANIFEST_VERSION,
+            root_name: "perm".to_owned(),
+            total_entries: 0,
+            entries: vec![ManifestEntry::File {
+                path: "danger.sh".to_owned(),
+                size: 4,
+                sha256: sha_hex(b"abcd"),
+                mode: Some(0o4755), // setuid + 0o755
+                mtime: None,
+            }],
+            created_utc: Utc::now(),
+        };
+        m.total_entries = u32::try_from(m.entries.len()).unwrap();
+        let json = serde_json::to_vec(&m).unwrap();
+        write_bundle(&bundle, &json, &[b"abcd"]);
+        let prefix = m.attachment_hash_i64().unwrap();
+
+        let result = extract_bundle(&bundle, prefix, downloads.path(), "setuidtest").unwrap();
+        let target = result.final_path.join("danger.sh");
+        let perms = fs::metadata(&target).unwrap().permissions();
+        // setuid bit (0o4000) MASKELENMIŞ olmalı.
+        assert_eq!(perms.mode() & 0o7777, 0o755);
     }
 
     #[test]

--- a/crates/hekadrop-core/src/folder/manifest.rs
+++ b/crates/hekadrop-core/src/folder/manifest.rs
@@ -111,12 +111,13 @@ impl BundleManifest {
 
         let actual = self.entries.len();
         // INVARIANT (CLAUDE.md I-5): peer-controlled `total_entries` u32, ama
-        // `entries.len()` usize. u32 → u64 lossless via From; usize → u64
-        // 64-bit hedeflerde lossless (CI matrix tüm hedefler 64-bit), 32-bit
-        // hedefte de usize ≤ u32 ≤ u64 yine lossless.
-        let claimed_u64 = u64::from(self.total_entries);
-        let actual_u64 = u64::try_from(actual).unwrap_or(u64::MAX);
-        if claimed_u64 != actual_u64 {
+        // `entries.len()` usize. usize ↔ u32 karşılaştırma için claimed'i
+        // usize'a `try_from` ile yükselt — 16-bit hedefte (teorik) overflow
+        // halinde mismatch döner (defansif, panic değil). Önceki `u64`
+        // çevrimi + `unwrap_or(u64::MAX)` 64-bit hedefte ölü koldu (Gemini
+        // PR #143 yorumu).
+        let claimed_matches = usize::try_from(self.total_entries).is_ok_and(|c| c == actual);
+        if !claimed_matches {
             return Err(ManifestError::EntryCountMismatch {
                 claimed: self.total_entries,
                 actual,

--- a/crates/hekadrop-core/src/folder/sanitize.rs
+++ b/crates/hekadrop-core/src/folder/sanitize.rs
@@ -19,7 +19,10 @@
 /// - `\0` (NUL byte) → reject
 /// - `..` segment → reject (path traversal)
 /// - `.` segment → skip
-/// - boş segment (consecutive `/`, leading `/`) → skip
+/// - boş segment (consecutive `/`, leading `/`, trailing `/`) → skip
+///   (örn. `a//b` → `["a", "b"]`, `a/b/` → `["a", "b"]`); `.` segment ile
+///   aynı politikayla normalize, reject değil — POSIX path normalize
+///   davranışı.
 /// - depth (sanitize sonrası segment sayısı) > 32 → reject
 /// - sanitize sonrası boş → reject
 ///
@@ -184,6 +187,27 @@ mod tests {
     #[test]
     fn sanitize_consecutive_slashes_collapsed() {
         let segs = sanitize_received_relative_path("a//b").unwrap();
+        assert_eq!(segs, vec!["a", "b"]);
+    }
+
+    #[test]
+    fn sanitize_multiple_consecutive_slashes_collapsed() {
+        // `a///b` ve `a////b/c` — boş segment skip politikası tüm consecutive
+        // separator senaryolarında deterministik (Gemini PR #143 yorumu — empty
+        // segment policy dokümante).
+        assert_eq!(
+            sanitize_received_relative_path("a///b").unwrap(),
+            vec!["a", "b"]
+        );
+        assert_eq!(
+            sanitize_received_relative_path("a////b/c").unwrap(),
+            vec!["a", "b", "c"]
+        );
+    }
+
+    #[test]
+    fn sanitize_trailing_slash_skipped() {
+        let segs = sanitize_received_relative_path("a/b/").unwrap();
         assert_eq!(segs, vec!["a", "b"]);
     }
 

--- a/crates/hekadrop-proto/proto/hekadrop_extensions.proto
+++ b/crates/hekadrop-proto/proto/hekadrop_extensions.proto
@@ -34,7 +34,7 @@ message HekaDropFrame {
     ChunkIntegrity  chunk_tag     = 11;  // RFC 0003 §3.2 (ChunkIntegrity)
     ResumeHint      resume_hint   = 12;  // RFC 0004 (placeholder, v0.8.1)
     ResumeReject    resume_reject = 13;  // RFC 0004 (placeholder, v0.8.1)
-    FolderManifest  folder_mft    = 14;  // RFC 0005 §3.2 (slot ABI seal; mesaj boş — manifest in-bundle)
+    FolderManifest  folder_mft    = 14;  // RFC 0005 §3.2 (slot ABI seal; mesaj alan içermez — manifest in-bundle taşınır, bu slot yalnız oneof tag ABI rezervi)
   }
 }
 

--- a/docs/protocol/folder-payload.md
+++ b/docs/protocol/folder-payload.md
@@ -20,9 +20,9 @@ intent and this document is authoritative for bytes on the wire.
 
 ## 1. Why this exists (one paragraph)
 
-Quick Share's wire format addresses a single file per `FileMetadata`. Drag-
-dropping a folder today flattens it: N files arrive in `~/Downloads/` with
-their parent directory structure lost (RFC-0005 §1, §2). NearDrop has had
+Quick Share's wire format addresses a single file per `FileMetadata`. As a
+result, drag-dropping a folder today is flattened on the wire: N files arrive
+in `~/Downloads/` with their parent directory structure lost (RFC-0005 §1, §2). NearDrop has had
 the same gap open for two years (issue #211); LocalSend issues an HTTP
 request per file with no folder grouping primitive. To preserve directory
 structure, atomic delivery, and bundle-level integrity *without* modifying


### PR DESCRIPTION
## Özet

PR #142-147 post-merge AI review'inde toplanmış 15 medium-tier yorumun **tier-2 toplu cleanup**'ı. Bu PR fix grubunu (8 yorum) tek scope'ta uyguluyor; defer grubu (7 yorum) separat reply olarak bırakılıyor.

## Yorum → Aksiyon mapping

| # | PR | File:line | Aksiyon |
|---|---|---|---|
| 1 | #142 | `hekadrop_extensions.proto:37` | **Fix** — comment ifadesi açıklığı (slot ABI rezervi vs alan-içermez) |
| 2 | #142 | `folder-payload.md:23` | **Fix** — "flatten on the wire" netleştirme |
| 3 | #143 | `bundle.rs:296` | **Fix** — `u64::min(...)` → `.min(...)` method form |
| 4 | #143 | `manifest.rs:118` | **Fix** — usize↔u32 karşılaştırma; ölü `unwrap_or(u64::MAX)` kaldırıldı |
| 5 | #143 | `sanitize.rs:46` | **Fix** — empty-segment policy doc + 2 yeni test (multi consecutive `/`, trailing `/`) |
| 6 | #144 | `sender.rs:195` | **Defer + reply** — payload_id collision RFC §3.7 spec; entropy yeterli |
| 7 | #144 | `sender.rs:1634` | **Defer + reply** — aynı (yukarı) |
| 8 | #145 | `extract.rs:360` | **Defer + reply** — `spawn_blocking` async refactor; ayrı PR'a |
| 9 | #145 | `extract.rs:326` | **Fix** — RFC-0005 §3.2 `mode` best-effort apply (Unix-only) + setuid/setgid/sticky bit MASKE; 2 yeni test. `mtime` defer (yeni `filetime` dep eklemek istemiyoruz; v0.8.1) |
| 10 | #145 | `connection.rs:569` | **Defer + reply** — i18n key ayrımı UX kararı, v0.8.1 |
| 11 | #145 | `connection.rs:548` | **Defer + reply** — stat duplication branch ayrımı, v0.8.1 |
| 12 | #145 | `extract.rs:125` | **Fix** — `FileSizeTooLarge` dead variant kaldırıldı (size guard `FileSizeOverflow` ile) |
| 13 | #146 | `connection.rs:926` | **Defer + reply** — `spawn_blocking` async refactor |
| 14 | #146 | `connection.rs:1190` | **Defer + reply** — aynı |
| 15 | #147 | `CHANGELOG.md:26` | **Fix** — rfc-0003 satırına PR ref + legacy fallback notu |

## Mode apply güvenlik notu

Hostile peer setuid/setgid/sticky bit gönderebilir. Apply path'inde `mode & 0o777` ile MASKE — sadece alt 9 bit (rwx) uygulanır. Test (`extract_masks_setuid_setgid_sticky_bits`) `0o4755` input'unun `0o755` olarak set edildiğini verify eder.

## Test plan

- [x] `cargo fmt --all -- --check` — temiz
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — temiz
- [x] `cargo test --workspace` — 328 → 332 test (4 yeni: 2 sanitize + 2 mode)
- [x] `cargo machete --with-metadata` — temiz
- [x] `typos` — temiz
- [x] CLAUDE.md I-1/I-2/I-3 grep — sadece doc-comment ref'leri
- [ ] Cross-platform CI: Linux + Windows clippy/test (mode apply Windows'ta no-op)

## Defer'lı yorumlara cevap

Defer grubuna her yorum altına `gh api` ile spec referanslı reply yorumu bırakıldı; bu PR ile follow-up tracking ayrı issue'lara bağlanacak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)