### PR TITLE
chore(lint): #[allow(dead_code)] cleanup — 10 stale silindi, 3 #[expect] migrate

### DIFF
--- a/crates/hekadrop-app/src/ui.rs
+++ b/crates/hekadrop-app/src/ui.rs
@@ -651,7 +651,10 @@ pub(crate) fn show_info(title: &str, body: &str) {
 }
 
 /// `choose file` dialog → seçilen dosyanın tam yolu veya None (tek dosya).
-#[allow(dead_code)]
+#[expect(
+    dead_code,
+    reason = "single-file API helper; UI'da çoklu seçim default, single-pick gelecek toggle için reservoir"
+)]
 pub(crate) async fn choose_file() -> Option<std::path::PathBuf> {
     choose_files().await.and_then(|mut v| v.pop())
 }
@@ -1085,7 +1088,10 @@ fn choose_device_blocking(labels: &[String]) -> Option<String> {
 
 /// Dosya keşif sırasında basit bir ilerleme/bildirim dialog'u olmadığı için
 /// notify kullanıyoruz.
-#[allow(dead_code)]
+#[expect(
+    dead_code,
+    reason = "send-side progress notification; sender flow şu an UI port üzerinden, helper future use için tutuldu"
+)]
 pub(crate) fn send_progress_notify(device: &str, file: &str) {
     notify("HekaDrop", &format!("Gönderiliyor: {file} → {device}"));
 }

--- a/crates/hekadrop-core/src/error.rs
+++ b/crates/hekadrop-core/src/error.rs
@@ -20,7 +20,6 @@
 use thiserror::Error;
 
 #[derive(Debug, Error)]
-#[allow(dead_code)]
 pub enum HekaError {
     // ---- Transport / çerçeve ----
     /// I/O hatası (TCP reset, EOF, slow-loris timeout'u jeneriğe düşerse).

--- a/crates/hekadrop-core/src/identity.rs
+++ b/crates/hekadrop-core/src/identity.rs
@@ -137,7 +137,6 @@ impl DeviceIdentity {
 
     /// İleride `signed_data` doğrulaması için ECDSA imza anahtarı türetir.
     /// v0.6'da kullanılmıyor; imza akışı v0.7 pairing protokolüyle gelecek.
-    #[allow(dead_code)]
     #[must_use]
     pub fn signing_key(&self) -> [u8; 32] {
         let h = crate::crypto::hkdf_sha256(

--- a/crates/hekadrop-core/src/payload.rs
+++ b/crates/hekadrop-core/src/payload.rs
@@ -78,12 +78,10 @@ pub const ASSEMBLER_GC_TIMEOUT: Duration = Duration::from_secs(120);
 #[derive(Debug)]
 pub enum CompletedPayload {
     Bytes {
-        #[allow(dead_code)]
         id: i64,
         data: Vec<u8>,
     },
     File {
-        #[allow(dead_code)]
         id: i64,
         path: PathBuf,
         total_size: i64,
@@ -429,7 +427,6 @@ impl PayloadAssembler {
     /// Hiç chunk gelmemiş pending destination kayıtları için de diskteki
     /// 0-bayt placeholder'ı siler — aksi halde iptal sonrası indirme
     /// klasöründe sahibsiz sıfır bayt dosyalar birikir (review-18 MED).
-    #[allow(dead_code)]
     pub fn cancel(&mut self, payload_id: i64) {
         self.bytes_buffers.remove(&payload_id);
         if let Some(sink) = self.file_sinks.remove(&payload_id) {

--- a/crates/hekadrop-core/src/sender.rs
+++ b/crates/hekadrop-core/src/sender.rs
@@ -106,7 +106,10 @@ struct PlannedFolder {
     /// Sender disk root path (folder kökü). Şu anda sadece debug log'da
     /// kullanılıyor; ileride retry/resume yolunda walk-yenileme için
     /// gerekecek (PR-D sonrası).
-    #[allow(dead_code)] // PR-C scope: log + future use; field zaten plan-level.
+    #[expect(
+        dead_code,
+        reason = "PR-C scope: log + future use; field plan-level (PR-D sonrası kullanılacak)"
+    )]
     root_path: std::path::PathBuf,
     /// Manifest validate edilmiş + JSON-serialize için hazır.
     manifest: crate::folder::BundleManifest,

--- a/crates/hekadrop-core/src/settings.rs
+++ b/crates/hekadrop-core/src/settings.rs
@@ -348,7 +348,6 @@ impl Settings {
     /// Davranış: `is_trusted_legacy` ile aynı — legacy kayıtları hâlâ
     /// çalıştırır, TTL kontrolü yapmaz. Yeni kodun `is_trusted_by_hash`
     /// kullanması beklenir.
-    #[allow(dead_code)]
     #[must_use]
     pub fn is_trusted(&self, device_name: &str, id: &str) -> bool {
         self.is_trusted_legacy(device_name, id)
@@ -508,7 +507,6 @@ impl Settings {
     ///
     /// Gelecekte UI "bu ad/id çifti güvenlikten çıksın" seçeneği sunduğunda
     /// kullanılacak — şu an yalnız testlerden çağrılıyor.
-    #[allow(dead_code)]
     pub fn remove_trusted_by_id(&mut self, device_name: &str, id: &str) {
         self.trusted_devices
             .retain(|d| !(d.name == device_name && d.id == id));
@@ -519,7 +517,6 @@ impl Settings {
     /// v0.6'da zengin UI (TTL rozeti) kullanılmaya başlandığından ana UI
     /// yolu `push_trusted_to_ui` içindeki yapılandırılmış JSON'u tercih
     /// eder; bu fonksiyon legacy IPC çağrıları ve testler için korunur.
-    #[allow(dead_code)]
     #[must_use]
     pub fn trusted_display_list(&self) -> Vec<String> {
         self.trusted_devices.iter().map(|d| d.display()).collect()

--- a/crates/hekadrop-core/src/state.rs
+++ b/crates/hekadrop-core/src/state.rs
@@ -52,7 +52,6 @@ pub enum ProgressState {
 #[derive(Clone, Debug)]
 pub struct HistoryItem {
     pub file_name: String,
-    #[allow(dead_code)]
     pub path: PathBuf,
     pub size: i64,
     pub device: String,

--- a/crates/hekadrop-core/src/ukey2.rs
+++ b/crates/hekadrop-core/src/ukey2.rs
@@ -32,7 +32,6 @@ pub struct DerivedKeys {
     pub encrypt_key: [u8; 32],
     /// Receiver tarafı: HMAC imzalama (sunucudan giden)
     pub send_hmac_key: [u8; 32],
-    #[allow(dead_code)]
     pub auth_key: [u8; 32],
     pub pin_code: String,
     /// UKEY2 derive `next_secret` — `SecureMessage` D2D anahtarlarının türetildiği


### PR DESCRIPTION
Kullanıcı tarafından sorgulama: "rust gevşetmeleri yapılan allow, deadcode gibi başka neler var" sonrası 13 site analiz edildi.

## Özet

| Aksiyon | Sayı | Detay |
|---|---|---|
| **Stale allow silindi** | 10 | `pub` items hekadrop-core içinde → `pub` external API olduğu için dead_code lint zaten trigger olmuyor. RFC-0001 refactor sonrasında stale kaldı. |
| **#[expect] migrate** | 3 | Private veya pub(crate), gelecek-kullanım iddialı. `#[expect]` daha katı — item kullanılmaya başlanırsa lint hatırlatır. |

## Stale silinenler (10)

- `core/error.rs:23` (HekaError pub enum)
- `core/identity.rs:140` (pub fn)
- `core/state.rs:55` (HistoryItem.path pub field)
- `core/settings.rs:351, 511, 522` (pub fn x3)
- `core/payload.rs:81, 86` (CompletedPayload variants pub field x2)
- `core/payload.rs:432` (cancel pub fn)
- `core/ukey2.rs:35` (DerivedKeys.auth_key pub field)

## Migrate edilen #[expect] (3)

- `core/sender.rs:109` (PlannedFolder.root_path)
- `app/ui.rs:654` (choose_file pub(crate))
- `app/ui.rs:1088` (send_progress_notify pub(crate))

## Why

CLAUDE.md I-2 disiplini — minimum gerekçeli allow. Stale allow'lar kod hijyenini bozar; `#[expect]` gelecek-koruyucu (Rust 1.81+ pattern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)