### PR TITLE
chore(lint): app/lib.rs crate-level #![allow(dead_code)] kaldır

### DIFF
--- a/crates/hekadrop-app/src/lib.rs
+++ b/crates/hekadrop-app/src/lib.rs
@@ -7,7 +7,6 @@
 //! dar bir yüzey (crypto + `file_size_guard` + UKEY2 downgrade validator
 //! + H#4 privacy controls için settings) açmaktır.
 
-#![allow(dead_code)]
 // Test profili (lib unit tests + inline `#[cfg(test)] mod tests`): production
 // için ship-blocker olan lint'ler test idiomatik kullanımı engellemesin.
 // Integration test'ler (`tests/*.rs`) ayrı crate olduğu için bu attribute
@@ -68,8 +67,9 @@ pub use hekadrop_proto::{location, securegcm, securemessage, sharing};
 // alıyordu — Adım 3 öncesi yüzeyi korumak için aynı seviyede yeniden export.
 pub use hekadrop_core::{process_client_init, validate_server_init, DerivedKeys};
 
-// `platform` modülü uygulamaya özgüdür (Win32 / macOS Cocoa / Linux GTK
-// shim'leri); core'a sızdırılmaz, tests/benches da bu modüle dokunmaz.
-// `pub(crate)` ile lib surface dışına çıkarıldı — PR #107 review (Copilot)
-// `pub mod` + iç items `pub(crate)` tutarsızlığını yakaladı.
-pub(crate) mod platform;
+// NOT: `mod platform;` lib build'de **deklare edilmez** — binary `main.rs`
+// kendi `mod platform;` deklarasyonunu yapar (Cargo lib+bin hibrit:
+// modül ağaçları bağımsız). Lib build'de redundant; aksi halde 10
+// `pub(crate) fn` lib build'inde "dead_code" warning üretirdi. Bu sayede
+// crate-level `#![allow(dead_code)]` ihtiyacı ortadan kalkar (PR #152
+// sweep + bu PR ile birlikte).


### PR DESCRIPTION
## Summary

CLAUDE.md I-2 disiplini gereği crate-level `#![allow]` kabul edilmez (proto generated kod tek istisna). `app/src/lib.rs`'in `#![allow(dead_code)]`'u stale: redundant `pub(crate) mod platform;` deklarasyonundan dolayı 10 `pub(crate) fn`'in lib build'de "dead" görünmesini bastırıyordu.

## Çözüm

`pub(crate) mod platform;` lib.rs'den silindi. Binary `main.rs` kendi `mod platform;` deklarasyonunu yapıyor (Cargo lib+bin hibrit: modül ağaçları bağımsız). Lib build'de platform modülüne ihtiyaç yok (lib surface bench/test için, platform shim'i sadece binary detayı).

## Sonuç

- `#![allow(dead_code)]` crate-level kaldırıldı ✓
- `mod platform` deklarasyonu lib.rs'den silindi
- 10 dead_code warning ortadan kalktı
- Binary main.rs etkilenmedi (kendi mod deklarasyonu var)

## Crate-level allow durumu (sonrası)

Sadece **1 prod crate-level allow kaldı:**
- `hekadrop-cli/src/main.rs:15` `#![allow(unused_imports)]` — stub binary, future implementation için import'lar hazır.

Ve **5 module-level allow** (proto generated kod, prost output) — bunlar CLAUDE.md I-2 explicit istisnası.

## Test plan

- [x] `cargo build --workspace` — temiz, 0 warning
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — temiz
- [x] `cargo test --workspace` — yeşil

🤖 Generated with [Claude Code](https://claude.com/claude-code)