### PR TITLE
chore(lint): cli/main.rs crate-level #![allow(unused_imports)] kaldır

### DIFF
--- a/crates/hekadrop-cli/src/main.rs
+++ b/crates/hekadrop-cli/src/main.rs
@@ -11,8 +11,10 @@
 
 // hekadrop-core + hekadrop-net path-dep olarak çekilse de v0.7 stub'ında
 // hiçbir sembol kullanılmıyor — `cargo machete` false-pozitif önlenmiş
-// (ignore listesi `Cargo.toml`'da). v0.10.0'da kaldırılacak.
-#![allow(unused_imports)]
+// (ignore listesi `Cargo.toml`'da). v0.10.0'da `use hekadrop_core::*` gibi
+// import'lar geldiğinde `unused_imports` lint'i kendini hatırlatır.
+// (PR #152/#153 sweep'inden sonra `#![allow(unused_imports)]` kaldırıldı —
+// stub'ta hiç `use` yok, allow stale-iydi.)
 
 // CLI binary stdout output legitimate use case; workspace-wide
 // `clippy::print_stdout = "warn"` (PR #87 Tier 1) UI/library kodu için


### PR DESCRIPTION
## Summary

cli/main.rs stub binary'sinde hiç `use` deklarasyonu yok → `unused_imports` lint zaten tetiklenmez. `#![allow(unused_imports)]` crate-level allow stale.

## Crate-level allow durumu (sonrası)

**Prod kod tarafında crate-level `#![allow(...)]` artık 0** ✓

Geriye sadece **5 module-level allow** (proto generated kod) kalıyor — bunlar CLAUDE.md I-2 explicit istisnası (`prost` üretilmiş kod, manuel düzenlenemez).

Bu PR ile birlikte CLAUDE.md I-2 disiplini tam uygulanmış oldu.

## Test plan

- [x] `cargo build --workspace` — temiz
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — temiz

🤖 Generated with [Claude Code](https://claude.com/claude-code)