### PR TITLE
chore(lint): expect_used + too_many_arguments — #[expect] migrate (29 site)

### DIFF
--- a/crates/hekadrop-app/src/main.rs
+++ b/crates/hekadrop-app/src/main.rs
@@ -1422,7 +1422,10 @@ fn js_safe_json(v: &serde_json::Value) -> String {
     // fail etmez (yalnız map key'i string olmayan veya recursive yapı
     // panic'leyebilir, ama `Value`'nun map key tipi `String`'tir). Bu
     // expect runtime hatası değil, invariant'ı belgelemek için.
-    #[allow(clippy::expect_used)]
+    #[expect(
+        clippy::expect_used,
+        reason = "INVARIANT: serde_json::Value serialize infallible (map key tipi String, recursion yok)"
+    )]
     let s = serde_json::to_string(v).expect("serde_json::Value serialize infallible");
     s.replace("</", "<\\/")
         .replace('\u{2028}', "\\u2028")

--- a/crates/hekadrop-app/src/state.rs
+++ b/crates/hekadrop-app/src/state.rs
@@ -49,7 +49,10 @@ pub(crate) fn get() -> Arc<AppState> {
     // INVARIANT: `init()` her zaman `main`'in ilk işlerinden — `get()`
     // öncesinde çağrılması garanti. Aksi durum programlama hatası, panik
     // yerine sessiz default state üretmek bug'ı maskeler.
-    #[allow(clippy::expect_used)]
+    #[expect(
+        clippy::expect_used,
+        reason = "INVARIANT: state::init() main'in ilk işi; get() öncesinde çağrılmamış olması = programlama hatası"
+    )]
     STATE
         .get()
         .expect("state::init() çağrılmadan state::get() çağrıldı")

--- a/crates/hekadrop-core/src/chunk_hmac.rs
+++ b/crates/hekadrop-core/src/chunk_hmac.rs
@@ -118,7 +118,10 @@ pub fn compute_tag(
     // gereği TÜM key uzunluklarını kabul eder (kısa key zero-pad'lenir, uzun
     // key SHA-256'dan geçer). Burada key sabit 32 byte; `Result` yalnız trait
     // signature uniformluğu için var. `crypto::hmac_sha256` ile aynı invariant.
-    #[allow(clippy::expect_used)]
+    #[expect(
+        clippy::expect_used,
+        reason = "INVARIANT: HMAC-SHA256 (RFC 2104) tüm key uzunluklarını kabul eder; Result yalnız trait uniformluğu"
+    )]
     let mut mac = HmacSha256::new_from_slice(chunk_hmac_key)
         .expect("HMAC-SHA256 her key uzunluğunu kabul eder");
     mac.update(&prefix);

--- a/crates/hekadrop-core/src/connection.rs
+++ b/crates/hekadrop-core/src/connection.rs
@@ -498,7 +498,10 @@ pub async fn handle(
 /// içinde Drop guard); UI'a `ToastRaw` ile reject mesajı düşer ve hiçbir
 /// `History` kaydı eklenmez. Başarı → `History` extract edilen klasör
 /// path'i ile push edilir.
-#[allow(clippy::too_many_arguments)] // INVARIANT: 9 arg — UI/state/assembler dispatch tek nokta
+#[expect(
+    clippy::too_many_arguments,
+    reason = "9 arg — UI/state/assembler dispatch tek nokta; struct refactor v0.9'a defer"
+)]
 async fn finalize_received_payload(
     peer: &SocketAddr,
     id: i64,
@@ -561,8 +564,10 @@ async fn finalize_received_payload(
                     // INVARIANT (CLAUDE.md I-5): payload finalize'da
                     // total_size ≥ 0 garanti (payload.rs ingest_file negatif
                     // reject); try_from non-negative garantisini lint'e taşır.
-                    #[allow(clippy::expect_used)]
-                    // INVARIANT: payload ingest_file rejects total_size < 0
+                    #[expect(
+                        clippy::expect_used,
+                        reason = "INVARIANT: payload ingest_file rejects total_size < 0 → u64::try_from infallible"
+                    )]
                     let total_u = u64::try_from(total_size).expect(
                         "INVARIANT: total_size >= 0 (payload ingest_file rejects negative)",
                     );
@@ -696,7 +701,10 @@ fn finalize_received_file(
         let snap_opt = {
             let mut s = state.stats.write();
             // payload.rs ingest_file aşamasında `total_size < 0` reddediliyor — burada >= 0 garanti.
-            #[allow(clippy::expect_used)] // INVARIANT: payload ingest_file rejects total_size < 0
+            #[expect(
+                clippy::expect_used,
+                reason = "INVARIANT: payload ingest_file rejects total_size < 0 → u64::try_from infallible"
+            )]
             let total_size_u = u64::try_from(total_size)
                 .expect("INVARIANT: total_size >= 0 (payload ingest_file rejects negative)");
             s.record_received(remote_name, total_size_u);
@@ -808,7 +816,10 @@ enum FlowOutcome {
 // RFC-0001 §5 Adım 5b: handler call-graph'ında 13 arg vardı; 14. olarak `ui`
 // eklendi. Adım 5c'de 15. olarak `state` eklendi (singleton lookup yerine
 // inject); helper'lar bir sonraki refactor'da struct olarak gruplanacak.
-#[allow(clippy::too_many_arguments)]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "RFC-0001 §5 — handler call-graph (15 arg: socket/ctx/assembler/ui/state/...); HandlerCtx struct refactor v0.9'a defer"
+)]
 async fn handle_sharing_frame(
     peer: &SocketAddr,
     socket: &mut TcpStream,
@@ -1563,7 +1574,10 @@ fn resolve_resume_path(
     // SECURITY: untrusted-disk size — `meta.received_bytes` ile eşleşmesi
     // resume offset semantiğinin disk gerçeğine oturduğunu garanti eder.
     // `try_from` validate() received_bytes >= 0 garantisini lint'e taşır.
-    #[allow(clippy::expect_used)] // INVARIANT: PartialMeta::validate() rejects received_bytes < 0
+    #[expect(
+        clippy::expect_used,
+        reason = "INVARIANT: PartialMeta::validate() rejects received_bytes < 0 → u64::try_from infallible"
+    )]
     let expected = u64::try_from(meta.received_bytes)
         .expect("INVARIANT: PartialMeta::validate() guards received_bytes >= 0");
     if md.len() != expected {
@@ -1592,7 +1606,10 @@ fn resolve_resume_path(
 ///
 /// Bu PR (PR-C) kapsamında sadece **emit** tarafı; sender bu hint'i consume
 /// edecek (PR-D), receiver `.part` üstüne devam edecek (PR-E).
-#[allow(clippy::too_many_arguments)]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "resume hint emit pipeline — socket/ctx/assembler/dir/session/payload/file context; struct refactor v0.9'a defer"
+)]
 async fn handle_resume_for_file(
     socket: &mut TcpStream,
     ctx: &mut SecureCtx,
@@ -1738,8 +1755,10 @@ async fn handle_resume_for_file(
         // SECURITY: receiver tarafı kendi diskindeki `.part`'ı doğruluyor —
         // `meta.received_bytes` validate'lı. `try_from` validate() guarantee'sini
         // lint'e taşır (panic infallible).
-        #[allow(clippy::expect_used)]
-        // INVARIANT: PartialMeta::validate() rejects received_bytes < 0
+        #[expect(
+            clippy::expect_used,
+            reason = "INVARIANT: PartialMeta::validate() rejects received_bytes < 0 → u64::try_from infallible"
+        )]
         let off_u = u64::try_from(meta.received_bytes)
             .expect("INVARIANT: PartialMeta::validate() guards received_bytes >= 0");
         let dest_path = std::path::Path::new(&meta.dest_path);
@@ -1794,7 +1813,10 @@ async fn handle_resume_for_file(
 /// - Bilinmeyen `Payload` varyantı → log + skip (forward-compat).
 ///
 /// Hata döner: socket write, ctx.encrypt, prost decode failure'ları.
-#[allow(clippy::too_many_arguments)]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "hekadrop frame dispatcher — socket/ctx/capabilities/peer/state context; struct refactor v0.9'a defer"
+)]
 async fn handle_hekadrop_frame(
     bytes: &[u8],
     peer: &SocketAddr,

--- a/crates/hekadrop-core/src/crypto.rs
+++ b/crates/hekadrop-core/src/crypto.rs
@@ -20,7 +20,10 @@ pub fn hkdf_sha256(ikm: &[u8], salt: &[u8], info: &[u8], len: usize) -> Vec<u8> 
     // INVARIANT: HKDF-SHA256 yalnızca `len > 255 * HashLen (= 8160 bayt)` için
     // başarısız olur; tüm caller'lar (UKEY2 key derivation, Quick Share session
     // keys) ≤32 bayt ister. Çağrı kontrat ihlali = programlama hatası.
-    #[allow(clippy::expect_used)]
+    #[expect(
+        clippy::expect_used,
+        reason = "INVARIANT: HKDF len ≤ 8160 bayt; tüm caller'lar ≤32 bayt ister, fail = programlama hatası"
+    )]
     hk.expand(info, &mut out)
         .expect("HKDF len > 255*32 invariant ihlali");
     out
@@ -83,7 +86,10 @@ pub fn hmac_sha256(key: &[u8], data: &[u8]) -> [u8; 32] {
     // (kısa key zero-pad'lenir, uzun key SHA-256'dan geçer). `new_from_slice`
     // dökümante edilmiş olarak hiçbir koşulda fail etmez — yalnız trait
     // signature uniformluğu için Result döner.
-    #[allow(clippy::expect_used)]
+    #[expect(
+        clippy::expect_used,
+        reason = "INVARIANT: HMAC-SHA256 (RFC 2104) tüm key uzunluklarını kabul eder; Result yalnız trait uniformluğu"
+    )]
     let mut mac =
         HmacSha256::new_from_slice(key).expect("HMAC-SHA256 her key uzunluğunu kabul eder");
     mac.update(data);

--- a/crates/hekadrop-core/src/folder/bundle.rs
+++ b/crates/hekadrop-core/src/folder/bundle.rs
@@ -84,20 +84,29 @@ impl BundleHeader {
 
         // INVARIANT: slice uzunluğu ≥ 16 yukarıda doğrulandı; aşağıdaki
         // try_into'lar sabit-array slice → array, infallible.
-        #[allow(clippy::expect_used)] // INVARIANT: 8-byte slice → [u8; 8] sonsuz.
+        #[expect(
+            clippy::expect_used,
+            reason = "INVARIANT: bytes.len() >= 16 yukarıda doğrulandı; 8-byte slice → [u8; 8] infallible"
+        )]
         let magic: [u8; 8] = bytes[0..8].try_into().expect("8-byte slice");
         if magic != HEKABUND_MAGIC {
             return Err(BundleError::MagicMismatch(magic));
         }
 
-        #[allow(clippy::expect_used)] // INVARIANT: 4-byte slice → [u8; 4] sonsuz.
+        #[expect(
+            clippy::expect_used,
+            reason = "INVARIANT: bytes.len() >= 16 yukarıda doğrulandı; 4-byte slice → [u8; 4] infallible"
+        )]
         let version_bytes: [u8; 4] = bytes[8..12].try_into().expect("4-byte slice");
         let version = u32::from_be_bytes(version_bytes);
         if version != HEKABUND_VERSION {
             return Err(BundleError::UnsupportedVersion(version));
         }
 
-        #[allow(clippy::expect_used)] // INVARIANT: 4-byte slice → [u8; 4] sonsuz.
+        #[expect(
+            clippy::expect_used,
+            reason = "INVARIANT: bytes.len() >= 16 yukarıda doğrulandı; 4-byte slice → [u8; 4] infallible"
+        )]
         let manifest_len_bytes: [u8; 4] = bytes[12..16].try_into().expect("4-byte slice");
         let manifest_len = u32::from_be_bytes(manifest_len_bytes);
         if manifest_len == 0 {

--- a/crates/hekadrop-core/src/folder/manifest.rs
+++ b/crates/hekadrop-core/src/folder/manifest.rs
@@ -183,7 +183,10 @@ impl BundleManifest {
         let digest = self.manifest_sha256()?;
         // INVARIANT: digest sabit 32 byte; [0..8] slice her zaman 8 byte.
         // try_into() infallible — array → array.
-        #[allow(clippy::expect_used)] // INVARIANT: 32-byte digest, [0..8] her zaman 8 byte
+        #[expect(
+            clippy::expect_used,
+            reason = "INVARIANT: 32-byte sha256 digest; [0..8] slice her zaman 8 byte → try_into infallible"
+        )]
         let prefix: [u8; 8] = digest[0..8].try_into().expect("sha256 prefix is 8 bytes");
         Ok(i64::from_be_bytes(prefix))
     }

--- a/crates/hekadrop-core/src/payload.rs
+++ b/crates/hekadrop-core/src/payload.rs
@@ -333,7 +333,10 @@ impl PayloadAssembler {
     // INVARIANT: 8 argüman — production caller tek nokta (handle_resume_for_file).
     // Builder pattern overkill; receiver-side resume injection field'ları (4 yeni)
     // organik olarak biriktirildi, struct-arg refactor scope dışı.
-    #[allow(clippy::too_many_arguments)] // INVARIANT: tek production caller, struct-arg refactor scope dışı
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "INVARIANT: tek production caller (handle_resume_for_file); resume injection field'ları organik biriktirildi, struct refactor v0.9'a defer"
+    )]
     pub fn enable_resume_with_offset(
         &mut self,
         payload_id: i64,

--- a/crates/hekadrop-core/src/sender.rs
+++ b/crates/hekadrop-core/src/sender.rs
@@ -647,7 +647,10 @@ pub async fn send(req: SendRequest, state: Arc<AppState>) -> Result<()> {
                                 let mut s = state.stats.write();
                                 for plan in &plans {
                                     // INVARIANT: .max(0) ile alt sınır 0 → try_from infallible.
-                                    #[allow(clippy::expect_used)] // INVARIANT: max(0) ≥ 0
+                                    #[expect(
+                                        clippy::expect_used,
+                                        reason = "INVARIANT: plan.size.max(0) ≥ 0 → u64::try_from infallible"
+                                    )]
                                     let size_u = u64::try_from(plan.size.max(0))
                                         .expect("INVARIANT: max(0) sonrası i64 ≥ 0");
                                     s.record_sent(&peer_label, size_u);
@@ -960,7 +963,10 @@ pub async fn send_text(
                             let snap_opt = {
                                 let mut s = state.stats.write();
                                 // INVARIANT: .max(0) ile alt sınır 0 → try_from infallible.
-                                #[allow(clippy::expect_used)] // INVARIANT: max(0) ≥ 0
+                                #[expect(
+                                    clippy::expect_used,
+                                    reason = "INVARIANT: total_bytes.max(0) ≥ 0 → u64::try_from infallible"
+                                )]
                                 let total_bytes_u = u64::try_from(total_bytes.max(0))
                                     .expect("INVARIANT: max(0) sonrası i64 ≥ 0");
                                 s.record_sent(&peer_label, total_bytes_u);
@@ -1012,7 +1018,10 @@ pub async fn send_text(
 /// Metni Bytes payload olarak gönderir. Küçük metin tek chunk + son empty
 /// chunk ile biter; büyük metin `CHUNK_SIZE` sınırıyla bölünür (Android
 /// tarafı her iki durumu da assembler reassembly ile ele alır).
-#[allow(clippy::too_many_arguments)]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "send pipeline helper — socket/ctx/state/cancel/payload context; struct refactor v0.9'a defer"
+)]
 async fn send_text_bytes(
     socket: &mut TcpStream,
     ctx: &mut SecureCtx,
@@ -1117,7 +1126,10 @@ fn build_introduction_text(
     }
 }
 
-#[allow(clippy::too_many_arguments)]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "send pipeline helper — file/ctx/state/resume context; struct refactor v0.9'a defer"
+)]
 async fn send_file_chunks(
     socket: &mut TcpStream,
     ctx: &mut SecureCtx,
@@ -1141,7 +1153,10 @@ async fn send_file_chunks(
     if start_offset > 0 {
         // INVARIANT: start_offset > 0 outer if + caller `wait_for_resume_hint_or_zero`
         // negatif değerleri fallback `0` ile değiştiriyor → try_from infallible.
-        #[allow(clippy::expect_used)] // INVARIANT: start_offset > 0 (outer if)
+        #[expect(
+            clippy::expect_used,
+            reason = "INVARIANT: start_offset > 0 (outer if) + caller-checked non-negative → u64::try_from infallible"
+        )]
         let pos = u64::try_from(start_offset)
             .expect("INVARIANT: start_offset > 0 (outer if) + caller-checked non-negative");
         file.seek(std::io::SeekFrom::Start(pos)).await?;
@@ -1268,7 +1283,6 @@ async fn send_file_chunks(
 ///    - Hash verify (fast-path: `last_chunk_tag` + `chunk_hmac_key`, slow-
 ///      path: `partial_hash_streaming`) → mismatch → `HASH_MISMATCH` + 0
 /// 4. Tüm kontroller geçerse `hint.offset` döndür → caller seek edecek.
-#[allow(clippy::too_many_arguments)]
 async fn wait_for_resume_hint_or_zero(
     socket: &mut TcpStream,
     ctx: &mut SecureCtx,
@@ -1436,7 +1450,10 @@ async fn verify_partial_hash_full(
     use subtle::ConstantTimeEq;
     // INVARIANT: caller `offset > 0` kontrolünü zaten yaptı (§5 row 3);
     // ayrıca spec_offset >= 0 garanti — try_from infallible.
-    #[allow(clippy::expect_used)] // INVARIANT: caller §5 row 3 rejects offset < 0
+    #[expect(
+        clippy::expect_used,
+        reason = "INVARIANT: caller §5 row 3 `INVALID_OFFSET` rejects offset < 0 → u64::try_from infallible"
+    )]
     let off_u = u64::try_from(offset)
         .expect("INVARIANT: caller §5 row 3 `INVALID_OFFSET` rejects offset < 0");
     let owned_path = path.to_path_buf();
@@ -1479,7 +1496,10 @@ async fn verify_last_chunk_tag(
 
     let mut file = tokio::fs::File::open(path).await?;
     // INVARIANT: caller offset > 0 + chunk-aligned + < file_size → last_chunk_start >= 0.
-    #[allow(clippy::expect_used)] // INVARIANT: last_chunk_start >= 0 (caller-checked)
+    #[expect(
+        clippy::expect_used,
+        reason = "INVARIANT: last_chunk_start >= 0 (caller offset > 0 + chunk-aligned) → u64::try_from infallible"
+    )]
     let pos = u64::try_from(last_chunk_start)
         .expect("INVARIANT: last_chunk_start >= 0 (caller offset > 0 + chunk-aligned)");
     file.seek(std::io::SeekFrom::Start(pos)).await?;
@@ -1688,7 +1708,10 @@ fn flatten_folder_to_files(folder: &PlannedFolder) -> Vec<PlannedFile> {
 /// artan `offset`. Last chunk `flags=1`. RFC-0003 chunk-HMAC enabled ise her
 /// data chunk'ından sonra `ChunkIntegrity` envelope'u emit edilir (mevcut
 /// `send_file_chunks` pattern'ı).
-#[allow(clippy::too_many_arguments)]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "folder bundle send pipeline — socket/ctx/state/manifest/cancel context; struct refactor v0.9'a defer"
+)]
 async fn send_folder_bundle(
     socket: &mut TcpStream,
     ctx: &mut SecureCtx,
@@ -1808,7 +1831,10 @@ async fn send_folder_bundle(
 /// Tek bundle chunk'ını wrap + encrypt + write yap; chunk-HMAC enabled ise
 /// `ChunkIntegrity` envelope'u peşinden ekle. PR-C: hot-path artık
 /// `send_file_chunks` ile aynı emit pattern'ı.
-#[allow(clippy::too_many_arguments)]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "bundle chunk emit helper — socket/ctx/payload/offset/body/flags context; struct refactor v0.9'a defer"
+)]
 async fn send_bundle_chunk(
     socket: &mut TcpStream,
     ctx: &mut SecureCtx,
@@ -1923,7 +1949,10 @@ fn compute_percent(bytes_before: i64, offset: i64, total: i64) -> Option<u8> {
     let product = cumulative.checked_mul(100)?;
     let raw = product.checked_div(total)?;
     // INVARIANT: clamp(0, 100) sonrası değer 0..=100 → u8::try_from infallible.
-    #[allow(clippy::expect_used)] // INVARIANT: clamp(0, 100) ⊆ u8 range
+    #[expect(
+        clippy::expect_used,
+        reason = "INVARIANT: clamp(0, 100) ⊆ u8 range → u8::try_from infallible"
+    )]
     let percent =
         u8::try_from(raw.clamp(0, 100)).expect("INVARIANT: clamp(0, 100) → 0..=100 fits in u8");
     Some(percent)

--- a/crates/hekadrop-core/src/state.rs
+++ b/crates/hekadrop-core/src/state.rs
@@ -152,7 +152,10 @@ impl AppState {
         // yazılamıyor identity ile yola devam etmek "her cihaz aynı görünür"
         // güvenlik açığı doğurur. Startup'ta panik = kullanıcıya hata göster,
         // devam etme. Issue #17.
-        #[allow(clippy::expect_used)]
+        #[expect(
+            clippy::expect_used,
+            reason = "SECURITY: identity load/create fail = trust kararı geçersiz; startup panik kullanıcıya hata gösterir (Issue #17)"
+        )]
         let identity = DeviceIdentity::load_or_create_at(identity_path)
             .expect("DeviceIdentity yüklenemedi/oluşturulamadı — identity.key kontrol edin");
         // Stats corrupt olursa default + uyarı; geçmiş istatistikler kaybolur


### PR DESCRIPTION
## Özet

PR #155 sonrası kalan 20 `#[allow(clippy::expect_used)]` + 10 `#[allow(clippy::too_many_arguments)]` site'ı `#[expect(reason="...")]` formuna mass migrate edildi. Eski yorumlardaki `INVARIANT: ...` içerikleri `reason = ...` payload'una taşındı.

Why: `#[expect]` `#[allow]`'a göre gelecek-koruyucu — lint stale olursa `unfulfilled_lint_expectations` zincirinden hatırlatma yapar (CLAUDE.md I-2 disipliniyle uyumlu, recent PR'lardaki migrate pattern'inin devamı: PR #152, #155, #156).

## Site dağılımı

**`#[allow(clippy::expect_used)]` (20 site → 20 migrate):**
- `crates/hekadrop-core/src/sender.rs` — 5 site (max(0)/start_offset/last_chunk_start/clamp INVARIANT'ları)
- `crates/hekadrop-core/src/connection.rs` — 4 site (payload ingest_file + PartialMeta::validate INVARIANT'ları)
- `crates/hekadrop-core/src/folder/bundle.rs` — 3 site (HEKABUND header parse, slice → array)
- `crates/hekadrop-core/src/crypto.rs` — 2 site (HKDF-SHA256 + HMAC-SHA256 RFC infallibility)
- `crates/hekadrop-core/src/state.rs` — 1 site (SECURITY: identity load fail = trust geçersiz, Issue #17)
- `crates/hekadrop-core/src/chunk_hmac.rs` — 1 site (HMAC-SHA256 RFC 2104)
- `crates/hekadrop-core/src/folder/manifest.rs` — 1 site (sha256 prefix slice → [u8; 8])
- `crates/hekadrop-app/src/state.rs` — 1 site (state singleton init contract)
- `crates/hekadrop-app/src/main.rs` — 1 site (serde_json::Value serialize infallible)
- `crates/hekadrop-core/src/payload.rs` — 1 site (`enable_resume_with_offset` resume injection)
  → bu aslında `too_many_arguments` site'ı, ana bölüme yazıldı.

**`#[allow(clippy::too_many_arguments)]` (10 site → 9 migrate, 1 silindi):**
- `crates/hekadrop-core/src/sender.rs` — 4 migrate (`send_text_bytes`, `send_file_chunks`, `send_folder_bundle`, `send_bundle_chunk`)
- `crates/hekadrop-core/src/connection.rs` — 4 migrate (`finalize_received_payload`, `handle_sharing_frame`, `handle_resume_for_file`, `handle_hekadrop_frame`)
- `crates/hekadrop-core/src/payload.rs` — 1 migrate (`enable_resume_with_offset`)
- `crates/hekadrop-core/src/sender.rs::wait_for_resume_hint_or_zero` — **1 silindi**: 7 arg ile clippy default threshold'unu (>7) geçmiyordu; eski `#[allow]` faydasızdı. `#[expect]` migrate `unfulfilled_lint_expectations` ile bunu yakaladı.

## Helper / refactor kararları

- **Helper wrapper YOK.** `u64::try_from(i64).expect("INVARIANT...")` pattern'i 7 site'da geçiyor ama her birinin INVARIANT gerekçesi farklı (`max(0)`, `start_offset > 0`, `validate() rejects < 0`, `payload ingest_file rejects < 0`, vb.). Tek `usize_to_i64()` helper'ına kondense etmek context'i kaybeder; per-site `reason=` payload'u daha okunabilir kalıyor.
- **Struct refactor (`HandlerCtx` benzeri) DEFER.** `connection.rs::handle_sharing_frame` (15 arg) ve `handle_hekadrop_frame` ana adaylar, ama refactor scope'u büyük (call-graph-wide). RFC-0001 §5 yorumu zaten "helper'lar bir sonraki refactor'da struct olarak gruplanacak" diyor — v0.9'a defer önerisi `reason=` metinlerinde de notlu.

## Pre-commit kontrol

- `cargo fmt --all -- --check` — temiz
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — temiz (1 unfulfilled-expectation yakalandı + fix edildi)
- `cargo test --workspace` — 524 test geçer, 0 fail
- `cargo machete --with-metadata` — temiz
- `typos` — temiz
- I-1/I-2/I-3 grep'leri — temiz

## Test plan

- [ ] CI workspace clippy-strict yeşil (Linux + macOS + Windows)
- [ ] `unfulfilled_lint_expectations` lint'i `#[expect]` site'ları üzerinde sessiz (CI'da `-D warnings` ile zorlanmış)
- [ ] CHUNK ve crypto site'ları davranışsal değişiklik yok — yalnız attribute yeniden yazıldı