### PR TITLE
fix: 6 audit yorumu (1 SECURITY-HIGH + 1 safety + 4 stylistic)

### DIFF
--- a/crates/hekadrop-app/src/lib.rs
+++ b/crates/hekadrop-app/src/lib.rs
@@ -67,9 +67,7 @@ pub use hekadrop_proto::{location, securegcm, securemessage, sharing};
 // alıyordu — Adım 3 öncesi yüzeyi korumak için aynı seviyede yeniden export.
 pub use hekadrop_core::{process_client_init, validate_server_init, DerivedKeys};
 
-// NOT: `mod platform;` lib build'de **deklare edilmez** — binary `main.rs`
-// kendi `mod platform;` deklarasyonunu yapar (Cargo lib+bin hibrit:
-// modül ağaçları bağımsız). Lib build'de redundant; aksi halde 10
-// `pub(crate) fn` lib build'inde "dead_code" warning üretirdi. Bu sayede
-// crate-level `#![allow(dead_code)]` ihtiyacı ortadan kalkar (PR #152
-// sweep + bu PR ile birlikte).
+// NOT: `platform` modülü sadece binary (`main.rs`) tarafından kullanılır.
+// Cargo lib+bin hibrit yapısında modül ağaçları bağımsız olduğu için,
+// kütüphane tarafında deklare edilmesi gereksiz `dead_code` uyarılarına
+// yol açar — bu nedenle `mod platform;` lib build'de yok.

--- a/crates/hekadrop-app/src/platform.rs
+++ b/crates/hekadrop-app/src/platform.rs
@@ -470,8 +470,13 @@ pub(crate) mod win {
         //   (MSDN: learn.microsoft.com/en-us/windows/win32/api/combaseapi/nf-combaseapi-cotaskmemfree)
         //   on every path that took ownership; no dangling reference
         //   escapes the block (the `OsString` owns a copy).
-        // - Thread-safe: `SHGetKnownFolderPath` is callable from any
-        //   thread without prior COM init for `KF_FLAG_DEFAULT`.
+        // - Thread-safety: MSDN `SHGetKnownFolderPath` UI thread dışından
+        //   çağrıldığında COM init şart koşar (`CoInitialize`/`CoInitializeEx`).
+        //   `KF_FLAG_DEFAULT` bu gereksinimi düşürmez. Defensive: çağrı öncesi
+        //   `ensure_com_init()` (per-thread idempotent ref-count). PR #156
+        //   medium yorumu (Gemini) ile güçlendirildi; eski "without prior COM
+        //   init" iddiası teknik olarak hatalıydı.
+        ensure_com_init();
         unsafe {
             // windows-rs 0.60: flag enum doğrudan geçilir (eski sürümlerde u32).
             let pwstr: PWSTR = SHGetKnownFolderPath(folder, KF_FLAG_DEFAULT, None).ok()?;

--- a/crates/hekadrop-app/src/platform.rs
+++ b/crates/hekadrop-app/src/platform.rs
@@ -761,14 +761,17 @@ pub(crate) mod win {
         //   underlying buffer — read-only).
         // - `GlobalLock(hglobal)` yields a stable pointer valid until the
         //   matching `GlobalUnlock`; we null-check before any deref.
-        // - Read length is `min(GlobalSize/2, PCWSTR::len())`. Two
-        //   independent upper bounds:
+        // - **Read length policy** (PR #156 SECURITY-HIGH fix):
         //     * `GlobalSize` (MSDN: ...nf-winbase-globalsize) is the true
-        //       allocation size in bytes — divides by 2 for `u16` slots,
-        //       guards against malformed (non-NUL-terminated) data.
-        //     * `PCWSTR::len()` walks until the embedded NUL.
-        //   The smaller wins, so `from_raw_parts(ptr, len)` cannot
-        //   over-read the allocation regardless of malformed input.
+        //       allocation size in bytes — divides by 2 for `u16` slots.
+        //     * Build slice with `from_raw_parts(ptr, max_u16)` FIRST
+        //       (allocation-bounded), then search for NUL inside that slice.
+        //     * **DO NOT** call `PCWSTR::len()` first — it walks until NUL
+        //       without bounds, so malformed (non-NUL-terminated) clipboard
+        //       data triggers a buffer over-read past `GlobalSize`. The
+        //       previous "min(PCWSTR::len(), GlobalSize/2)" pattern was a
+        //       latent UB: PCWSTR::len() already over-read by the time min
+        //       was applied.
         // - `GlobalUnlock` and `CloseClipboard` are called on every exit
         //   path (early-return guards include both); the handle's
         //   ownership remains with the clipboard.
@@ -784,13 +787,17 @@ pub(crate) mod win {
                 let _ = CloseClipboard();
                 return Err(windows::core::Error::from_win32());
             }
-            // GlobalSize bayt döner; u16 slot sayısına çevir.
+            // GlobalSize bayt döner; u16 slot sayısına çevir (allocation-bounded).
             let size_bytes = GlobalSize(hglobal);
             let max_u16 = if size_bytes >= 2 { size_bytes / 2 } else { 0 };
-            // İkinci üst sınır: NUL'a kadar say. İkisi de NUL/OOM'a karşı savunma.
-            let nul_len = PCWSTR::from_raw(ptr).len();
-            let len = nul_len.min(max_u16);
-            let slice = std::slice::from_raw_parts(ptr, len);
+            // PR #156 SECURITY-HIGH fix: önce allocation-bounded slice oluştur,
+            // SONRA NUL ara. Eski kod `PCWSTR::len()` ile bounds-free taramayı
+            // önce yapıyordu — malformed clipboard'da `GlobalSize` aşımı
+            // (buffer over-read UB).
+            let bounded_slice = std::slice::from_raw_parts(ptr, max_u16);
+            let nul_pos = bounded_slice.iter().position(|&w| w == 0);
+            let len = nul_pos.unwrap_or(max_u16);
+            let slice = &bounded_slice[..len];
             let s = String::from_utf16_lossy(slice);
             let _ = GlobalUnlock(hglobal);
             let _ = CloseClipboard();

--- a/crates/hekadrop-app/src/platform.rs
+++ b/crates/hekadrop-app/src/platform.rs
@@ -454,6 +454,10 @@ pub(crate) mod win {
     /// `SHGetKnownFolderPath` → `PathBuf`. Çıktı bellek `CoTaskMemFree` ile serbest
     /// bırakılır (aksi halde leak). Bellek tahsisi başarısızsa `None`.
     pub(super) fn known_folder(folder: &GUID) -> Option<PathBuf> {
+        // MSDN `SHGetKnownFolderPath` UI thread dışından çağrıldığında COM
+        // init şart koşar; `KF_FLAG_DEFAULT` bu gereksinimi düşürmez.
+        // Defensive: unsafe block öncesi idempotent per-thread ref-count.
+        ensure_com_init();
         // SAFETY: `SHGetKnownFolderPath`
         // (MSDN: learn.microsoft.com/en-us/windows/win32/api/shlobj_core/nf-shlobj_core-shgetknownfolderpath)
         // - `folder` is a `&GUID` from the caller; only read, no aliasing.
@@ -470,13 +474,8 @@ pub(crate) mod win {
         //   (MSDN: learn.microsoft.com/en-us/windows/win32/api/combaseapi/nf-combaseapi-cotaskmemfree)
         //   on every path that took ownership; no dangling reference
         //   escapes the block (the `OsString` owns a copy).
-        // - Thread-safety: MSDN `SHGetKnownFolderPath` UI thread dışından
-        //   çağrıldığında COM init şart koşar (`CoInitialize`/`CoInitializeEx`).
-        //   `KF_FLAG_DEFAULT` bu gereksinimi düşürmez. Defensive: çağrı öncesi
-        //   `ensure_com_init()` (per-thread idempotent ref-count). PR #156
-        //   medium yorumu (Gemini) ile güçlendirildi; eski "without prior COM
-        //   init" iddiası teknik olarak hatalıydı.
-        ensure_com_init();
+        // - Thread-safety: COM init `ensure_com_init()` çağrısı (yukarıda)
+        //   ile garanti altında; her thread per-call idempotent.
         unsafe {
             // windows-rs 0.60: flag enum doğrudan geçilir (eski sürümlerde u32).
             let pwstr: PWSTR = SHGetKnownFolderPath(folder, KF_FLAG_DEFAULT, None).ok()?;

--- a/crates/hekadrop-cli/src/main.rs
+++ b/crates/hekadrop-cli/src/main.rs
@@ -11,10 +11,7 @@
 
 // hekadrop-core + hekadrop-net path-dep olarak çekilse de v0.7 stub'ında
 // hiçbir sembol kullanılmıyor — `cargo machete` false-pozitif önlenmiş
-// (ignore listesi `Cargo.toml`'da). v0.10.0'da `use hekadrop_core::*` gibi
-// import'lar geldiğinde `unused_imports` lint'i kendini hatırlatır.
-// (PR #152/#153 sweep'inden sonra `#![allow(unused_imports)]` kaldırıldı —
-// stub'ta hiç `use` yok, allow stale-iydi.)
+// (ignore listesi `Cargo.toml`'da). v0.10.0'da kaldırılacak.
 
 // CLI binary stdout output legitimate use case; workspace-wide
 // `clippy::print_stdout = "warn"` (PR #87 Tier 1) UI/library kodu için

--- a/crates/hekadrop-core/src/folder/extract.rs
+++ b/crates/hekadrop-core/src/folder/extract.rs
@@ -352,11 +352,12 @@ fn extract_bundle_inner(
                 let _ = fs::remove_dir_all(&final_path);
                 return Err(copy_err);
             }
-            // Source'u sil (best-effort). NOT (PR #148 medium): Drop guard
-            // yalnızca staging dir'i izler; eğer burada başarısız olursak
-            // staging artık kabul edilmiş success path üzerinde olduğundan
-            // (rename hedefi final_path tamam) Drop *staging*'i tekrar dener.
-            // final_path zaten merge'lenmiş gerçek hedef, dokunulmaz.
+            // Source'u sil (best-effort). Outer caller success path'inde
+            // `disarm_staging` çağırır — bu noktada `remove_dir_all` fail
+            // olursa staging dir orphan kalır (Drop guard disarm sonrası
+            // tekrar denemez). Pratikte EXDEV+rename başarılı + remove fail
+            // nadir; orphan staging cleanup sweep'ı tarafından sonradan
+            // toplanır.
             let _ = fs::remove_dir_all(staging_dir);
         }
         Err(e) => return Err(ExtractError::Io(e)),

--- a/crates/hekadrop-core/src/sender.rs
+++ b/crates/hekadrop-core/src/sender.rs
@@ -103,12 +103,12 @@ struct PlannedFile {
 /// - capability inactive ise `flatten_folder_to_files` ile individual file
 ///   plan'larına çevrilir (mevcut multi-file akış)
 struct PlannedFolder {
-    /// Sender disk root path (folder kökü). Şu anda sadece debug log'da
-    /// kullanılıyor; ileride retry/resume yolunda walk-yenileme için
-    /// gerekecek (PR-D sonrası).
+    /// Sender disk root path (folder kökü). Gelecekteki retry/resume
+    /// yolunda walk-yenileme için tutulur (manifest yeniden hesabı +
+    /// disk state ile karşılaştırma).
     #[expect(
         dead_code,
-        reason = "PR-C scope: log + future use; field plan-level (PR-D sonrası kullanılacak)"
+        reason = "Gelecekteki retry/resume özellikleri için planlanan ancak şu an okunmayan alan"
     )]
     root_path: std::path::PathBuf,
     /// Manifest validate edilmiş + JSON-serialize için hazır.


### PR DESCRIPTION
## ⚠️ Security + safety + stylistic — 6 yorum tek PR

Kullanıcı tarafından son 6 PR'ın yorumlarına bakılmadığı tespit edildi (process gap). Tarama sonucu **gerçek security bug + 5 medium** bulundu.

### 1. PR #156 platform.rs:771 — SECURITY-HIGH

`PCWSTR::len()` allocation sınırları gözetmeden NUL'a kadar tarar. Malformed (NUL-sonlanmamış) clipboard içeriği → buffer over-read past `GlobalSize`. Heap garbage / sentinel / guard page UB / info leak.

**Fix:** `slice::from_raw_parts(ptr, max_u16)` allocation-bounded slice → NUL search inside slice.

### 2. PR #156 platform.rs:474 — medium safety

`SHGetKnownFolderPath` MSDN'e göre UI thread dışından çağrıldığında COM init şart. `KF_FLAG_DEFAULT` bu gereksinimi düşürmez.

**Fix:** `ensure_com_init()` çağrısı + SAFETY yorumu güncellendi.

### 3-6. Stylistic comments (PR #151-154)

| PR | Site | Sorun | Fix |
|---|---|---|---|
| #151 | extract.rs:359 | Drop guard yorumu yanlış davranış tarif ediyordu | gerçek davranış (orphan cleanup) |
| #152 | sender.rs:106-112 | `root_path` reason'da "PR-C/PR-D" referansları | kalıcı "Gelecekteki retry/resume" |
| #153 | lib.rs:75 | yorumda "bu PR", "10 fn" spesifik | mimari odaklı sade yorum |
| #154 | cli/main.rs:17 | "PR #152/#153 sweep'inden sonra... stale-iydi" tarihsel | sadece v0.10.0 notu |

## Test plan

- [x] cargo build --workspace — temiz
- [x] cargo clippy --workspace --all-targets --all-features -- -D warnings — temiz
- [x] CI Windows step ile cfg-gated kod doğrulaması (lokalde Win32 derlenmez)

🤖 Generated with [Claude Code](https://claude.com/claude-code)