### PR TITLE
chore(lint): pedantic batch 2 — closure_method_calls + cloned_copied + manual_string_new + unnested_or + flat_map_option

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -226,5 +226,11 @@ Enforce edilenler (sweep history):
   - `clippy::single_char_pattern` (0 hit) — `.split("a")` → `.split('a')`.
   - `clippy::inefficient_to_string` (0 hit) — `&T: Display` üzerinde `.to_string()`.
   - `clippy::needless_late_init` (0 hit) — declaration-time init.
+- **pedantic batch 2** (PR `chore/lint-pedantic-batch-2`: 5 lint, 17 hit `cargo clippy --fix` auto-fix; 0 allow; davranış-koruyucu mikro temizlik):
+  - `clippy::redundant_closure_for_method_calls` (16 hit auto-fix) — `|x| x.foo()` → `Foo::foo` (`Bytes::len`, `Result::ok`, `IpAddr::is_ipv4`, `DirEntry::file_name`, `PoisonError::into_inner`, `str::trim`, `VecDeque::len`, `TrustedDevice::display`).
+  - `clippy::cloned_instead_of_copied` (0 hit) — `.cloned()` Copy type üzerinde → `.copied()`.
+  - `clippy::manual_string_new` (0 hit) — `String::from("")` → `String::new()`.
+  - `clippy::unnested_or_patterns` (1 hit auto-fix) — `Err(A) | Err(B)` → `Err(A | B)` (`folder/sanitize.rs`).
+  - `clippy::flat_map_option` (0 hit) — `.flat_map(Option)` → `.filter_map`.
 
 Refactor (RFC-0001) bittikten sonra strictness sweep'lere dön.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,13 @@ if_not_else = "warn"            # `if !cond { a } else { b }` → `if cond { b }
 single_char_pattern = "warn"    # `s.split("a")` → `s.split('a')`; mikro-perf + idiomatic.
 inefficient_to_string = "warn"  # `&T: Display` üzerinde `.to_string()` ekstra ref; format!() inline tercih.
 needless_late_init = "warn"     # `let x; if {...} else {...}` → `let x = if {...} else {...}`; init-at-decl.
+# pedantic batch 2 — closure / pattern micro-cleanups (PR: chore/lint-pedantic-batch-2)
+# 17 hit auto-fix + 0 allow; davranış-koruyucu refactor.
+redundant_closure_for_method_calls = "warn"  # 16 hit auto-fix: `|x| x.foo()` → `Foo::foo`; closure allocation azalır.
+cloned_instead_of_copied = "warn"            # 0 hit; `.cloned()` Copy type üzerinde → `.copied()`; perf + clarity.
+manual_string_new = "warn"                   # 0 hit; `String::from("")` → `String::new()`; idiomatic.
+unnested_or_patterns = "warn"                # 1 hit auto-fix: `Foo(_) | Bar(_)` → `Foo(_) | Bar(_)` nested form.
+flat_map_option = "warn"                     # 0 hit; `.flat_map(Option)` → `.filter_map`; intent netliği.
 
 [workspace.lints.rustdoc]
 broken_intra_doc_links = "deny"

--- a/crates/hekadrop-app/src/ui.rs
+++ b/crates/hekadrop-app/src/ui.rs
@@ -715,7 +715,7 @@ pathList
     let text = String::from_utf8_lossy(&out.stdout);
     let paths: Vec<_> = text
         .lines()
-        .map(|l| l.trim())
+        .map(str::trim)
         .filter(|l| !l.is_empty())
         .map(std::path::PathBuf::from)
         .collect();

--- a/crates/hekadrop-app/src/ui.rs
+++ b/crates/hekadrop-app/src/ui.rs
@@ -757,7 +757,7 @@ if ($dlg.ShowDialog() -eq 'OK') { $dlg.FileNames -join "`n" }
     let text = String::from_utf8_lossy(&out.stdout);
     let paths: Vec<_> = text
         .lines()
-        .map(|l| l.trim())
+        .map(str::trim)
         .filter(|l| !l.is_empty())
         .map(std::path::PathBuf::from)
         .collect();
@@ -788,7 +788,7 @@ fn choose_files_blocking() -> Option<Vec<std::path::PathBuf>> {
         let text = String::from_utf8_lossy(&out.stdout);
         let paths: Vec<_> = text
             .lines()
-            .map(|l| l.trim())
+            .map(str::trim)
             .filter(|l| !l.is_empty())
             .map(std::path::PathBuf::from)
             .collect();
@@ -815,7 +815,7 @@ fn choose_files_blocking() -> Option<Vec<std::path::PathBuf>> {
         let text = String::from_utf8_lossy(&out.stdout);
         let paths: Vec<_> = text
             .lines()
-            .map(|l| l.trim())
+            .map(str::trim)
             .filter(|l| !l.is_empty())
             .map(std::path::PathBuf::from)
             .collect();

--- a/crates/hekadrop-app/tests/folder_chunk_hmac_resume.rs
+++ b/crates/hekadrop-app/tests/folder_chunk_hmac_resume.rs
@@ -105,7 +105,9 @@ struct TempHome {
 
 impl TempHome {
     fn new() -> Self {
-        let guard = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let guard = HOME_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let dir = std::env::temp_dir().join(unique_label("home"));
         fs::create_dir_all(&dir).expect("temp home mkdir");
         let key = if cfg!(windows) { "USERPROFILE" } else { "HOME" };

--- a/crates/hekadrop-app/tests/rate_limiter.rs
+++ b/crates/hekadrop-app/tests/rate_limiter.rs
@@ -252,7 +252,11 @@ fn hash_verified_peer_sonsuz_baglanti_yapabilir() {
     // `src/state.rs::RateLimiter::forget_most_recent` tarafından test
     // ediliyor (tests/trust_hijack.rs::issue_17_rate_limit modülü).
     assert!(!rl.check_and_record_at(trusted_ip, t));
-    let len = rl.windows.read().get(&trusted_ip).map(|q| q.len());
+    let len = rl
+        .windows
+        .read()
+        .get(&trusted_ip)
+        .map(std::collections::VecDeque::len);
     assert_eq!(
         len,
         Some(1),

--- a/crates/hekadrop-app/tests/resume_e2e.rs
+++ b/crates/hekadrop-app/tests/resume_e2e.rs
@@ -109,7 +109,9 @@ struct TempHome {
 
 impl TempHome {
     fn new() -> Self {
-        let guard = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let guard = HOME_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let dir = std::env::temp_dir().join(unique_label("home"));
         std::fs::create_dir_all(&dir).expect("temp home mkdir");
         let key = if cfg!(windows) { "USERPROFILE" } else { "HOME" };

--- a/crates/hekadrop-app/tests/resume_meta_persist.rs
+++ b/crates/hekadrop-app/tests/resume_meta_persist.rs
@@ -79,7 +79,9 @@ struct TempHome {
 
 impl TempHome {
     fn new() -> Self {
-        let guard = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let guard = HOME_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let dir = std::env::temp_dir().join(unique_label("home"));
         std::fs::create_dir_all(&dir).expect("temp home mkdir");
         let key = if cfg!(windows) { "USERPROFILE" } else { "HOME" };

--- a/crates/hekadrop-app/tests/server_rate_limiter.rs
+++ b/crates/hekadrop-app/tests/server_rate_limiter.rs
@@ -283,7 +283,11 @@ fn hash_dogrulanmadan_muafiyet_verilmez() {
     // Hash yok → forget_most_recent çağrılmıyor. Queue 5 kayıtlı kalmalı.
     // (Mirror'daki RateLimiter'da forget_most_recent direct erişim yok;
     // production side ile aynı davranış: çağrı yoksa queue değişmez.)
-    let queue_len = rl.windows.read().get(&ip).map_or(0, |q| q.len());
+    let queue_len = rl
+        .windows
+        .read()
+        .get(&ip)
+        .map_or(0, std::collections::VecDeque::len);
     assert_eq!(
         queue_len, 5,
         "hash doğrulanmadığında queue intact kalmalı (forget_most_recent çağrılmaz)"

--- a/crates/hekadrop-app/tests/trust_hijack.rs
+++ b/crates/hekadrop-app/tests/trust_hijack.rs
@@ -246,7 +246,10 @@ mod issue_17_rate_limit {
         }
 
         fn queue_len(&self, ip: IpAddr) -> usize {
-            self.windows.read().get(&ip).map_or(0, |q| q.len())
+            self.windows
+                .read()
+                .get(&ip)
+                .map_or(0, std::collections::VecDeque::len)
         }
     }
 

--- a/crates/hekadrop-core/src/connection.rs
+++ b/crates/hekadrop-core/src/connection.rs
@@ -363,7 +363,7 @@ pub async fn handle(
                         let id = header.id.unwrap_or(0);
                         let total = header.total_size.unwrap_or(0);
                         let offset = chunk.offset.unwrap_or(0);
-                        let body_len_usize = chunk.body.as_ref().map_or(0, |b| b.len());
+                        let body_len_usize = chunk.body.as_ref().map_or(0, bytes::Bytes::len);
                         // SECURITY: peer'den gelen `offset` + `body_len` + `total`
                         // alanları unvalidated. `*100` ve `+` operasyonlarını
                         // checked aritmetikle koru; overflow olursa progress

--- a/crates/hekadrop-core/src/folder/sanitize.rs
+++ b/crates/hekadrop-core/src/folder/sanitize.rs
@@ -233,7 +233,7 @@ mod tests {
         let r = sanitize_received_relative_path("..\\escape");
         assert!(matches!(
             r,
-            Err(PathError::BackslashSeparator) | Err(PathError::Traversal)
+            Err(PathError::BackslashSeparator | PathError::Traversal)
         ));
     }
 

--- a/crates/hekadrop-core/src/settings.rs
+++ b/crates/hekadrop-core/src/settings.rs
@@ -515,7 +515,10 @@ impl Settings {
     /// eder; bu fonksiyon legacy IPC çağrıları ve testler için korunur.
     #[must_use]
     pub fn trusted_display_list(&self) -> Vec<String> {
-        self.trusted_devices.iter().map(|d| d.display()).collect()
+        self.trusted_devices
+            .iter()
+            .map(TrustedDevice::display)
+            .collect()
     }
 }
 
@@ -1796,13 +1799,16 @@ mod tests {
 
         let leftovers: Vec<_> = std::fs::read_dir(&dir)
             .unwrap()
-            .filter_map(|e| e.ok())
+            .filter_map(std::result::Result::ok)
             .filter(|e| e.file_name().to_string_lossy().ends_with(".tmp"))
             .collect();
         assert!(
             leftovers.is_empty(),
             "atomic_write sonrası tmp dosya kalmamalı: {:?}",
-            leftovers.iter().map(|e| e.file_name()).collect::<Vec<_>>()
+            leftovers
+                .iter()
+                .map(std::fs::DirEntry::file_name)
+                .collect::<Vec<_>>()
         );
         let _ = std::fs::remove_dir_all(&dir);
     }
@@ -1828,13 +1834,16 @@ mod tests {
         // dir içinde hiç .tmp kalmamalı (eğer tmp yaratıldıysa cleanup silmeli).
         let leftovers: Vec<_> = std::fs::read_dir(&dir)
             .unwrap()
-            .filter_map(|e| e.ok())
+            .filter_map(std::result::Result::ok)
             .filter(|e| e.file_name().to_string_lossy().ends_with(".tmp"))
             .collect();
         assert!(
             leftovers.is_empty(),
             "hatalı yazım sonrası tmp dosya kalmamalı: {:?}",
-            leftovers.iter().map(|e| e.file_name()).collect::<Vec<_>>()
+            leftovers
+                .iter()
+                .map(std::fs::DirEntry::file_name)
+                .collect::<Vec<_>>()
         );
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/crates/hekadrop-core/src/ukey2.rs
+++ b/crates/hekadrop-core/src/ukey2.rs
@@ -302,7 +302,7 @@ pub fn process_client_init(client_init_frame: &[u8]) -> Result<ServerInitResult>
             "  commitment[{}]: cipher={:?}, len={}",
             idx,
             c.handshake_cipher,
-            c.commitment.as_ref().map_or(0, |v| v.len())
+            c.commitment.as_ref().map_or(0, bytes::Bytes::len)
         );
     }
 

--- a/crates/hekadrop-net/src/discovery.rs
+++ b/crates/hekadrop-net/src/discovery.rs
@@ -41,7 +41,7 @@ pub async fn scan(duration: Duration, own_port: u16) -> Result<Vec<DiscoveredDev
         })
         .await
         .ok()
-        .and_then(|r| r.ok());
+        .and_then(std::result::Result::ok);
 
         let Some(event) = event_opt else { continue };
 

--- a/crates/hekadrop-net/src/mdns.rs
+++ b/crates/hekadrop-net/src/mdns.rs
@@ -54,7 +54,7 @@ pub fn advertise(device_name: &str, port: u16) -> Result<Option<MdnsHandle>> {
         .filter(|i| !i.is_p2p())
         .filter(|i| !skip_prefix.iter().any(|p| i.name.starts_with(p)))
         .map(|i| i.ip())
-        .filter(|ip| ip.is_ipv4())
+        .filter(std::net::IpAddr::is_ipv4)
         .collect();
 
     if addrs.is_empty() {


### PR DESCRIPTION
## Summary

Kademeli `clippy::pedantic` enforce stratejisinin 2. batch'i (PR #160 sonrası). 5 lint workspace `[workspace.lints.clippy]` setine ekleniyor: 17 hit `cargo clippy --fix` auto-fix (davranış-koruyucu) + 0 allow.

3 lint mevcut codebase'de zaten 0 hit (`cloned_instead_of_copied`, `manual_string_new`, `flat_map_option`) — I-4 invariant ile direkt enforce.

## Hit dağılımı

| Lint | Hit | Yöntem |
|---|---|---|
| `clippy::redundant_closure_for_method_calls` | 16 | auto-fix |
| `clippy::unnested_or_patterns` | 1 | auto-fix |
| `clippy::cloned_instead_of_copied` | 0 | direkt enforce |
| `clippy::manual_string_new` | 0 | direkt enforce |
| `clippy::flat_map_option` | 0 | direkt enforce |

### `redundant_closure_for_method_calls` örnekleri

- `|v| v.len()` → `bytes::Bytes::len` (`ukey2.rs`, `connection.rs`)
- `|e| e.ok()` → `Result::ok` (`net/discovery.rs`, `core/settings.rs`)
- `|ip| ip.is_ipv4()` → `IpAddr::is_ipv4` (`net/mdns.rs`)
- `|e| e.file_name()` → `DirEntry::file_name` (`core/settings.rs`)
- `|e| e.into_inner()` → `PoisonError::into_inner` (3 test dosyası)
- `|q| q.len()` → `VecDeque::len` (3 test dosyası)
- `|d| d.display()` → `TrustedDevice::display` (`core/settings.rs`)
- `|l| l.trim()` → `str::trim` (`app/ui.rs`)

### `unnested_or_patterns`

`crates/hekadrop-core/src/folder/sanitize.rs:236`
`Err(PathError::BackslashSeparator) | Err(PathError::Traversal)`
→ `Err(PathError::BackslashSeparator | PathError::Traversal)`

## Pre-merge kontroller

- `cargo fmt --all -- --check` — temiz
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — temiz (macOS host)
- `cargo test --workspace` — 328+ test yeşil
- I-1/I-2/I-3 invariants — temiz

## Test plan

- [ ] CI Linux + Windows clippy yeşil (Win32-gated kod macOS'ta derlenmediği için ek hit çıkma ihtimali — PR #160 pattern'i: 1 ek iter beklenir)
- [ ] Gemini + Copilot review yorumları triaj

CLAUDE.md sweep history "pedantic batch 2" girdisi eklendi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)