### PR TITLE
chore(lint): pedantic batch 4 — control-flow + iterator idiom

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -238,5 +238,11 @@ Enforce edilenler (sweep history):
   - `clippy::checked_conversions` (0 hit) — `i32 as u32` overflow-aware `try_from` alternatif.
   - `clippy::ptr_as_ptr` (0 hit) — `*const T as *const U` → `.cast()`.
   - `clippy::ref_option_ref` (0 hit) — `&Option<&T>` redundant indirection.
+- **pedantic batch 4** (PR `chore/lint-pedantic-batch-4`: 5 lint, 3 hit manuel fix; 0 allow; control-flow + iterator + collection idiom temizliği):
+  - `clippy::implicit_clone` (0 hit) — Clone tipinde `.to_owned()` → `.clone()`; intent netliği.
+  - `clippy::map_flatten` (0 hit) — `.map(...).flatten()` → `.flat_map(...)`; tek pass.
+  - `clippy::needless_continue` (3 hit manuel fix) — `crates/hekadrop-core/src/folder/sanitize.rs` (1) + `crates/hekadrop-core/src/settings.rs` (2 site: `backup_corrupt_file` retry loop + `atomic_write_mode` tmp open loop). Match arm sonu `=> continue` → `=> {}`; loop akışı zaten devam ediyor.
+  - `clippy::manual_assert` (0 hit) — `if !cond { panic!(...) }` → `assert!(cond, ...)`; idiomatic.
+  - `clippy::range_minus_one` (0 hit) — `0..(n-1)` → `0..=(n-2)`; inclusive range netliği.
 
 Refactor (RFC-0001) bittikten sonra strictness sweep'lere dön.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,6 +108,13 @@ stable_sort_primitive = "warn"          # 0 hit; primitive slice `.sort()` → `
 checked_conversions = "warn"            # 0 hit; `i32 as u32` overflow-aware checked alternatif (`u32::try_from`).
 ptr_as_ptr = "warn"                     # 0 hit; `*const T as *const U` → `.cast()`; pointer cast idiom.
 ref_option_ref = "warn"                 # 0 hit; `&Option<&T>` redundant indirection — direkt `Option<&T>`.
+# pedantic batch 4 — control-flow + iterator + collection idiom temizliği (PR: chore/lint-pedantic-batch-4)
+# 3 hit manuel fix + 0 allow; davranış-koruyucu, control-flow netliği.
+implicit_clone = "warn"                 # 0 hit; `.to_owned()` Clone tipinde → `.clone()`; intent netliği.
+map_flatten = "warn"                    # 0 hit; `.map(...).flatten()` → `.flat_map(...)`; tek pass.
+needless_continue = "warn"              # 3 hit manuel fix: match arm sonu `=> continue` → `=> {}` (sanitize.rs + settings.rs ×2); döngünün doğal akışı zaten devam ediyor.
+manual_assert = "warn"                  # 0 hit; `if !cond { panic!(...) }` → `assert!(cond, ...)`; idiomatic.
+range_minus_one = "warn"                # 0 hit; `0..(n-1)` → `0..=(n-2)`; inclusive range netliği.
 
 [workspace.lints.rustdoc]
 broken_intra_doc_links = "deny"

--- a/crates/hekadrop-core/src/folder/sanitize.rs
+++ b/crates/hekadrop-core/src/folder/sanitize.rs
@@ -42,7 +42,7 @@ pub fn sanitize_received_relative_path(raw: &str) -> Result<Vec<String>, PathErr
     let mut out: Vec<String> = Vec::new();
     for seg in raw.split('/') {
         match seg {
-            "" | "." => continue,
+            "" | "." => {}
             ".." => return Err(PathError::Traversal),
             other => out.push(other.to_owned()),
         }

--- a/crates/hekadrop-core/src/settings.rs
+++ b/crates/hekadrop-core/src/settings.rs
@@ -843,7 +843,6 @@ pub fn backup_corrupt_file(path: &std::path::Path) -> std::io::Result<std::path:
             Ok(()) => return Ok(backup),
             Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
                 last_err = Some(e);
-                continue;
             }
             Err(e) => return Err(e),
         }
@@ -911,7 +910,7 @@ pub(crate) fn atomic_write_mode(
         }
         match opts.open(&tmp) {
             Ok(f) => break (f, tmp),
-            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists && attempts < 8 => continue,
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists && attempts < 8 => {}
             Err(e) => return Err(e),
         }
     };


### PR DESCRIPTION
## Summary

clippy::pedantic kademeli enable stratejisinin 4. batch'i. 5 lint enforce; mevcut codebase'de toplam **3 hit** (yalnız `needless_continue`); hepsi manuel fix; **0 allow**.

| Lint | Hit | Strateji |
|---|---|---|
| `clippy::implicit_clone` | 0 | direkt enforce |
| `clippy::map_flatten` | 0 | direkt enforce |
| `clippy::needless_continue` | **3** | manuel fix (sanitize.rs ×1 + settings.rs ×2) |
| `clippy::manual_assert` | 0 | direkt enforce |
| `clippy::range_minus_one` | 0 | direkt enforce |

## Fix detayı

- `crates/hekadrop-core/src/folder/sanitize.rs:45` — `"" | "." => continue` → `=> {}` (match loop body'nin tamamı; doğal akış zaten devam ediyor).
- `crates/hekadrop-core/src/settings.rs:846` (`backup_corrupt_file`) — AlreadyExists retry kolunda redundant `continue;` kaldırıldı; `last_err = Some(e)` sonrası match exit zaten loop'un sonu.
- `crates/hekadrop-core/src/settings.rs:914` (`atomic_write_mode`) — tmp open retry guard'ında `=> continue` → `=> {}`.

Davranış-koruyucu — tüm match arm'lar loop body'nin son ifadesi.

## CLAUDE.md güncellemesi

"Deferred strictness sweep'leri" → "pedantic batch 4" girdisi eklendi (PR #87 listesindeki kalan pedantic lint'lerden 5 tanesi daha enable edildi).

## Bilinen gap

Win32-gated kod macOS lokalde derlenmedi (CLAUDE.md "bilinen gap"). PR #160-#162 paterninde Linux/Windows CI run'unda ek hit çıkarsa fix iter beklenir.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace` (tüm test target'lar yeşil)
- [x] `cargo machete --with-metadata` (unused dep yok)
- [x] `typos` (yeşil)
- [x] I-1/I-2/I-3 invariant grep taramaları (gerçek violation yok)
- [ ] CI Linux + Windows yeşil (cross-platform clippy doğrulaması)

🤖 Generated with [Claude Code](https://claude.com/claude-code)