### PR TITLE
chore(lint): pedantic batch 8 — iterator/variant/call/derive/binding idiom

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -262,5 +262,11 @@ Enforce edilenler (sweep history):
   - `clippy::no_effect_underscore_binding` (1 hit manuel fix) — `crates/hekadrop-core/src/settings.rs::v06_reject_path_legacy_upgrade_yapmaz` test'inde `let _peer_hash = [0xCC; 6];` no-op binding (eski kodun ne yaptığını dökümante etmek için). Yorum bloğuna dönüştürüldü; `0xCC` literal aşağıdaki assertion'da zaten var (`is_trusted_by_hash(&[0xCC; 6])`).
   - `clippy::needless_raw_string_hashes` (0 hit) — `r#"..."#` raw string'de gereksiz `#` (string'de `"` yoksa); idiomatic.
   - `clippy::redundant_pub_crate` (58 hit, **KAPSAM-DIŞI**) — `hekadrop-app` `lib.rs + main.rs` hibrit crate; `i18n/paths/platform/state/ui/ui_adapter` modülleri yalnız `main.rs`'in private modül ağacında ve `pub(crate)` kullanıyor. Auto-fix `pub`'a çevirmek istiyor — fakat workspace zaten `unreachable_pub = "warn"` enforce ediyor; bu lint aynı item'ları tam tersi yönde (`pub` → `pub(crate)`) raporlar. İki lint **uzlaşmaz**: `redundant_pub_crate` enforce etmek için `unreachable_pub` invariant'ını gevşetmek gerekir. RFC-0001 sonrası `app` crate yeniden yapılandırılırken (örn. salt-binary `bin/`) yeniden değerlendirilecek.
+- **pedantic batch 8** (PR `chore/lint-pedantic-batch-8`: 5 lint, 4 zero-hit el yazımı kod + 1 generated-only allow; iterator / variant / call / derive / binding idiom temizliği):
+  - `clippy::iter_without_into_iter` (0 hit) — type `iter()` metoduna sahip ama `IntoIterator` impl etmemiş; for-loop ergonomi tutarsızlığı.
+  - `clippy::manual_is_variant_and` (0 hit) — `.map_or(false, |x| x.foo())` → `.is_some_and(|x| x.foo())`; intent netliği.
+  - `clippy::or_fun_call` (0 hit) — `.unwrap_or(expensive())` → `.unwrap_or_else(|| ...)`; pahalı default lazy hesaplanır.
+  - `clippy::derive_partial_eq_without_eq` (6 hit, hepsi prost-üretilmiş `OUT_DIR` modüllerinde — `securegcm.rs:705`, `sharing.nearby.rs:424/647/747`) — `crates/hekadrop-proto/src/lib.rs` her generated `pub mod` allow listesine eklendi (PROTO istisnası, I-2). El yazımı kod 0 hit; gelecekte `PartialEq` derive eden yeni source tip `Eq` da derive etmeli (float field yoksa).
+  - `clippy::ref_binding_to_reference` (0 hit) — `if let Some(ref x) = &y` → `if let Some(x) = &y`; `&y` üzerinde `ref` redundant.
 
 Refactor (RFC-0001) bittikten sonra strictness sweep'lere dön.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,6 +142,14 @@ needless_pass_by_ref_mut = "warn"           # 0 hit; `&mut T` argüman gerçekte
 ref_as_ptr = "warn"                         # 0 hit; `&x as *const T` → `std::ptr::from_ref(&x)`; pointer cast idiom (Rust 1.76+).
 no_effect_underscore_binding = "warn"       # 1 hit manuel fix: `crates/hekadrop-core/src/settings.rs::v06_reject_path_legacy_upgrade_yapmaz` test'inde `let _peer_hash = [0xCC; 6];` no-op binding (eski kodun ne yaptığını dökümante etmek için). Yorum bloğuna dönüştürüldü; `0xCC` literal aşağıdaki assertion'da zaten var.
 needless_raw_string_hashes = "warn"         # 0 hit; `r#"..."#` raw string'de gereksiz `#` (string'de `"` yoksa); idiomatic.
+# pedantic batch 8 — iterator / variant / call / derive / binding idiom temizliği (PR: chore/lint-pedantic-batch-8)
+# 4 zero-hit lint enable + 1 generated-only (`derive_partial_eq_without_eq` — 6 hit prost-üretilmiş kodda;
+# `crates/hekadrop-proto/src/lib.rs` her generated `pub mod` allow listesine eklendi, el yazımı kod 0 hit).
+iter_without_into_iter = "warn"             # 0 hit; type `iter()` metoduna sahip ama `IntoIterator` impl etmemiş — for-loop ergonomi tutarsızlığı.
+manual_is_variant_and = "warn"              # 0 hit; `.map_or(false, |x| x.foo())` → `.is_some_and(|x| x.foo())`; intent netliği.
+or_fun_call = "warn"                        # 0 hit; `.unwrap_or(expensive())` → `.unwrap_or_else(|| ...)`; pahalı default lazy hesaplanır.
+derive_partial_eq_without_eq = "warn"       # 6 hit yalnız prost-generated kodda (proto crate `lib.rs` allow listesinde); el yazımı kod 0 hit. Yeni `PartialEq` derive eden tip `Eq` da derive etmeli (float field yoksa).
+ref_binding_to_reference = "warn"           # 0 hit; `if let Some(ref x) = &y` → `if let Some(x) = &y`; `&y` üzerinde `ref` redundant.
 
 [workspace.lints.rustdoc]
 broken_intra_doc_links = "deny"

--- a/crates/hekadrop-proto/src/lib.rs
+++ b/crates/hekadrop-proto/src/lib.rs
@@ -22,7 +22,10 @@
 //!   (proto comment'lardaki `<...>` benzeri token'lar), `dead_code`
 //!   (test'lerde kullanılmayan tipler için), `clippy::must_use_candidate`
 //!   (prost-generated `as_str_name` / `from_str_name` enum helper'ları —
-//!   workspace-wide enforce'a dahil edildi, generated kod düzeltilemez).
+//!   workspace-wide enforce'a dahil edildi, generated kod düzeltilemez),
+//!   `clippy::derive_partial_eq_without_eq` (prost `PartialEq` türetir ama
+//!   `Eq` türetmez — float field'lı message'larda `Eq` zaten geçersiz olur,
+//!   prost tek-tip strateji uygular; pedantic batch 8'de enforce edildi).
 //!
 //! Daha iyi olası iyileştirme (yapılmadı, GH issue'da takip edilmeli):
 //! `prost-build` config'inde `.message_attribute()` ile generated kod'a
@@ -39,6 +42,7 @@
     clippy::all,
     clippy::doc_markdown,
     clippy::must_use_candidate,
+    clippy::derive_partial_eq_without_eq,
     non_snake_case,
     non_camel_case_types,
     dead_code,
@@ -60,6 +64,7 @@ pub mod securegcm {
     clippy::all,
     clippy::doc_markdown,
     clippy::must_use_candidate,
+    clippy::derive_partial_eq_without_eq,
     non_snake_case,
     non_camel_case_types,
     dead_code,
@@ -81,6 +86,7 @@ pub mod securemessage {
     clippy::all,
     clippy::doc_markdown,
     clippy::must_use_candidate,
+    clippy::derive_partial_eq_without_eq,
     non_snake_case,
     non_camel_case_types,
     dead_code,
@@ -114,6 +120,7 @@ pub mod location {
     clippy::all,
     clippy::doc_markdown,
     clippy::must_use_candidate,
+    clippy::derive_partial_eq_without_eq,
     non_snake_case,
     non_camel_case_types,
     dead_code,
@@ -147,6 +154,7 @@ pub mod sharing {
     clippy::all,
     clippy::doc_markdown,
     clippy::must_use_candidate,
+    clippy::derive_partial_eq_without_eq,
     non_snake_case,
     non_camel_case_types,
     dead_code,


### PR DESCRIPTION
## Summary

Kademeli `clippy::pedantic` enable stratejisinin **8. batch'i**. 5 lint değerlendirildi:

| Lint | Hit | Aksiyon |
|---|---|---|
| `clippy::iter_without_into_iter` | 0 | direkt enforce |
| `clippy::manual_is_variant_and` | 0 | direkt enforce |
| `clippy::or_fun_call` | 0 | direkt enforce |
| `clippy::derive_partial_eq_without_eq` | 6 (hepsi prost-üretilmiş) | proto allow + enforce |
| `clippy::ref_binding_to_reference` | 0 | direkt enforce |

**El yazımı kod 0 hit** — sıfır production fix gerekti.

## Detaylar

- `derive_partial_eq_without_eq`'in 6 hit'i `OUT_DIR`'daki prost-üretilmiş modüllerde (`securegcm.rs:705`, `sharing.nearby.rs:424/647/747`). `crates/hekadrop-proto/src/lib.rs` zaten generated kod için module-level `#[allow(...)]` blokları taşıyor (PROTO istisnası, CLAUDE.md I-2). Her generated `pub mod` allow listesine `clippy::derive_partial_eq_without_eq` eklendi.
- `clippy::all` umbrella'sı pedantic lint'leri kapsamadığı için generated kod'u manuel allow'a eklemek zorunlu.
- Yeni `PartialEq` derive eden el yazımı tip eklenirse `Eq` da derive etmeli (float field yoksa) — lint forward-compat olarak enforce ediliyor.

## Sweep history

CLAUDE.md "Deferred strictness sweep'leri" bloğuna `pedantic batch 8` girdisi eklendi.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` → temiz
- [x] `cargo test --workspace` → 0 fail
- [x] `cargo machete --with-metadata` → temiz
- [x] `typos` → temiz
- [ ] CI: Linux + Windows clippy matrix (platform-gated kod lokal'de görülmedi — CLAUDE.md "Bilinen gap" notu)

🤖 Generated with [Claude Code](https://claude.com/claude-code)