### PR TITLE
chore(lint): pedantic batch 9 — iterator/literal/option/block/docs idiom

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -268,5 +268,11 @@ Enforce edilenler (sweep history):
   - `clippy::or_fun_call` (0 hit) — `.unwrap_or(expensive())` → `.unwrap_or_else(|| ...)`; pahalı default lazy hesaplanır.
   - `clippy::derive_partial_eq_without_eq` (6 hit, hepsi prost-üretilmiş `OUT_DIR` modüllerinde — `securegcm.rs:705`, `sharing.nearby.rs:424/647/747`) — `crates/hekadrop-proto/src/lib.rs` her generated `pub mod` allow listesine eklendi (PROTO istisnası, I-2). El yazımı kod 0 hit; gelecekte `PartialEq` derive eden yeni source tip `Eq` da derive etmeli (float field yoksa).
   - `clippy::ref_binding_to_reference` (0 hit) — `if let Some(ref x) = &y` → `if let Some(x) = &y`; `&y` üzerinde `ref` redundant.
+- **pedantic batch 9** (PR `chore/lint-pedantic-batch-9`: 5 lint, 14 hit auto-fix + 4 zero-hit lint enable + 0 allow; iterator / literal / option / block / docs idiom temizliği):
+  - `clippy::filter_map_next` (0 hit) — `.filter(p).next()` → `.find(p)`; intent netliği + tek pass.
+  - `clippy::char_lit_as_u8` (0 hit) — `'a' as u8` → `b'a'`; byte literal idiom.
+  - `clippy::manual_ok_or` (0 hit) — `match x { Some(v) => Ok(v), None => Err(e) }` → `x.ok_or(e)`; idiomatic.
+  - `clippy::semicolon_outside_block` (14 hit auto-fix) — `{ stmt; }` tek-statement bloklar `{ stmt; };` formuna alındı (block expression + outer `;`). Etki alanı: `crates/hekadrop-app/src/main.rs` (2 cfg-gated `eprintln!` blokları), `crates/hekadrop-app/tests/resume_e2e.rs` (7 scope-drop / set_var / sync_all bloku), `crates/hekadrop-app/tests/folder_chunk_hmac_resume.rs` (2), `crates/hekadrop-app/tests/resume_meta_persist.rs` (1), `crates/hekadrop-core/src/connection.rs` (1 test setup), `crates/hekadrop-core/src/payload.rs` (1 borrow scope). NOT: bu lint `clippy::semicolon_if_nothing_returned` (batch 3) ile etkileşir — auto-fix önce `{ stmt; }` → `{ stmt };` çevirir, sonra inner statement'a tekrar `;` ekler; final form `{ stmt; };` her iki lint'i de tatmin eder.
+  - `clippy::doc_link_with_quotes` (0 hit) — rustdoc link içinde gereksiz `"..."` quotes — direkt `[name]` referans.
 
 Refactor (RFC-0001) bittikten sonra strictness sweep'lere dön.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,6 +150,13 @@ manual_is_variant_and = "warn"              # 0 hit; `.map_or(false, |x| x.foo()
 or_fun_call = "warn"                        # 0 hit; `.unwrap_or(expensive())` → `.unwrap_or_else(|| ...)`; pahalı default lazy hesaplanır.
 derive_partial_eq_without_eq = "warn"       # 6 hit yalnız prost-generated kodda (proto crate `lib.rs` allow listesinde); el yazımı kod 0 hit. Yeni `PartialEq` derive eden tip `Eq` da derive etmeli (float field yoksa).
 ref_binding_to_reference = "warn"           # 0 hit; `if let Some(ref x) = &y` → `if let Some(x) = &y`; `&y` üzerinde `ref` redundant.
+# pedantic batch 9 — iterator / literal / option / block / docs idiom temizliği (PR: chore/lint-pedantic-batch-9)
+# 14 hit auto-fix (semicolon_outside_block) + 4 zero-hit lint enable; davranış-koruyucu formatting / micro-temizlik.
+filter_map_next = "warn"                    # 0 hit; `.filter(p).next()` → `.find(p)`; intent netliği + tek pass.
+char_lit_as_u8 = "warn"                     # 0 hit; `'a' as u8` → `b'a'`; byte literal idiom.
+manual_ok_or = "warn"                       # 0 hit; `match x { Some(v) => Ok(v), None => Err(e) }` → `x.ok_or(e)`; idiomatic.
+semicolon_outside_block = "warn"            # 14 hit auto-fix (`cargo clippy --fix`): `{ stmt; }` → `{ stmt };`; tek-statement bloklar için tutarlı formatting (app/main.rs cfg-gated `eprintln!` blokları + tests/resume_e2e.rs scope-drop blokları + connection.rs/payload.rs scope drop'ları).
+doc_link_with_quotes = "warn"               # 0 hit; rustdoc link içinde gereksiz `"..."` quotes — direkt `[name]` referans.
 
 [workspace.lints.rustdoc]
 broken_intra_doc_links = "deny"

--- a/crates/hekadrop-app/src/main.rs
+++ b/crates/hekadrop-app/src/main.rs
@@ -216,7 +216,7 @@ fn main() {
         )]
         {
             eprintln!("[HekaDrop] config yüklenirken hata: {err}");
-        }
+        };
         if matches!(err, settings::LoadError::Corrupt { .. }) {
             match settings::backup_corrupt_file(&config_path) {
                 Ok(backup) => {
@@ -376,7 +376,7 @@ fn setup_logging(log_level: settings::LogLevel) {
             )]
             {
                 eprintln!("[HekaDrop] log appender kurulamadı ({e}); stdout-only devam");
-            }
+            };
             None
         }
     };

--- a/crates/hekadrop-app/tests/folder_chunk_hmac_resume.rs
+++ b/crates/hekadrop-app/tests/folder_chunk_hmac_resume.rs
@@ -115,7 +115,7 @@ impl TempHome {
         // SAFETY: test sequenced via HOME_LOCK; tek thread bu noktada HOME yazar.
         unsafe {
             std::env::set_var(key, &dir);
-        }
+        };
         Self {
             dir,
             saved,
@@ -675,7 +675,7 @@ async fn bundle_resume_with_chunk_hmac_full_pipeline() {
             dest_path: bundle_path.to_string_lossy().into_owned(),
         };
         meta.store_atomic(&dir).unwrap();
-    }
+    };
 
     // Session 2: tek son chunk'ı ekle.
     let dir = partial_dir().unwrap();

--- a/crates/hekadrop-app/tests/resume_e2e.rs
+++ b/crates/hekadrop-app/tests/resume_e2e.rs
@@ -119,7 +119,7 @@ impl TempHome {
         // SAFETY: HOME_LOCK altında seri çalışıyoruz; concurrent set_var yok.
         unsafe {
             std::env::set_var(key, &dir);
-        }
+        };
         Self {
             dir,
             saved,
@@ -343,7 +343,7 @@ async fn e2e_resume_happy_path_meta_lookup_and_hint_verify() {
         // `.meta` checkpoint pass'inde zaten yazıldı + `cancel()` çağrılmadığı
         // için partial dosya + .meta diskte kalır (resume senaryosu için).
         drop(asm);
-    }
+    };
 
     let dir = partial_dir().expect("partial_dir");
     let meta_path = dir.join(meta_filename(session_id, payload_id));
@@ -505,7 +505,7 @@ async fn e2e_resume_hash_mismatch_triggers_reject_and_fresh_restart() {
         )
         .await;
         drop(asm); // scope drop → BufWriter::drop flush'ler; cancel() çağırma → .meta + partial korunur
-    }
+    };
 
     let dir = partial_dir().expect("partial_dir");
     let meta_path = dir.join(meta_filename(session_id, payload_id));
@@ -524,7 +524,7 @@ async fn e2e_resume_hash_mismatch_triggers_reject_and_fresh_restart() {
         f.seek(SeekFrom::Start(partial_bytes / 2)).unwrap();
         f.write_all(&[0xFFu8]).unwrap();
         f.sync_all().unwrap();
-    }
+    };
 
     // Tamper sonrası hash farklı olmalı.
     let tampered_hash = partial_hash_streaming(&dest, partial_bytes).unwrap();
@@ -750,7 +750,7 @@ async fn e2e_resume_chunk_hmac_fastpath_tag_persisted_in_meta() {
         )
         .await;
         drop(asm); // scope drop → BufWriter::drop flush'ler; cancel() çağırma → .meta + partial korunur
-    }
+    };
 
     let dir = partial_dir().expect("partial_dir");
     let meta_path = dir.join(meta_filename(session_id, payload_id));
@@ -911,7 +911,7 @@ async fn e2e_pr_g_receiver_append_preserves_existing_part() {
             offset += chunk_len;
         }
         drop(asm); // BufWriter::drop → flush
-    }
+    };
 
     // Session 1 sonrası dosya boyutu tam 2 chunk; içerik 0xCC.
     let mid_bytes = std::fs::read(&dest).unwrap();
@@ -1021,7 +1021,7 @@ async fn e2e_pr_g_receiver_seek_to_received_bytes() {
         let ci = build_chunk_integrity(payload_id, 1, chunk_len, new_chunk.len(), tag).unwrap();
         let completed = asm.verify_chunk_tag(&ci).await.unwrap();
         assert!(completed.is_some(), "last_chunk verify finalize etmeli");
-    }
+    };
 
     let final_bytes = std::fs::read(&dest).unwrap();
     assert_eq!(

--- a/crates/hekadrop-app/tests/resume_meta_persist.rs
+++ b/crates/hekadrop-app/tests/resume_meta_persist.rs
@@ -90,7 +90,7 @@ impl TempHome {
         // Diğer testler aynı kilit üzerinde bekler — concurrent set_var yok.
         unsafe {
             std::env::set_var(key, &dir);
-        }
+        };
         Self {
             dir,
             saved,

--- a/crates/hekadrop-core/src/connection.rs
+++ b/crates/hekadrop-core/src/connection.rs
@@ -2501,7 +2501,7 @@ mod tests {
             f1.write_all(b"half").unwrap();
             let mut f2 = std::fs::File::create(&p2).unwrap();
             f2.write_all(b"half").unwrap();
-        }
+        };
         asm.register_file_destination(101, p1.clone()).unwrap();
         asm.register_file_destination(202, p2.clone()).unwrap();
         names.insert(101, "a.bin".into());

--- a/crates/hekadrop-core/src/payload.rs
+++ b/crates/hekadrop-core/src/payload.rs
@@ -1036,7 +1036,7 @@ impl PayloadAssembler {
                     ci.chunk_index
                 ))
             })?;
-        }
+        };
 
         // Verify ok — pending'i çek, diske flush et.
         let sink = self


### PR DESCRIPTION
## Özet

`clippy::pedantic` umbrella'dan **batch 9** — 5 lint enforce.

| Lint | Hit | Aksiyon |
|---|---|---|
| `filter_map_next` | 0 | direkt enable |
| `char_lit_as_u8` | 0 | direkt enable |
| `manual_ok_or` | 0 | direkt enable |
| `semicolon_outside_block` | 14 | `cargo clippy --fix` auto-fix |
| `doc_link_with_quotes` | 0 | direkt enable |

Toplam: **14 hit auto-fix + 0 allow + 0 manuel fix**. Davranis-koruyucu mikro temizlik.

## semicolon_outside_block etkilesimi

Bu lint `clippy::semicolon_if_nothing_returned` (batch 3) ile etkilesir:
- Once `{ stmt; }` → `{ stmt };` (semicolon disari)
- Sonra inner statement icin tekrar `;` → `{ stmt; };`

Final form (`{ stmt; };`) her iki lint'i de tatmin eder. `cargo clippy --fix --tests` iki kez kosturuldu (ilk pass disari, ikinci pass icer).

## Etki alani (14 site)

- `crates/hekadrop-app/src/main.rs` — 2 (cfg-gated `eprintln!` blocklari)
- `crates/hekadrop-app/tests/resume_e2e.rs` — 7 (scope-drop / set_var / sync_all bloklari)
- `crates/hekadrop-app/tests/folder_chunk_hmac_resume.rs` — 2
- `crates/hekadrop-app/tests/resume_meta_persist.rs` — 1
- `crates/hekadrop-core/src/connection.rs` — 1 (test setup)
- `crates/hekadrop-core/src/payload.rs` — 1 (HMAC verify borrow scope)

## Test plan

- [x] `cargo fmt --all -- --check` → temiz
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` → temiz
- [x] `cargo test --workspace` → 328 + 3 = 331 test pass, 0 fail
- [x] `cargo machete --with-metadata` → unused dep yok
- [x] `typos` → temiz
- [x] I-1/I-2/I-3 invariant grep → temiz
- [ ] CI Linux + Windows yesil (cross-platform clippy gap — bekleniyorsa 1 ek iter)

## CLAUDE.md sweep history

`pedantic batch 9` girdisi eklendi (5 lint + hit sayilari + etkilesim notu).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>