### PR TITLE
release: v0.8.0 — workspace + protocol + lint discipline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-05-01
+
+**"Workspace + protocol" release — RFC-0001 Foundation refactor + 3 yeni protocol RFC.**
+
+HekaDrop v0.8.0, iki büyük dalga: (1) Cargo workspace'e geçiş ile 5-crate
+mimari (`hekadrop-{proto,core,net,cli,app}`); core artık UI/i18n/global-state
+bağımsız, headless CLI yolu açıldı. (2) Wire format negotiation üzerinden
+3 yeni protocol özelliği: chunk-HMAC integrity, transfer resume, folder
+bundle streaming — hepsi capability-gated, eski peer'larla geriye-dönük
+uyumlu. v0.7.0 internal version'da kaldı (release tag çıkarılmadı); v0.8.0
+hem workspace refactor hem protocol feature setini kapsar.
+
 ### Added — v0.8.0 protocol features (RFC-0003 + RFC-0004 + RFC-0005)
 - **feat(rfc-0005): folder bundle support** — `FOLDER_STREAM_V1` capability
   (`0x0000_0004`) `ALL_SUPPORTED`'a eklendi (PR-F). Sender tarafı `enumerate_folder`
@@ -45,6 +57,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `undocumented_unsafe_blocks`, `redundant_clone` vb. 23 lint warn/deny.
   Mevcut codebase 0 violation; yeni kod CI ile bloklanır.
 - **CLAUDE.md kuruluş prensipleri** + pre-commit kontrol listesi (PR #91 sonrası).
+
+### Added — Lint discipline (53 pedantic + doc enforce)
+- **Clippy pedantic batch 1-11** (PR'lar `chore/lint-pedantic-batch-{1..11}`):
+  53 lint workspace.lints'e `warn` olarak eklendi; 47 zero-hit + 6 toplam
+  manuel/auto fix. CI `-D warnings` ile fiili enforce. Davranış-koruyucu
+  mikro temizlik (closure → method ref, format string inline, string-builder
+  alloc eliminate, semicolon idiom, struct ergonomics).
+- **`clippy::missing_errors_doc` + `missing_panics_doc`** scope-limited
+  (`hekadrop-{core,net,app}` lib.rs `#![warn(...)]`): 56 unique pub fn'e
+  `# Errors` + 8 fn'e `# Panics` doc bloğu eklendi (PR #171/#172/#173/#174).
+- **`clippy::missing_docs_in_private_items`** scope-limited
+  (`hekadrop-{core,net,app}` `#![warn(...)]`): 199 unique private item
+  (struct field, fn, const, type alias, enum variant) 1-3 satır pratik
+  Türkçe doc ile dokümante (PR #175/#176/#177). Internal API surface
+  v0.8.0 release için tertemiz; yeni private item eklendiğinde CI bloklar.
 
 ### Added — v0.7 öncesi
 - **24 aylık yol haritası**: `docs/ROADMAP.md`, `docs/MILESTONES.md` — v1.0.0 hedef

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1491,7 +1491,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hekadrop"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "aes",
  "anyhow",
@@ -1532,7 +1532,7 @@ dependencies = [
 
 [[package]]
 name = "hekadrop-cli"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "hekadrop-core",
  "hekadrop-net",
@@ -1540,7 +1540,7 @@ dependencies = [
 
 [[package]]
 name = "hekadrop-core"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "aes",
  "anyhow",
@@ -1573,7 +1573,7 @@ dependencies = [
 
 [[package]]
 name = "hekadrop-net"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -1586,7 +1586,7 @@ dependencies = [
 
 [[package]]
 name = "hekadrop-proto"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "bytes",
  "prost",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/hekadrop-app", "crates/hekadrop-cli", "crates/hekadrop-core", "crates/hekadrop-net", "crates/hekadrop-proto"]
 
 [workspace.package]
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 rust-version = "1.90"
 authors = ["destek@sourvice.com"]

--- a/crates/hekadrop-app/Cargo.toml
+++ b/crates/hekadrop-app/Cargo.toml
@@ -18,9 +18,9 @@ categories = ["network-programming", "command-line-utilities"]
 # kuralı için workspace path-dep version belirtmesi şart.
 # RFC-0001 §5 Adım 2: hekadrop-proto. Adım 3: hekadrop-core (kripto, frame,
 # UKEY2, secure, error, log_redact, file_size_guard, config taşındı).
-hekadrop-core = { path = "../hekadrop-core", version = "=0.7.0" }
-hekadrop-net = { path = "../hekadrop-net", version = "=0.7.0" }
-hekadrop-proto = { path = "../hekadrop-proto", version = "=0.7.0" }
+hekadrop-core = { path = "../hekadrop-core", version = "=0.8.0" }
+hekadrop-net = { path = "../hekadrop-net", version = "=0.8.0" }
+hekadrop-proto = { path = "../hekadrop-proto", version = "=0.8.0" }
 
 # RFC-0001 §5 Adım 5b — `ui_adapter::UiAdapter` core'un `UiPort` trait'ini
 # implemente eder; `#[async_trait]` makro app crate'inde de gerekiyor.

--- a/crates/hekadrop-cli/Cargo.toml
+++ b/crates/hekadrop-cli/Cargo.toml
@@ -22,8 +22,8 @@ name = "hekadrop-cli"
 path = "src/main.rs"
 
 [dependencies]
-hekadrop-core = { path = "../hekadrop-core", version = "=0.7.0" }
-hekadrop-net = { path = "../hekadrop-net", version = "=0.7.0" }
+hekadrop-core = { path = "../hekadrop-core", version = "=0.8.0" }
+hekadrop-net = { path = "../hekadrop-net", version = "=0.8.0" }
 
 [lints]
 workspace = true

--- a/crates/hekadrop-core/Cargo.toml
+++ b/crates/hekadrop-core/Cargo.toml
@@ -23,7 +23,7 @@ publish = false
 
 [dependencies]
 # Workspace path-deps (proto bindings)
-hekadrop-proto = { path = "../hekadrop-proto", version = "=0.7.0" }
+hekadrop-proto = { path = "../hekadrop-proto", version = "=0.8.0" }
 
 # Async runtime — frame.rs (TcpStream, AsyncRead/Write, tokio::time::timeout),
 # ukey2.rs (TcpStream), settings.rs `save_debounced` (Handle::spawn). `rt`

--- a/crates/hekadrop-net/Cargo.toml
+++ b/crates/hekadrop-net/Cargo.toml
@@ -16,7 +16,7 @@ publish = false
 
 [dependencies]
 # Workspace internal — domain tipleri ve config (Adım 4'te core'a taşındı).
-hekadrop-core = { path = "../hekadrop-core", version = "=0.7.0" }
+hekadrop-core = { path = "../hekadrop-core", version = "=0.8.0" }
 
 # Async runtime — yalnız `tokio::task::spawn_blocking` (discovery.rs:39)
 # kullanılıyor; başka tokio API'sı yok. `rt` feature spawn için yeterli.


### PR DESCRIPTION
## Summary

- Workspace package `0.7.0 → 0.8.0` (root `Cargo.toml` + 7 inter-crate `=0.7.0` pin)
- `CHANGELOG.md` `[Unreleased]` → `[0.8.0] - 2026-05-01` finalize + lint discipline section eklendi
- v0.7.0 release tag çıkarılmadı; v0.8.0 RFC-0001 (workspace) + RFC-0003/4/5 (protocol) + 53 pedantic + 199 doc lint sweep'ini kapsar

## v0.8.0 release çatısı

**Workspace (RFC-0001):** 5-crate `hekadrop-{proto,core,net,cli,app}` ayrımı; core UI/i18n/global-state bağımsız, headless CLI yolu açık.

**Protocol (RFC-0003/4/5):** capability-gated chunk-HMAC + transfer resume + folder bundle; eski peer'larla geriye-dönük uyumlu.

**Lint discipline:** 53 pedantic warn + `missing_errors_doc` + `missing_panics_doc` + `missing_docs_in_private_items` (`hekadrop-{core,net,app}` scope-limited). 199 unique private item dokümante; CI `-D warnings` ile fiili enforce.

## Test plan

- [x] `cargo +stable build --workspace --all-features` — yeşil (1.95.0)
- [x] `cargo +stable clippy --workspace --all-targets --all-features -- -D warnings` — yeşil
- [x] `cargo +stable test --workspace` — 369 test pass, 0 fail
- [ ] CI matrix (macOS/Linux/Windows + lints + coverage) yeşil

🤖 Generated with [Claude Code](https://claude.com/claude-code)