### PR TITLE
docs: post-v0.8.0 AI review follow-up — doc accuracy fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,10 +60,11 @@ hem workspace refactor hem protocol feature setini kapsar.
 
 ### Added — Lint discipline (53 pedantic + doc enforce)
 - **Clippy pedantic batch 1-11** (PR'lar `chore/lint-pedantic-batch-{1..11}`):
-  53 lint workspace.lints'e `warn` olarak eklendi; 47 zero-hit + 6 toplam
-  manuel/auto fix. CI `-D warnings` ile fiili enforce. Davranış-koruyucu
-  mikro temizlik (closure → method ref, format string inline, string-builder
-  alloc eliminate, semicolon idiom, struct ergonomics).
+  53 lint workspace.lints'e `warn` olarak eklendi (43 zero-hit, 10 lint
+  toplam ~49 site auto-fix + manuel düzeltme). CI `-D warnings` ile fiili
+  enforce. Davranış-koruyucu mikro temizlik (closure → method ref, format
+  string inline, string-builder alloc eliminate, semicolon idiom, struct
+  ergonomics).
 - **`clippy::missing_errors_doc` + `missing_panics_doc`** scope-limited
   (`hekadrop-{core,net,app}` lib.rs `#![warn(...)]`): 56 unique pub fn'e
   `# Errors` + 8 fn'e `# Panics` doc bloğu eklendi (PR #171/#172/#173/#174).

--- a/crates/hekadrop-app/src/main.rs
+++ b/crates/hekadrop-app/src/main.rs
@@ -1002,7 +1002,7 @@ fn handle_settings_save(json: &str) {
         /// Otomatik kabul switch'i (geri uyumluluk için zorunlu).
         auto_accept: bool,
         #[serde(default)]
-        /// mDNS advertise switch'i (None → mevcut korunur).
+        /// mDNS advertise switch'i (`None` → mevcut korunur).
         advertise: Option<bool>,
         #[serde(default)]
         /// Log seviyesi string'i (`trace` / `debug` / `info` / `warn` / `error`).

--- a/crates/hekadrop-app/src/ui.rs
+++ b/crates/hekadrop-app/src/ui.rs
@@ -290,7 +290,7 @@ fn prompt_accept_blocking(
 }
 
 /// Linux sürümü — `zenity` veya `kdialog` ile 3-buton accept prompt; her
-/// ikisi de yoksa `notify-rust` ile bilgilendirip reddet.
+/// ikisi de yoksa log ile bilgilendirip reddet.
 #[cfg(target_os = "linux")]
 fn prompt_accept_blocking(
     device: &str,
@@ -1168,7 +1168,6 @@ fn escape_applescript(s: &str) -> String {
 /// zenity `--extra-button` flag'ini destekliyor mu? Versiyon 3.0+'da var.
 /// `zenity --version` çıktısı "3.44.0" gibi tek satır; major sayı ≥3 ise
 /// true. Hata durumunda (zenity açılmıyor vb.) false — iki-adım fallback.
-/// Linux sürümü — `zenity` argümanları için minimal escape (newline strip).
 #[cfg(target_os = "linux")]
 fn zenity_supports_extra_button() -> bool {
     let out = match Command::new("zenity")
@@ -1198,7 +1197,6 @@ fn zenity_supports_extra_button() -> bool {
 /// olsun diye `bin` içinde shell-special char görürsek direkt `false`
 /// dönüyoruz; helper ileride yanlışlıkla dış input ile çağrılırsa da
 /// güvenli kalıyor.
-/// Linux sürümü — `kdialog` argümanları için minimal escape.
 #[cfg(target_os = "linux")]
 fn have(bin: &str) -> bool {
     if bin


### PR DESCRIPTION
## Summary

PR #177 + PR #178 Gemini medium-priority yorumlarına follow-up paketi (5 fix tek commit):

- `main.rs:1005`: \`None\` backtick (clippy::doc_markdown tutarlılık)
- `ui.rs:293`: Linux fallback doc'unda \`notify-rust\` referansı yanlıştı; gerçek davranış \`tracing::warn!\` + Reject
- `ui.rs:1171`: \`zenity_supports_extra_button\` doc'undan yanıltıcı "argüman escape" satırı silindi
- `ui.rs:1201`: \`have()\` doc'undan yanıltıcı "kdialog escape" satırı silindi
- `CHANGELOG.md`: pedantic batch 1-11 istatistiği düzeltildi (43 zero-hit, 10 lint ~49 site)

## Test plan

- [x] \`cargo +stable clippy --workspace --all-targets --all-features -- -D warnings\` — yeşil
- [ ] CI matrix (macOS/Linux/Windows + lints + coverage) yeşil

🤖 Generated with [Claude Code](https://claude.com/claude-code)